### PR TITLE
Minor: Fixed indentation

### DIFF
--- a/ffi.nimble
+++ b/ffi.nimble
@@ -7,8 +7,10 @@ license = "MIT or Apache License 2.0"
 
 packageName   = "ffi"
 
-requires "nim >= 2.2.4"
+requires(
+    "nim >= 2.2.4",
     "chronos"
+)
 
 # Source files to include
 # srcDir        = "src"


### PR DESCRIPTION
The requires statement now uses the function call syntax with proper formatting