### PR TITLE
chore: bump nim to 2.2.6 and ci to 2.2.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       NIMBLE_VERSION: '0.22.3'
-      NIM_VERSION: '2.2.4'
+      NIM_VERSION: '2.2.10'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-15, windows-latest]
-        nim-version: ['2.2.4', 'stable']
+        nim-version: ['2.2.10', 'stable']
         mm: [orc, refc]
         include:
           - os: ubuntu-22.04

--- a/examples/timer/timer.nimble
+++ b/examples/timer/timer.nimble
@@ -4,7 +4,7 @@ author = "Institute of Free Technology"
 description = "Example Nim timer library using nim-ffi"
 license = "MIT or Apache License 2.0"
 
-requires "nim >= 2.2.4"
+requires "nim >= 2.2.6"
 requires "chronos"
 requires "chronicles"
 requires "taskpools"

--- a/ffi.nimble
+++ b/ffi.nimble
@@ -7,7 +7,7 @@ license = "MIT or Apache License 2.0"
 
 packageName = "ffi"
 
-requires "nim >= 2.2.4"
+requires "nim >= 2.2.6"
 requires "chronos"
 requires "chronicles"
 requires "taskpools"


### PR DESCRIPTION
Not sure if this is sth we want, but it wasn't much effort to create this.