### PR TITLE
rm ffiType macro

### DIFF
--- a/ffi/serial.nim
+++ b/ffi/serial.nim
@@ -1,4 +1,4 @@
-import std/[json, macros, options]
+import std/[json, options]
 import results
 import ./codegen/meta
 
@@ -119,38 +119,3 @@ proc ffiDeserialize*[T: object](s: cstring, _: typedesc[T]): Result[T, string] =
     ok(parseJson($s).to(T))
   except Exception as e:
     err(e.msg)
-
-macro ffiType*(body: untyped): untyped =
-  ## Statement macro applied to a type declaration block.
-  ## Registers the type in ffiTypeRegistry for binding generation.
-  ## Serialization is handled by the generic ffiSerialize/ffiDeserialize overloads.
-  ## Usage:
-  ##   ffiType:
-  ##     type Foo = object
-  ##       field: int
-  let typeSection = body[0]
-  let typeDef = typeSection[0]
-  let typeName =
-    if typeDef[0].kind == nnkPostfix:
-      typeDef[0][1]
-    else:
-      typeDef[0]
-
-  let typeNameStr = $typeName
-  var fieldMetas: seq[FFIFieldMeta] = @[]
-  let objTy = typeDef[2]
-  if objTy.kind == nnkObjectTy and objTy.len >= 3:
-    let recList = objTy[2]
-    if recList.kind == nnkRecList:
-      for identDef in recList:
-        if identDef.kind == nnkIdentDefs:
-          let fieldType = identDef[^2]
-          let fieldTypeName =
-            if fieldType.kind == nnkIdent: $fieldType
-            elif fieldType.kind == nnkPtrTy: "ptr " & $fieldType[0]
-            else: fieldType.repr
-          for i in 0 ..< identDef.len - 2:
-            fieldMetas.add(FFIFieldMeta(name: $identDef[i], typeName: fieldTypeName))
-
-  ffiTypeRegistry.add(FFITypeMeta(name: typeNameStr, fields: fieldMetas))
-  result = body

--- a/tests/test_ctx_validation.nim
+++ b/tests/test_ctx_validation.nim
@@ -5,9 +5,8 @@ import ../ffi
 
 type TestLib = object
 
-ffiType:
-  type CtxValidationConfig = object
-    initialValue: int
+type CtxValidationConfig {.ffi.} = object
+  initialValue: int
 
 proc ctxval_create*(
     config: CtxValidationConfig

--- a/tests/test_ffi_context.nim
+++ b/tests/test_ffi_context.nim
@@ -412,9 +412,8 @@ suite "sendRequestToFFIThread":
 type SimpleLib = object
   value: int
 
-ffiType:
-  type SimpleConfig = object
-    initialValue: int
+type SimpleConfig {.ffi.} = object
+  initialValue: int
 
 proc testlib_create*(
     config: SimpleConfig
@@ -454,9 +453,8 @@ suite "ffiCtor macro":
 # Simplified .ffi. macro integration test
 # ---------------------------------------------------------------------------
 
-ffiType:
-  type SendConfig = object
-    message: string
+type SendConfig {.ffi.} = object
+  message: string
 
 proc testlib_send*(
     lib: SimpleLib, cfg: SendConfig
@@ -558,9 +556,8 @@ suite "async/sync detection in .ffi.":
 type Handle = object
   data: string
 
-ffiType:
-  type NameParam = object
-    name: string
+type NameParam {.ffi.} = object
+  name: string
 
 proc testlib_alloc_handle*(
     lib: SimpleLib, np: NameParam

--- a/tests/test_serial.nim
+++ b/tests/test_serial.nim
@@ -1,16 +1,14 @@
 import unittest
 import results
-import ../ffi/serial
+import ../ffi
 
-ffiType:
-  type Point = object
-    x: int
-    y: int
+type Point {.ffi.} = object
+  x: int
+  y: int
 
-ffiType:
-  type Nested = object
-    label: string
-    point: Point
+type Nested {.ffi.} = object
+  label: string
+  point: Point
 
 suite "ffiSerialize / ffiDeserialize primitives":
   test "string round-trip":
@@ -81,7 +79,7 @@ suite "pointer serialization":
     let serialized = ffiSerialize(p)
     check serialized == "0"
 
-suite "ffiType macro — object round-trip":
+suite "{.ffi.} on type — object round-trip":
   test "Point round-trip":
     let pt = Point(x: 10, y: 20)
     let serialized = ffiSerialize(pt)


### PR DESCRIPTION
Remove the `ffiType` macro as it is more convenient to annotate ffi types with `{.ffi.}`.
Notice that those types annotated with `{.ffi.}` will be added to the C/C++/Rust headers at compile-time, by `genBindings()`.