### PR TITLE
Complete first ffi macro definition

### DIFF
--- a/ffi.nim
+++ b/ffi.nim
@@ -1,5 +1,8 @@
+import std/atomics, chronos
 import
   ffi/internal/[ffi_library, ffi_macro],
   ffi/[alloc, ffi_types, ffi_context, ffi_thread_request]
 
-export alloc, ffi_library, ffi_macro, ffi_types, ffi_context, ffi_thread_request
+export atomics, chronos
+export
+  atomics, alloc, ffi_library, ffi_macro, ffi_types, ffi_context, ffi_thread_request

--- a/ffi/ffi_context.nim
+++ b/ffi/ffi_context.nim
@@ -184,7 +184,7 @@ proc createFFIContext*[T](): Result[ptr FFIContext[T], string] =
 
   return ok(ctx)
 
-proc destroyFFIContext*[T](ctx: ptr FFIContext): Result[void, string] =
+proc destroyFFIContext*[T](ctx: ptr FFIContext[T]): Result[void, string] =
   ctx.running.store(false)
 
   let signaledOnTime = ctx.reqSignal.fireSync().valueOr:

--- a/ffi/ffi_context.nim
+++ b/ffi/ffi_context.nim
@@ -4,7 +4,7 @@
 
 import std/[options, atomics, os, net, locks, json]
 import chronicles, chronos, chronos/threadsync, taskpools/channels_spsc_single, results
-import ./ffi_types, ./ffi_thread_request, ./internal/ffi_macro
+import ./ffi_types, ./ffi_thread_request, ./internal/ffi_macro, ./logging
 
 type FFIContext*[T] = object
   myLib*: T
@@ -129,6 +129,8 @@ proc watchdogThreadBody(ctx: ptr FFIContext) {.thread.} =
 
 proc ffiThreadBody[T](ctx: ptr FFIContext[T]) {.thread.} =
   ## FFI thread that attends library user API requests
+
+  logging.setupLog(logging.LogLevel.DEBUG, logging.LogFormat.TEXT)
 
   let ffiRun = proc(ctx: ptr FFIContext[T]) {.async.} =
     while true:

--- a/ffi/ffi_context.nim
+++ b/ffi/ffi_context.nim
@@ -4,7 +4,7 @@
 
 import std/[options, atomics, os, net, locks, json]
 import chronicles, chronos, chronos/threadsync, taskpools/channels_spsc_single, results
-import ./ffi_types, ./ffi_thread_request, ./ffi_watchdog_req, ./internal/ffi_macro
+import ./ffi_types, ./ffi_thread_request, ./internal/ffi_macro
 
 type FFIContext*[T] = object
   myLib*: T

--- a/ffi/ffi_types.nim
+++ b/ffi/ffi_types.nim
@@ -1,3 +1,4 @@
+import std/tables
 import chronos
 
 ################################################################################
@@ -30,6 +31,9 @@ template foreignThreadGc*(body: untyped) =
     tearDownForeignThreadGc()
 
 type onDone* = proc()
+
+## Registered requests table populated at compile time
+var registeredRequests* {.threadvar.}: Table[cstring, FFIRequestProc]
 
 ### End of FFI utils
 ################################################################################

--- a/ffi/internal/ffi_library.nim
+++ b/ffi/internal/ffi_library.nim
@@ -62,7 +62,7 @@ macro declareLibrary*(libraryName: static[string]): untyped =
   let nimMainName = ident("lib" & libraryName & "NimMain")
 
   let initializeLibraryProc = quote:
-    proc `procName`() {.exported.} =
+    proc `procName`*() {.exported.} =
       if not initialized.exchange(true):
         ## Every Nim library needs to call `<yourprefix>NimMain` once exactly,
         ## to initialize the Nim runtime.
@@ -78,18 +78,4 @@ macro declareLibrary*(libraryName: static[string]): untyped =
 
   res.add(initializeLibraryProc)
 
-  ## Generate the exported C-callable callback setter
-  let setCallbackProc = quote:
-    proc set_event_callback(
-        ctx: ptr FFIContext, callback: FFICallBack, userData: pointer
-    ) {.dynlib, exportc.} =
-      initializeLibrary()
-      ctx[].eventCallback = cast[pointer](callback)
-      ctx[].eventUserData = userData
-
-  res.add(setCallbackProc)
-
-  # echo result.repr
   return res
-
-

--- a/ffi/internal/ffi_macro.nim
+++ b/ffi/internal/ffi_macro.nim
@@ -325,7 +325,6 @@ macro processReq*(
 
   let newReqCall = newCall(ident("ffiNewReq"), callArgs)
 
-  # CORRECT: use actual ctx symbol
   let sendCall = newCall(
     newDotExpr(ident("ffi_context"), ident("sendRequestToFFIThread")), ctx, newReqCall
   )
@@ -414,5 +413,4 @@ macro ffi*(prc: untyped): untyped =
     registerReqFFI(`reqName`, `paramIdent`: `paramType`):
       `anonymousProcNode`
 
-  # Final macro result
   result = newStmtList(registerReq, ffiProc)

--- a/ffi/internal/ffi_macro.nim
+++ b/ffi/internal/ffi_macro.nim
@@ -315,8 +315,6 @@ macro registerReqFFI*(reqTypeName, reqHandler, body: untyped): untyped =
   let deleteProc = buildFfiDeleteReqProc(reqTypeName, fields)
   result = newStmtList(typeDef, ffiNewReqProc, deleteProc, processProc, addNewReqToReg)
 
-  # echo "Registered FFI request: " & result.repr
-
 macro processReq*(
     reqType, ctx, callback, userData: untyped, args: varargs[untyped]
 ): untyped =
@@ -335,7 +333,7 @@ macro processReq*(
   result = quote:
     block:
       let res = `sendCall`
-      if res.isErr:
+      if res.isErr():
         let msg = "error in sendRequestToFFIThread: " & res.error
         `callback`(RET_ERR, unsafeAddr msg[0], cast[csize_t](msg.len), `userData`)
         return RET_ERR
@@ -401,7 +399,7 @@ macro ffi*(prc: untyped): untyped =
     name = procName,
     params = newParams,
     body = ffiBody,
-    pragmas = newTree(nnkPragma, ident "dynlib", ident "exportc"),
+    pragmas = newTree(nnkPragma, ident "dynlib", ident "exportc", ident "cdecl"),
   )
 
   var anonymousProcNode = newProc(

--- a/ffi/logging.nim
+++ b/ffi/logging.nim
@@ -1,0 +1,106 @@
+## This code has been copied and addapted from `status-im/nimbu-eth2` project.
+## Link: https://github.com/status-im/nimbus-eth2/blob/c585b0a5b1ae4d55af38ad7f4715ad455e791552/beacon_chain/nimbus_binary_common.nim
+## This is also copied in logos-messaging-nim repository (2025-12-10)
+import
+  std/[typetraits, os, strutils, syncio],
+  chronicles,
+  chronicles/log_output,
+  chronicles/topics_registry
+
+export chronicles.LogLevel
+
+{.push raises: [].}
+
+type LogFormat* = enum
+  TEXT
+  JSON
+
+## Utils
+
+proc stripAnsi(v: string): string =
+  ## Copied from: https://github.com/status-im/nimbus-eth2/blob/stable/beacon_chain/nimbus_binary_common.nim#L41
+  ## Silly chronicles, colors is a compile-time property
+  var
+    res = newStringOfCap(v.len)
+    i: int
+
+  while i < v.len:
+    let c = v[i]
+    if c == '\x1b':
+      var
+        x = i + 1
+        found = false
+
+      while x < v.len: # look for [..m
+        let c2 = v[x]
+        if x == i + 1:
+          if c2 != '[':
+            break
+        else:
+          if c2 in {'0' .. '9'} + {';'}:
+            discard # keep looking
+          elif c2 == 'm':
+            i = x + 1
+            found = true
+            break
+          else:
+            break
+        inc x
+
+      if found: # skip adding c
+        continue
+    res.add c
+    inc i
+
+  res
+
+proc writeAndFlush(f: syncio.File, s: LogOutputStr) =
+  try:
+    f.write(s)
+    f.flushFile()
+  except CatchableError:
+    logLoggingFailure(cstring(s), getCurrentException())
+
+## Setup
+
+proc setupLogLevel(level: LogLevel) =
+  # TODO: Support per topic level configuratio
+  topics_registry.setLogLevel(level)
+
+proc setupLogFormat(format: LogFormat, color = true) =
+  proc noOutputWriter(logLevel: LogLevel, msg: LogOutputStr) =
+    discard
+
+  proc stdoutOutputWriter(logLevel: LogLevel, msg: LogOutputStr) =
+    writeAndFlush(syncio.stdout, msg)
+
+  proc stdoutNoColorOutputWriter(logLevel: LogLevel, msg: LogOutputStr) =
+    writeAndFlush(syncio.stdout, stripAnsi(msg))
+
+  when defaultChroniclesStream.outputs.type.arity == 2:
+    case format
+    of LogFormat.Text:
+      defaultChroniclesStream.outputs[0].writer =
+        if color: stdoutOutputWriter else: stdoutNoColorOutputWriter
+      defaultChroniclesStream.outputs[1].writer = noOutputWriter
+    of LogFormat.Json:
+      defaultChroniclesStream.outputs[0].writer = noOutputWriter
+      defaultChroniclesStream.outputs[1].writer = stdoutOutputWriter
+  else:
+    {.
+      warning:
+        "the present module should be compiled with '-d:chronicles_default_output_device=dynamic' " &
+        "and '-d:chronicles_sinks=\"textlines,json\"' options"
+    .}
+
+proc setupLog*(level: LogLevel, format: LogFormat) =
+  ## Logging setup
+  # Adhere to NO_COLOR initiative: https://no-color.org/
+  let color =
+    try:
+      not parseBool(os.getEnv("NO_COLOR", "false"))
+    except CatchableError:
+      true
+
+  setupLogLevel(level)
+  setupLogFormat(format, color)


### PR DESCRIPTION
Far from being ideal, this PR represents step further in having a shared ffi environment for Nim

### Changes

- New `{.ffi.}` pragma is created
- Use of generics in `FFIContext`:
```nim
type FFIContext*[T] = object
  myLib*: T
  ...
```
Notice that `myLib` is an instance of the object/library to be exposed, e.g., `LogosMessagingNim`; `LibP2P`; `LogosChat`; `SDS`; etc.

### Related PR

- https://github.com/logos-messaging/logos-messaging-nim/pull/3656

( cc @fryorcraken @NagyZoltanPeter @plopezlpz @richard-ramos @arnetheduck .)
