### PR TITLE
improve event handling

### DIFF
--- a/examples/timer/cpp_bindings/main.cpp
+++ b/examples/timer/cpp_bindings/main.cpp
@@ -1,6 +1,9 @@
 #include "my_timer.hpp"
-#include <iostream>
+#include <atomic>
+#include <chrono>
 #include <future>
+#include <iostream>
+#include <thread>
 
 int main() {
     try {
@@ -62,6 +65,57 @@ int main() {
                   << ", firstRunAtMs=" << scheduleRes.firstRunAtMs
                   << ", effectiveBackoffMs=" << scheduleRes.effectiveBackoffMs
                   << "\n";
+
+        // ── 7. Library-initiated events ───────────────────────────────
+        // Each `{.ffiEvent.}` declared on the Nim side gets a typed
+        // registration method — `addOnEchoFiredListener(handler)` here.
+        // A second `addEventListener` overload registers a catch-all
+        // wildcard listener that receives every event as raw envelope
+        // bytes plus the FFI return code. Both fire from the lib's
+        // dispatch thread, so synchronise via std::promise / atomics.
+        std::promise<EchoEvent> echoEvtPromise;
+        auto echoEvtFuture = echoEvtPromise.get_future();
+        const auto typedHandle = ctx->addOnEchoFiredListener(
+            [&](const EchoEvent& evt) { echoEvtPromise.set_value(evt); });
+
+        std::atomic<int> wildcardHits{0};
+        // Wildcard listener receives every event with the wire `eventId`
+        // pre-extracted plus the raw CBOR envelope bytes. Dispatch on
+        // `eventId` and use `decodeEventPayload<T>` to lift the payload
+        // into a typed value without hand-parsing CBOR.
+        const auto wildcardHandle = ctx->addEventListener(
+            [&](int retCode, const std::string& eventId,
+                const std::vector<std::uint8_t>& envelope) {
+                wildcardHits.fetch_add(1);
+                std::cout << "[7] wildcard event: retCode=" << retCode
+                          << ", eventId=" << eventId
+                          << ", envelope bytes=" << envelope.size() << "\n";
+                if (retCode != 0) return;
+                if (eventId == "on_echo_fired") {
+                    EchoEvent decoded{};
+                    if (decodeEventPayload(envelope, decoded)) {
+                        std::cout << "    decoded EchoEvent: message="
+                                  << decoded.message
+                                  << ", echoCount=" << decoded.echoCount << "\n";
+                    }
+                }
+            });
+
+        ctx->echo(EchoRequest{"event-demo", 1});
+        const auto evt = echoEvtFuture.get();
+        std::cout << "[7] typed event onEchoFired: message=" << evt.message
+                  << ", echoCount=" << evt.echoCount
+                  << ", wildcardHits=" << wildcardHits.load() << "\n";
+
+        // Drop the typed listener — only the wildcard fires for the
+        // follow-up echo. Sleep briefly to give the lib thread time to
+        // deliver before we tear the ctx down.
+        ctx->removeEventListener(typedHandle);
+        ctx->echo(EchoRequest{"event-demo-after-remove", 1});
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        std::cout << "[7] after removeEventListener: wildcardHits="
+                  << wildcardHits.load() << "\n";
+        ctx->removeEventListener(wildcardHandle);
 
         std::cout << "\nDone.\n";
     } catch (const std::exception& ex) {

--- a/examples/timer/cpp_bindings/my_timer.hpp
+++ b/examples/timer/cpp_bindings/my_timer.hpp
@@ -12,6 +12,7 @@
 #include <optional>
 #include <type_traits>
 #include <cstring>
+#include <unordered_map>
 extern "C" {
 #include <tinycbor/cbor.h>
 }
@@ -627,7 +628,8 @@ int my_timer_version(void* ctx, FFICallback callback, void* user_data, const uin
 int my_timer_complex(void* ctx, FFICallback callback, void* user_data, const uint8_t* req_cbor, size_t req_cbor_len);
 int my_timer_schedule(void* ctx, FFICallback callback, void* user_data, const uint8_t* req_cbor, size_t req_cbor_len);
 int my_timer_destroy(void* ctx);
-void my_timer_set_event_callback(void* ctx, FFICallback callback, void* user_data);
+uint64_t my_timer_add_event_listener(void* ctx, const char* event_name, FFICallback callback, void* user_data);
+int my_timer_remove_event_listener(void* ctx, uint64_t listener_id);
 } // extern "C"
 
 // ============================================================
@@ -683,6 +685,19 @@ inline std::vector<std::uint8_t> ffi_call_(std::function<int(FFICallback, void*)
 
 } // anonymous namespace
 
+template <class T>
+inline bool decodeEventPayload(const std::vector<std::uint8_t>& envelope, T& out) {
+    if (envelope.empty()) return false;
+    CborParser parser; CborValue it;
+    if (cbor_parser_init(envelope.data(), envelope.size(), 0, &parser, &it) != CborNoError)
+        return false;
+    if (!cbor_value_is_map(&it)) return false;
+    CborValue payloadField;
+    if (cbor_value_map_find_value(&it, "payload", &payloadField) != CborNoError)
+        return false;
+    return decode_cbor(payloadField, out) == CborNoError;
+}
+
 // ============================================================
 // High-level C++ context class
 // ============================================================
@@ -730,15 +745,34 @@ public:
     MyTimerCtx(MyTimerCtx&&) = delete;
     MyTimerCtx& operator=(MyTimerCtx&&) = delete;
 
-    // ── Typed event handlers ────────────────────────────────
-    struct Events {
-        std::function<void(const std::string&)> on_error;
-        std::function<void(const EchoEvent&)> onEchoFired;
-    };
+    // ── Event listener API ──────────────────────────────────
+    struct ListenerHandle { std::uint64_t id = 0; };
 
-    void setEventHandlers(Events handlers) {
-        events_ = std::make_unique<Events>(std::move(handlers));
-        my_timer_set_event_callback(ptr_, &MyTimerCtx::eventTrampoline, events_.get());
+    ListenerHandle addOnEchoFiredListener(std::function<void(const EchoEvent&)> handler) {
+        auto owned = std::make_unique<TypedListener<EchoEvent>>(std::move(handler));
+        auto* raw = owned.get();
+        const auto id = my_timer_add_event_listener(
+            ptr_, "on_echo_fired", &MyTimerCtx::typedTrampoline<EchoEvent>, raw);
+        if (id == 0) return ListenerHandle{0};
+        listeners_.emplace(id, std::move(owned));
+        return ListenerHandle{id};
+    }
+
+    ListenerHandle addEventListener(std::function<void(int, const std::string&, const std::vector<std::uint8_t>&)> handler) {
+        auto owned = std::make_unique<WildcardListener>(std::move(handler));
+        auto* raw = owned.get();
+        const auto id = my_timer_add_event_listener(
+            ptr_, "", &MyTimerCtx::wildcardTrampoline, raw);
+        if (id == 0) return ListenerHandle{0};
+        listeners_.emplace(id, std::move(owned));
+        return ListenerHandle{id};
+    }
+
+    bool removeEventListener(ListenerHandle handle) {
+        if (handle.id == 0) return false;
+        const auto rc = my_timer_remove_event_listener(ptr_, handle.id);
+        listeners_.erase(handle.id);
+        return rc == 0;
     }
 
     EchoResponse echo(const EchoRequest& req) const {
@@ -794,37 +828,64 @@ public:
     }
 
 private:
-    void* ptr_;
-    std::chrono::milliseconds timeout_;
-    std::unique_ptr<Events> events_;
-    explicit MyTimerCtx(void* p, std::chrono::milliseconds t) : ptr_(p), timeout_(t) {}
-    static void eventTrampoline(int ret, const char* msg, std::size_t len, void* ud) {
-        if (!ud) return;
-        auto* events = static_cast<Events*>(ud);
-        if (ret != 0) {
-            if (events->on_error) {
-                std::string err(msg ? msg : "", len);
-                events->on_error(err);
-            }
-            return;
-        }
-        if (!msg || len == 0) return;
+    struct ListenerBase {
+        virtual ~ListenerBase() = default;
+    };
+
+    template <class T>
+    struct TypedListener : ListenerBase {
+        std::function<void(const T&)> fn;
+        explicit TypedListener(std::function<void(const T&)> f) : fn(std::move(f)) {}
+    };
+
+    struct WildcardListener : ListenerBase {
+        std::function<void(int, const std::string&, const std::vector<std::uint8_t>&)> fn;
+        explicit WildcardListener(std::function<void(int, const std::string&, const std::vector<std::uint8_t>&)> f) : fn(std::move(f)) {}
+    };
+
+    template <class T>
+    static void typedTrampoline(int ret, const char* msg, std::size_t len, void* ud) {
+        if (!ud || ret != 0 || !msg || len == 0) return;
+        auto* listener = static_cast<TypedListener<T>*>(ud);
+        if (!listener->fn) return;
         std::vector<std::uint8_t> bytes(reinterpret_cast<const std::uint8_t*>(msg),
                                         reinterpret_cast<const std::uint8_t*>(msg) + len);
         CborParser parser; CborValue it;
         if (cbor_parser_init(bytes.data(), bytes.size(), 0, &parser, &it) != CborNoError) return;
         if (!cbor_value_is_map(&it)) return;
-        CborValue evtField;
-        if (cbor_value_map_find_value(&it, "eventType", &evtField) != CborNoError) return;
-        if (!cbor_value_is_text_string(&evtField)) return;
-        std::string evtName; if (decode_cbor(evtField, evtName) != CborNoError) return;
         CborValue payloadField;
         if (cbor_value_map_find_value(&it, "payload", &payloadField) != CborNoError) return;
-        if (evtName == "on_echo_fired") {
-            if (events->onEchoFired) {
-                EchoEvent payload{}; if (decode_cbor(payloadField, payload) == CborNoError) events->onEchoFired(payload);
-            }
-        }
+        T payload{};
+        if (decode_cbor(payloadField, payload) != CborNoError) return;
+        listener->fn(payload);
     }
 
+    static void wildcardTrampoline(int ret, const char* msg, std::size_t len, void* ud) {
+        if (!ud) return;
+        auto* listener = static_cast<WildcardListener*>(ud);
+        if (!listener->fn) return;
+        std::vector<std::uint8_t> envelope;
+        if (msg && len > 0) {
+            envelope.assign(reinterpret_cast<const std::uint8_t*>(msg),
+                            reinterpret_cast<const std::uint8_t*>(msg) + len);
+        }
+        std::string eventId;
+        if (ret == 0 && !envelope.empty()) {
+            CborParser parser; CborValue it;
+            if (cbor_parser_init(envelope.data(), envelope.size(), 0, &parser, &it) == CborNoError
+                && cbor_value_is_map(&it)) {
+                CborValue evtField;
+                if (cbor_value_map_find_value(&it, "eventType", &evtField) == CborNoError
+                    && cbor_value_is_text_string(&evtField)) {
+                    (void)decode_cbor(evtField, eventId);
+                }
+            }
+        }
+        listener->fn(ret, eventId, envelope);
+    }
+
+    void* ptr_;
+    std::chrono::milliseconds timeout_;
+    std::unordered_map<std::uint64_t, std::unique_ptr<ListenerBase>> listeners_;
+    explicit MyTimerCtx(void* p, std::chrono::milliseconds t) : ptr_(p), timeout_(t) {}
 };

--- a/examples/timer/rust_bindings/Cargo.lock
+++ b/examples/timer/rust_bindings/Cargo.lock
@@ -85,6 +85,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "my_timer"
+version = "0.1.0"
+dependencies = [
+ "ciborium",
+ "flume",
+ "serde",
+ "tokio",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,22 +175,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "timer"
-version = "0.1.0"
-dependencies = [
- "ciborium",
- "flume",
- "serde",
- "tokio",
-]
-
-[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/examples/timer/rust_bindings/Cargo.toml
+++ b/examples/timer/rust_bindings/Cargo.toml
@@ -8,3 +8,6 @@ serde = { version = "1", features = ["derive"] }
 ciborium = "0.2"
 flume = { version = "0.11", default-features = false, features = ["async"] }
 tokio = { version = "1", features = ["sync", "time"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }

--- a/examples/timer/rust_bindings/examples/main.rs
+++ b/examples/timer/rust_bindings/examples/main.rs
@@ -1,0 +1,96 @@
+//! Synchronous example: exercises a couple of round-trip methods and the
+//! library-event listener API (typed + wildcard + remove).
+//!
+//! Run with: `cargo run --example main`
+
+use my_timer::{decode_event_payload, EchoEvent, EchoRequest, ListenerHandle, MyTimerCtx, TimerConfig};
+use std::os::raw::c_int;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    mpsc, Arc,
+};
+use std::time::Duration;
+
+fn main() -> Result<(), String> {
+    let ctx = MyTimerCtx::create(
+        TimerConfig {
+            name: "rust-sync-demo".into(),
+        },
+        Duration::from_secs(5),
+    )?;
+    println!("[1] Context created");
+
+    let version = ctx.version()?;
+    println!("[2] Version: {}", version);
+
+    // ── Typed listener for `onEchoFired` ──────────────────────────────
+    // The handler runs on the lib's dispatch thread; route the payload
+    // back to main via an mpsc channel so we can print synchronously.
+    let (tx, rx) = mpsc::channel::<EchoEvent>();
+    let typed_handle: ListenerHandle = ctx.add_on_echo_fired_listener(move |evt: &EchoEvent| {
+        let _ = tx.send(evt.clone());
+    });
+
+    // ── Wildcard listener (catch-all) ─────────────────────────────────
+    // Receives every event with the wire `event_id` pre-extracted and
+    // the raw CBOR envelope bytes. Dispatch on `event_id` and lift the
+    // payload via `decode_event_payload::<T>` to avoid hand-rolled CBOR.
+    let wildcard_hits = Arc::new(AtomicUsize::new(0));
+    let wildcard_hits_for_cb = Arc::clone(&wildcard_hits);
+    let wildcard_handle: ListenerHandle =
+        ctx.add_event_listener(move |ret: c_int, event_id: &str, envelope: &[u8]| {
+            wildcard_hits_for_cb.fetch_add(1, Ordering::SeqCst);
+            println!(
+                "[3] wildcard event: ret={}, event_id={}, envelope_bytes={}",
+                ret,
+                event_id,
+                envelope.len()
+            );
+            if ret == 0 && event_id == "on_echo_fired" {
+                match decode_event_payload::<EchoEvent>(envelope) {
+                    Ok(evt) => println!(
+                        "    decoded EchoEvent: message={}, echo_count={}",
+                        evt.message, evt.echo_count
+                    ),
+                    Err(e) => println!("    decode failed: {}", e),
+                }
+            }
+        });
+
+    // Trigger an echo — fires `{.ffiEvent: "on_echo_fired".}` once.
+    let echo = ctx.echo(EchoRequest {
+        message: "sync-event-demo".into(),
+        delay_ms: 1,
+    })?;
+    println!("[4] Echo response: echoed={}", echo.echoed);
+
+    // Block for the typed event.
+    match rx.recv_timeout(Duration::from_secs(2)) {
+        Ok(evt) => println!(
+            "[5] typed event onEchoFired: message={}, echo_count={}, wildcard_hits={}",
+            evt.message,
+            evt.echo_count,
+            wildcard_hits.load(Ordering::SeqCst)
+        ),
+        Err(e) => return Err(format!("event never arrived: {}", e)),
+    }
+
+    // Drop the typed listener — a second echo only reaches the wildcard.
+    let removed = ctx.remove_event_listener(typed_handle);
+    assert!(removed, "remove_event_listener should report true");
+
+    ctx.echo(EchoRequest {
+        message: "after-remove".into(),
+        delay_ms: 1,
+    })?;
+    // Give the lib thread a beat to deliver to the wildcard.
+    std::thread::sleep(Duration::from_millis(50));
+    println!(
+        "[6] after remove: wildcard_hits={} (typed listener silent)",
+        wildcard_hits.load(Ordering::SeqCst)
+    );
+
+    ctx.remove_event_listener(wildcard_handle);
+    println!("Done.");
+    Ok(())
+}

--- a/examples/timer/rust_bindings/examples/tokio_main.rs
+++ b/examples/timer/rust_bindings/examples/tokio_main.rs
@@ -1,0 +1,104 @@
+//! Tokio (async) example: same shape as `main.rs` but exercises the
+//! async `_async` API and bridges library events into a tokio-aware
+//! channel for async consumption.
+//!
+//! Run with: `cargo run --example tokio_main`
+
+use my_timer::{decode_event_payload, EchoEvent, EchoRequest, ListenerHandle, MyTimerCtx, TimerConfig};
+use std::os::raw::c_int;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+use std::time::Duration;
+use tokio::sync::mpsc;
+
+#[tokio::main]
+async fn main() -> Result<(), String> {
+    let ctx = MyTimerCtx::new_async(
+        TimerConfig {
+            name: "rust-tokio-demo".into(),
+        },
+        Duration::from_secs(5),
+    )
+    .await?;
+    println!("[1] Context created");
+
+    let version = ctx.version_async().await?;
+    println!("[2] Version: {}", version);
+
+    // ── Typed listener for `onEchoFired` ──────────────────────────────
+    // The handler fires on the lib's dispatch thread, so we hop into an
+    // `mpsc::UnboundedSender` (which is Send + Sync) to forward into the
+    // tokio runtime.
+    let (typed_tx, mut typed_rx) = mpsc::unbounded_channel::<EchoEvent>();
+    let typed_handle: ListenerHandle = ctx.add_on_echo_fired_listener(move |evt: &EchoEvent| {
+        let _ = typed_tx.send(evt.clone());
+    });
+
+    // ── Wildcard listener (catch-all) ─────────────────────────────────
+    // The handler receives the FFI return code, the pre-extracted wire
+    // `event_id`, and the raw CBOR envelope. Pair with
+    // `decode_event_payload::<T>` to lift the payload into a typed
+    // value when the event is one you care about.
+    let wildcard_hits = Arc::new(AtomicUsize::new(0));
+    let wildcard_hits_for_cb = Arc::clone(&wildcard_hits);
+    let wildcard_handle: ListenerHandle =
+        ctx.add_event_listener(move |ret: c_int, event_id: &str, envelope: &[u8]| {
+            wildcard_hits_for_cb.fetch_add(1, Ordering::SeqCst);
+            println!(
+                "[3] wildcard event: ret={}, event_id={}, envelope_bytes={}",
+                ret,
+                event_id,
+                envelope.len()
+            );
+            if ret == 0 && event_id == "on_echo_fired" {
+                match decode_event_payload::<EchoEvent>(envelope) {
+                    Ok(evt) => println!(
+                        "    decoded EchoEvent: message={}, echo_count={}",
+                        evt.message, evt.echo_count
+                    ),
+                    Err(e) => println!("    decode failed: {}", e),
+                }
+            }
+        });
+
+    // Trigger an echo via the async API — fires `on_echo_fired` once.
+    let echo = ctx
+        .echo_async(EchoRequest {
+            message: "async-event-demo".into(),
+            delay_ms: 1,
+        })
+        .await?;
+    println!("[4] Echo response: echoed={}", echo.echoed);
+
+    // Await the typed event with a bounded timeout.
+    let evt = tokio::time::timeout(Duration::from_secs(2), typed_rx.recv())
+        .await
+        .map_err(|_| "event never arrived".to_string())?
+        .ok_or_else(|| "typed channel closed".to_string())?;
+    println!(
+        "[5] typed event onEchoFired: message={}, echo_count={}, wildcard_hits={}",
+        evt.message,
+        evt.echo_count,
+        wildcard_hits.load(Ordering::SeqCst)
+    );
+
+    // Drop the typed listener; a second echo only reaches the wildcard.
+    assert!(ctx.remove_event_listener(typed_handle));
+
+    ctx.echo_async(EchoRequest {
+        message: "after-remove".into(),
+        delay_ms: 1,
+    })
+    .await?;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    println!(
+        "[6] after remove: wildcard_hits={} (typed listener silent)",
+        wildcard_hits.load(Ordering::SeqCst)
+    );
+
+    ctx.remove_event_listener(wildcard_handle);
+    println!("Done.");
+    Ok(())
+}

--- a/examples/timer/rust_bindings/src/api.rs
+++ b/examples/timer/rust_bindings/src/api.rs
@@ -98,62 +98,72 @@ where
     }
 }
 
-/// Typed event handlers for `MyTimerCtx`. Each field is `None` by
-/// default; set the ones you care about and pass to
-/// `MyTimerCtx::set_event_handlers`.
-#[allow(non_snake_case)]
-pub struct Events {
-    pub on_error: Option<Box<dyn Fn(&str) + Send + Sync>>,
-    pub onEchoFired: Option<Box<dyn Fn(&EchoEvent) + Send + Sync>>,
+struct OnEchoFiredHandler {
+    f: Box<dyn Fn(&EchoEvent) + Send + Sync>,
 }
 
-impl Default for Events {
-    fn default() -> Self {
-        Self { on_error: None, onEchoFired: None }
+unsafe extern "C" fn on_echo_fired_trampoline(
+    ret: c_int, msg: *const c_char, len: usize, ud: *mut c_void,
+) {
+    if ud.is_null() || ret != 0 || msg.is_null() || len == 0 {
+        return;
+    }
+    let h = &*(ud as *const OnEchoFiredHandler);
+    let bytes = slice::from_raw_parts(msg as *const u8, len);
+    #[derive(serde::Deserialize)]
+    struct Envelope { payload: EchoEvent }
+    if let Ok(env) = ciborium::de::from_reader::<Envelope, _>(bytes) {
+        (h.f)(&env.payload);
     }
 }
 
-unsafe extern "C" fn my_timer_event_trampoline(
+struct WildcardHandler {
+    f: Box<dyn Fn(c_int, &str, &[u8]) + Send + Sync>,
+}
+
+unsafe extern "C" fn my_timer_wildcard_trampoline(
     ret: c_int, msg: *const c_char, len: usize, ud: *mut c_void,
 ) {
     if ud.is_null() { return; }
-    let events = &*(ud as *const Events);
-    if ret != 0 {
-        if let Some(ref on_err) = events.on_error {
-            let bytes = if !msg.is_null() && len > 0 {
-                slice::from_raw_parts(msg as *const u8, len)
-            } else { &[] };
-            let s = String::from_utf8_lossy(bytes);
-            on_err(&s);
-        }
-        return;
-    }
-    if msg.is_null() || len == 0 { return; }
-    let bytes = slice::from_raw_parts(msg as *const u8, len);
-    #[derive(serde::Deserialize)]
-    struct EnvelopeMeta {
-        #[serde(rename = "eventType")]
-        event_type: String,
-    }
-    let meta: EnvelopeMeta = match ciborium::de::from_reader(bytes) {
-        Ok(m) => m,
-        Err(_) => return,
-    };
-    if meta.event_type == "on_echo_fired" {
+    let h = &*(ud as *const WildcardHandler);
+    let bytes = if !msg.is_null() && len > 0 {
+        slice::from_raw_parts(msg as *const u8, len)
+    } else { &[] };
+    let event_id = if ret == 0 && !bytes.is_empty() {
         #[derive(serde::Deserialize)]
-        struct Envelope { payload: EchoEvent }
-        if let Ok(env) = ciborium::de::from_reader::<Envelope, _>(bytes) {
-            if let Some(ref h) = events.onEchoFired { h(&env.payload); }
+        struct EnvelopeMeta {
+            #[serde(rename = "eventType")]
+            event_type: String,
         }
-        return;
-    }
+        ciborium::de::from_reader::<EnvelopeMeta, _>(bytes)
+            .map(|m| m.event_type).unwrap_or_default()
+    } else {
+        String::new()
+    };
+    (h.f)(ret, event_id.as_str(), bytes);
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ListenerHandle { pub id: u64 }
+
+/// Decode the `payload` field of a CBOR `EventEnvelope` as `T`.
+/// Returns `Err` if the envelope is empty / malformed / the payload
+/// cannot be deserialised as `T`.
+pub fn decode_event_payload<T: serde::de::DeserializeOwned>(
+    envelope: &[u8],
+) -> Result<T, String> {
+    #[derive(serde::Deserialize)]
+    struct Envelope<T> { payload: T }
+    let env: Envelope<T> = ciborium::de::from_reader(envelope)
+        .map_err(|e| format!("decode event payload: {e}"))?;
+    Ok(env.payload)
 }
 
 /// High-level context for `MyTimer`.
 pub struct MyTimerCtx {
     ptr: *mut c_void,
     timeout: Duration,
-    events: *mut Events,
+    listeners: std::sync::Mutex<std::collections::HashMap<u64, Box<dyn std::any::Any + Send>>>,
 }
 
 // SAFETY: The `ptr` field points to an FFIContext owned by the Nim runtime.
@@ -173,10 +183,6 @@ impl Drop for MyTimerCtx {
             unsafe { ffi::my_timer_destroy(self.ptr); }
             self.ptr = std::ptr::null_mut();
         }
-        if !self.events.is_null() {
-            unsafe { drop(Box::from_raw(self.events)); }
-            self.events = std::ptr::null_mut();
-        }
     }
 }
 
@@ -190,7 +196,7 @@ impl MyTimerCtx {
         })?;
         let addr_str: String = decode_cbor(&raw_bytes)?;
         let addr: usize = addr_str.parse().map_err(|e: std::num::ParseIntError| e.to_string())?;
-        Ok(Self { ptr: addr as *mut c_void, timeout, events: std::ptr::null_mut() })
+        Ok(Self { ptr: addr as *mut c_void, timeout, listeners: std::sync::Mutex::new(std::collections::HashMap::new()) })
     }
 
     pub async fn new_async(config: TimerConfig, timeout: Duration) -> Result<Self, String> {
@@ -202,23 +208,57 @@ impl MyTimerCtx {
         }).await?;
         let addr_str: String = decode_cbor(&raw_bytes)?;
         let addr: usize = addr_str.parse().map_err(|e: std::num::ParseIntError| e.to_string())?;
-        Ok(Self { ptr: addr as *mut c_void, timeout, events: std::ptr::null_mut() })
+        Ok(Self { ptr: addr as *mut c_void, timeout, listeners: std::sync::Mutex::new(std::collections::HashMap::new()) })
     }
 
-    /// Attach typed event handlers. Replacing handlers calls the
-    /// dylib's set_event_callback with a fresh trampoline target.
-    /// The previously-installed Events box (if any) is dropped here,
-    /// so callbacks in flight on the FFI thread must already be done.
-    pub fn set_event_handlers(&mut self, handlers: Events) {
-        if !self.events.is_null() {
-            unsafe { drop(Box::from_raw(self.events)); }
-            self.events = std::ptr::null_mut();
+    /// Register a typed listener for `on_echo_fired`. The returned handle can be
+    /// passed to `remove_event_listener` to unregister.
+    pub fn add_on_echo_fired_listener<F>(&self, handler: F) -> ListenerHandle
+    where F: Fn(&EchoEvent) + Send + Sync + 'static,
+    {
+        let owned: Box<OnEchoFiredHandler> = Box::new(OnEchoFiredHandler { f: Box::new(handler) });
+        let raw = &*owned as *const OnEchoFiredHandler as *mut c_void;
+        let id = unsafe {
+            ffi::my_timer_add_event_listener(
+                self.ptr, b"on_echo_fired\0".as_ptr() as *const c_char,
+                on_echo_fired_trampoline, raw)
+        };
+        if id != 0 {
+            self.listeners.lock().unwrap().insert(id, owned);
         }
-        let raw = Box::into_raw(Box::new(handlers));
-        self.events = raw;
-        unsafe {
-            ffi::my_timer_set_event_callback(self.ptr, my_timer_event_trampoline, raw as *mut c_void);
+        ListenerHandle { id }
+    }
+
+    /// Register a catch-all listener that receives every event.
+    /// The handler arguments are (return_code, event_id, envelope_bytes):
+    /// `event_id` is the wire `eventType` string extracted from the
+    /// envelope (empty on error or malformed envelope); `envelope_bytes`
+    /// is the full CBOR envelope, suitable for `decode_event_payload::<T>`.
+    pub fn add_event_listener<F>(&self, handler: F) -> ListenerHandle
+    where F: Fn(c_int, &str, &[u8]) + Send + Sync + 'static,
+    {
+        let owned: Box<WildcardHandler> = Box::new(WildcardHandler { f: Box::new(handler) });
+        let raw = &*owned as *const WildcardHandler as *mut c_void;
+        let id = unsafe {
+            ffi::my_timer_add_event_listener(
+                self.ptr, b"\0".as_ptr() as *const c_char,
+                my_timer_wildcard_trampoline, raw)
+        };
+        if id != 0 {
+            self.listeners.lock().unwrap().insert(id, owned);
         }
+        ListenerHandle { id }
+    }
+
+    /// Remove a previously-registered listener by handle. Returns true
+    /// if the listener existed and was removed; false otherwise.
+    pub fn remove_event_listener(&self, handle: ListenerHandle) -> bool {
+        if handle.id == 0 { return false; }
+        let rc = unsafe {
+            ffi::my_timer_remove_event_listener(self.ptr, handle.id)
+        };
+        self.listeners.lock().unwrap().remove(&handle.id);
+        rc == 0
     }
 
     pub fn echo(&self, req: EchoRequest) -> Result<EchoResponse, String> {

--- a/examples/timer/rust_bindings/src/ffi.rs
+++ b/examples/timer/rust_bindings/src/ffi.rs
@@ -15,5 +15,6 @@ extern "C" {
     pub fn my_timer_complex(ctx: *mut c_void, callback: FFICallback, user_data: *mut c_void, req_cbor: *const u8, req_cbor_len: usize) -> c_int;
     pub fn my_timer_schedule(ctx: *mut c_void, callback: FFICallback, user_data: *mut c_void, req_cbor: *const u8, req_cbor_len: usize) -> c_int;
     pub fn my_timer_destroy(ctx: *mut c_void) -> c_int;
-    pub fn my_timer_set_event_callback(ctx: *mut c_void, callback: FFICallback, user_data: *mut c_void);
+    pub fn my_timer_add_event_listener(ctx: *mut c_void, event_name: *const c_char, callback: FFICallback, user_data: *mut c_void) -> u64;
+    pub fn my_timer_remove_event_listener(ctx: *mut c_void, listener_id: u64) -> c_int;
 }

--- a/ffi.nim
+++ b/ffi.nim
@@ -2,10 +2,13 @@ import std/[atomics, tables]
 import chronos, chronicles
 import
   ffi/internal/[ffi_library, ffi_macro],
-  ffi/[alloc, ffi_types, ffi_context, ffi_context_pool, ffi_thread_request, cbor_serial]
+  ffi/[
+    alloc, ffi_types, ffi_events, ffi_context, ffi_context_pool, ffi_thread_request,
+    cbor_serial,
+  ]
 
 export atomics, tables
 export chronos, chronicles
 export
-  atomics, alloc, ffi_library, ffi_macro, ffi_types, ffi_context, ffi_context_pool,
-  ffi_thread_request, cbor_serial
+  atomics, alloc, ffi_library, ffi_macro, ffi_types, ffi_events, ffi_context,
+  ffi_context_pool, ffi_thread_request, cbor_serial

--- a/ffi/codegen/cpp.nim
+++ b/ffi/codegen/cpp.nim
@@ -138,80 +138,191 @@ proc cppBracedInit(structName: string, fieldNames: seq[string]): string =
 proc emitEventDispatcher(
     lines: var seq[string], ctxTypeName, libName: string, events: seq[FFIEventMeta]
 ) =
-  ## Emit the typed-event support inside the C++ context class body:
-  ## a nested `Events` struct of std::function handlers, plus a
-  ## `setEventHandlers` method that owns the handlers on the heap and
-  ## hands the raw pointer to the dylib as `user_data` for the trampoline.
+  ## Public listener-registration API in the generated context class:
   ##
-  ## Storage strategy: `Events` lives on the heap (unique_ptr) so the raw
-  ## pointer we hand to the C ABI as `user_data` survives the (non-)
-  ## lifetime of the surrounding context object. The context itself is
-  ## owned via `std::unique_ptr<MyTimerCtx>` returned from `create`, so
-  ## it's never moved out from under the trampoline.
+  ## - `addOn<X>Listener(std::function<void(const T&)>) -> ListenerHandle`
+  ##   per declared `{.ffiEvent.}`. Internally registers under the wire
+  ##   event name; the per-listener trampoline decodes the CBOR
+  ##   envelope's `payload` field as `T` and invokes the user handler.
+  ## - `addEventListener(std::function<void(int, const std::string&)>) ->
+  ##   ListenerHandle` registers a catch-all wildcard listener
+  ##   (event_name == "") that receives every event as raw envelope
+  ##   bytes plus the FFI return code.
+  ## - `removeEventListener(ListenerHandle) -> bool` drops a listener by
+  ##   handle. After it returns true, no further callbacks for that id
+  ##   are in flight on the FFI side (the Nim-side registry lock plus
+  ##   snapshot copy guarantees this).
+  ##
+  ## Ownership: each listener's callable is held by a
+  ## `std::unique_ptr<ListenerBase>` in `listeners_`, keyed by id; the
+  ## raw pointer is handed to the dylib as `user_data`. The map entry
+  ## (and therefore the callable) survives at a stable heap address
+  ## until `removeEventListener` removes it.
   if events.len == 0:
     return
-  lines.add("    // ── Typed event handlers ────────────────────────────────")
-  lines.add("    struct Events {")
-  lines.add("        std::function<void(const std::string&)> on_error;")
-  for ev in events:
-    lines.add(
-      "        std::function<void(const $1&)> $2;" %
-        [ev.payloadTypeName, ev.nimProcName]
-    )
-  lines.add("    };")
+  lines.add("    // ── Event listener API ──────────────────────────────────")
+  lines.add("    struct ListenerHandle { std::uint64_t id = 0; };")
   lines.add("")
-  lines.add("    void setEventHandlers(Events handlers) {")
-  lines.add("        events_ = std::make_unique<Events>(std::move(handlers));")
+  # Per-event typed registration helpers.
+  for ev in events:
+    let methodName =
+      "addOn" & capitalizeFirstLetter(ev.nimProcName).substr(2) & "Listener"
+    lines.add(
+      "    ListenerHandle $1(std::function<void(const $2&)> handler) {" %
+        [methodName, ev.payloadTypeName]
+    )
+    lines.add(
+      "        auto owned = std::make_unique<TypedListener<$1>>(std::move(handler));" %
+        [ev.payloadTypeName]
+    )
+    lines.add("        auto* raw = owned.get();")
+    lines.add(
+      "        const auto id = $1_add_event_listener(" % [libName]
+    )
+    lines.add(
+      "            ptr_, \"$1\", &$2::typedTrampoline<$3>, raw);" %
+        [ev.wireName, ctxTypeName, ev.payloadTypeName]
+    )
+    lines.add("        if (id == 0) return ListenerHandle{0};")
+    lines.add("        listeners_.emplace(id, std::move(owned));")
+    lines.add("        return ListenerHandle{id};")
+    lines.add("    }")
+    lines.add("")
+  # Generic wildcard registration.
+  #
+  # The handler receives the FFI return code, the wire `eventType` string
+  # extracted from the CBOR envelope (empty if the envelope is malformed
+  # or `ret != 0`), and the raw envelope bytes. Pair with
+  # `decodeEventPayload<T>` to lift the payload into a typed value
+  # without hand-rolling CBOR parsing.
   lines.add(
-    "        $1_set_event_callback(ptr_, &$2::eventTrampoline, events_.get());" %
-      [libName, ctxTypeName]
+    "    ListenerHandle addEventListener(std::function<void(int, const std::string&, const std::vector<std::uint8_t>&)> handler) {"
   )
+  lines.add(
+    "        auto owned = std::make_unique<WildcardListener>(std::move(handler));"
+  )
+  lines.add("        auto* raw = owned.get();")
+  lines.add("        const auto id = $1_add_event_listener(" % [libName])
+  lines.add(
+    "            ptr_, \"\", &$1::wildcardTrampoline, raw);" % [ctxTypeName]
+  )
+  lines.add("        if (id == 0) return ListenerHandle{0};")
+  lines.add("        listeners_.emplace(id, std::move(owned));")
+  lines.add("        return ListenerHandle{id};")
+  lines.add("    }")
+  lines.add("")
+  # Remove by handle.
+  lines.add("    bool removeEventListener(ListenerHandle handle) {")
+  lines.add("        if (handle.id == 0) return false;")
+  lines.add(
+    "        const auto rc = $1_remove_event_listener(ptr_, handle.id);" % [libName]
+  )
+  lines.add("        listeners_.erase(handle.id);")
+  lines.add("        return rc == 0;")
   lines.add("    }")
   lines.add("")
 
 proc emitEventTrampoline(
     lines: var seq[string], events: seq[FFIEventMeta]
 ) =
-  ## Emit the private static trampoline that backs `setEventHandlers`. The
-  ## generated function parses the CBOR `EventEnvelope`, picks the matching
-  ## std::function from the Events struct, decodes the payload as the
-  ## registered type, and fires the handler.
+  ## Private listener machinery for the public API emitted by
+  ## `emitEventDispatcher`:
+  ##
+  ## - `ListenerBase` is a polymorphic base so the context's
+  ##   `listeners_` map can own typed and wildcard listeners under a
+  ##   single value type.
+  ## - `TypedListener<T>` holds the user's `std::function<void(const T&)>`
+  ##   and is the target of `typedTrampoline<T>`, which CBOR-decodes the
+  ##   envelope's `payload` field as `T` and invokes the handler.
+  ## - `WildcardListener` holds a `std::function<void(int, const
+  ##   std::string&)>` and is the target of `wildcardTrampoline`, which
+  ##   forwards the FFI return code plus raw payload bytes verbatim.
   if events.len == 0:
     return
-  lines.add("    static void eventTrampoline(int ret, const char* msg, std::size_t len, void* ud) {")
-  lines.add("        if (!ud) return;")
-  lines.add("        auto* events = static_cast<Events*>(ud);")
-  lines.add("        if (ret != 0) {")
-  lines.add("            if (events->on_error) {")
-  lines.add("                std::string err(msg ? msg : \"\", len);")
-  lines.add("                events->on_error(err);")
-  lines.add("            }")
-  lines.add("            return;")
-  lines.add("        }")
-  lines.add("        if (!msg || len == 0) return;")
-  lines.add("        std::vector<std::uint8_t> bytes(reinterpret_cast<const std::uint8_t*>(msg),")
-  lines.add("                                        reinterpret_cast<const std::uint8_t*>(msg) + len);")
+  lines.add("    struct ListenerBase {")
+  lines.add("        virtual ~ListenerBase() = default;")
+  lines.add("    };")
+  lines.add("")
+  lines.add("    template <class T>")
+  lines.add("    struct TypedListener : ListenerBase {")
+  lines.add("        std::function<void(const T&)> fn;")
+  lines.add("        explicit TypedListener(std::function<void(const T&)> f) : fn(std::move(f)) {}")
+  lines.add("    };")
+  lines.add("")
+  lines.add("    struct WildcardListener : ListenerBase {")
+  lines.add(
+    "        std::function<void(int, const std::string&, const std::vector<std::uint8_t>&)> fn;"
+  )
+  lines.add(
+    "        explicit WildcardListener(std::function<void(int, const std::string&, const std::vector<std::uint8_t>&)> f) : fn(std::move(f)) {}"
+  )
+  lines.add("    };")
+  lines.add("")
+  # Typed trampoline — one instantiation per payload type, all sharing a body.
+  lines.add("    template <class T>")
+  lines.add("    static void typedTrampoline(int ret, const char* msg, std::size_t len, void* ud) {")
+  lines.add("        if (!ud || ret != 0 || !msg || len == 0) return;")
+  lines.add("        auto* listener = static_cast<TypedListener<T>*>(ud);")
+  lines.add("        if (!listener->fn) return;")
+  lines.add(
+    "        std::vector<std::uint8_t> bytes(reinterpret_cast<const std::uint8_t*>(msg),"
+  )
+  lines.add(
+    "                                        reinterpret_cast<const std::uint8_t*>(msg) + len);"
+  )
   lines.add("        CborParser parser; CborValue it;")
-  lines.add("        if (cbor_parser_init(bytes.data(), bytes.size(), 0, &parser, &it) != CborNoError) return;")
+  lines.add(
+    "        if (cbor_parser_init(bytes.data(), bytes.size(), 0, &parser, &it) != CborNoError) return;"
+  )
   lines.add("        if (!cbor_value_is_map(&it)) return;")
-  lines.add("        CborValue evtField;")
-  lines.add("        if (cbor_value_map_find_value(&it, \"eventType\", &evtField) != CborNoError) return;")
-  lines.add("        if (!cbor_value_is_text_string(&evtField)) return;")
-  lines.add("        std::string evtName; if (decode_cbor(evtField, evtName) != CborNoError) return;")
   lines.add("        CborValue payloadField;")
-  lines.add("        if (cbor_value_map_find_value(&it, \"payload\", &payloadField) != CborNoError) return;")
-  var first = true
-  for ev in events:
-    let branchKw = if first: "if" else: "else if"
-    lines.add("        $1 (evtName == \"$2\") {" % [branchKw, ev.wireName])
-    lines.add("            if (events->$1) {" % [ev.nimProcName])
-    lines.add(
-      "                $1 payload{}; if (decode_cbor(payloadField, payload) == CborNoError) events->$2(payload);" %
-        [ev.payloadTypeName, ev.nimProcName]
-    )
-    lines.add("            }")
-    lines.add("        }")
-    first = false
+  lines.add(
+    "        if (cbor_value_map_find_value(&it, \"payload\", &payloadField) != CborNoError) return;"
+  )
+  lines.add("        T payload{};")
+  lines.add(
+    "        if (decode_cbor(payloadField, payload) != CborNoError) return;"
+  )
+  lines.add("        listener->fn(payload);")
+  lines.add("    }")
+  lines.add("")
+  # Wildcard trampoline — extracts `eventType` from the CBOR envelope so
+  # the user can match on the event name without hand-parsing. Falls back
+  # to an empty `eventId` if the envelope is missing, malformed, or the
+  # FFI return code signals an error (in which case the bytes are an
+  # error string, not a CBOR envelope).
+  lines.add(
+    "    static void wildcardTrampoline(int ret, const char* msg, std::size_t len, void* ud) {"
+  )
+  lines.add("        if (!ud) return;")
+  lines.add("        auto* listener = static_cast<WildcardListener*>(ud);")
+  lines.add("        if (!listener->fn) return;")
+  lines.add("        std::vector<std::uint8_t> envelope;")
+  lines.add("        if (msg && len > 0) {")
+  lines.add(
+    "            envelope.assign(reinterpret_cast<const std::uint8_t*>(msg),"
+  )
+  lines.add(
+    "                            reinterpret_cast<const std::uint8_t*>(msg) + len);"
+  )
+  lines.add("        }")
+  lines.add("        std::string eventId;")
+  lines.add("        if (ret == 0 && !envelope.empty()) {")
+  lines.add("            CborParser parser; CborValue it;")
+  lines.add(
+    "            if (cbor_parser_init(envelope.data(), envelope.size(), 0, &parser, &it) == CborNoError"
+  )
+  lines.add("                && cbor_value_is_map(&it)) {")
+  lines.add("                CborValue evtField;")
+  lines.add(
+    "                if (cbor_value_map_find_value(&it, \"eventType\", &evtField) == CborNoError"
+  )
+  lines.add("                    && cbor_value_is_text_string(&evtField)) {")
+  lines.add("                    (void)decode_cbor(evtField, eventId);")
+  lines.add("                }")
+  lines.add("            }")
+  lines.add("        }")
+  lines.add("        listener->fn(ret, eventId, envelope);")
   lines.add("    }")
   lines.add("")
 
@@ -303,17 +414,46 @@ proc generateCppHeader*(
       )
     of FFIKind.DTOR:
       lines.add("int $1(void* ctx);" % [p.procName])
-  # The event-callback setter is always exported by the dylib (via
-  # declareLibrary). Declare it here so the typed event-handler wiring
-  # below can call into it.
+  # `declareLibrary` always exports the listener-registration ABI. Declare
+  # it here so the typed event-handler wiring below can call into it.
   lines.add(
-    "void $1_set_event_callback(void* ctx, FFICallback callback, void* user_data);" %
+    "uint64_t $1_add_event_listener(void* ctx, const char* event_name, FFICallback callback, void* user_data);" %
       [libName]
+  )
+  lines.add(
+    "int $1_remove_event_listener(void* ctx, uint64_t listener_id);" % [libName]
   )
   lines.add("} // extern \"C\"")
   lines.add("")
 
   lines.add(SyncCallHelperTpl)
+
+  # ── Event-payload decoder helper ──────────────────────────────────────────
+  # Lets wildcard-listener bodies lift the `payload` field out of a CBOR
+  # envelope into any registered event type with a single call, e.g.
+  #     EchoEvent evt;
+  #     if (decodeEventPayload(envelope, evt)) { ... }
+  # Relies on the per-struct `decode_cbor` codec emitted above.
+  if events.len > 0:
+    lines.add("template <class T>")
+    lines.add(
+      "inline bool decodeEventPayload(const std::vector<std::uint8_t>& envelope, T& out) {"
+    )
+    lines.add("    if (envelope.empty()) return false;")
+    lines.add("    CborParser parser; CborValue it;")
+    lines.add(
+      "    if (cbor_parser_init(envelope.data(), envelope.size(), 0, &parser, &it) != CborNoError)"
+    )
+    lines.add("        return false;")
+    lines.add("    if (!cbor_value_is_map(&it)) return false;")
+    lines.add("    CborValue payloadField;")
+    lines.add(
+      "    if (cbor_value_map_find_value(&it, \"payload\", &payloadField) != CborNoError)"
+    )
+    lines.add("        return false;")
+    lines.add("    return decode_cbor(payloadField, out) == CborNoError;")
+    lines.add("}")
+    lines.add("")
 
   # ── High-level C++ context class ──────────────────────────────────────────
   var ctors: seq[FFIProcMeta] = @[]
@@ -497,16 +637,27 @@ proc generateCppHeader*(
     lines.add("")
 
   lines.add("private:")
+  # Listener machinery (`ListenerBase`, `TypedListener<T>`,
+  # `WildcardListener`, plus the static trampolines) must appear before
+  # the `listeners_` data member declaration — C++ requires the value
+  # type of a member to be complete at point of declaration. The public
+  # add*/remove methods above also reference these types, but member
+  # function bodies see the full class scope regardless of declaration
+  # order, so emitting here is sufficient for both.
+  emitEventTrampoline(lines, events)
   lines.add("    void* ptr_;")
   lines.add("    std::chrono::milliseconds timeout_;")
   if events.len > 0:
-    lines.add("    std::unique_ptr<Events> events_;")
+    # One owning entry per live listener, keyed by id. Destroyed after
+    # the destructor body runs `<lib>_destroy(ptr_)`, by which point the
+    # FFI side has joined its threads so no callback is mid-flight.
+    lines.add(
+      "    std::unordered_map<std::uint64_t, std::unique_ptr<ListenerBase>> listeners_;"
+    )
   lines.add(
     "    explicit $1(void* p, std::chrono::milliseconds t) : ptr_(p), timeout_(t) {}" %
       [ctxTypeName]
   )
-  # Static trampoline stays private; user only sees Events + setEventHandlers.
-  emitEventTrampoline(lines, events)
   lines.add("};")
   lines.add("")
 

--- a/ffi/codegen/rust.nim
+++ b/ffi/codegen/rust.nim
@@ -74,6 +74,10 @@ proc generateCargoToml*(libName: string): string =
   # pulling its async-std/futures shims.
   # `tokio` is needed only for `tokio::time::timeout` around the async
   # `recv_async`. Feature-gating tokio (item 11) is a follow-up commit.
+  #
+  # `[dev-dependencies]` enables the bundled `examples/` to use
+  # `#[tokio::main]` (needs the `rt-multi-thread` and `macros` features)
+  # without pulling those into the library's runtime profile.
   return
     """[package]
 name = "$1"
@@ -85,6 +89,9 @@ serde = { version = "1", features = ["derive"] }
 ciborium = "0.2"
 flume = { version = "0.11", default-features = false, features = ["async"] }
 tokio = { version = "1", features = ["sync", "time"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
 """ %
     [libName]
 
@@ -207,10 +214,14 @@ proc generateFFIRs*(procs: seq[FFIProcMeta]): string =
       params.add("ctx: *mut c_void")
       lines.add("    pub fn $1($2) -> c_int;" % [p.procName, params.join(", ")])
 
-  # Event-callback setter — emitted on the Nim side by `declareLibrary`,
+  # Listener-registration ABI — emitted on the Nim side by `declareLibrary`,
   # always present in the dylib.
   lines.add(
-    "    pub fn $1_set_event_callback(ctx: *mut c_void, callback: FFICallback, user_data: *mut c_void);" %
+    "    pub fn $1_add_event_listener(ctx: *mut c_void, event_name: *const c_char, callback: FFICallback, user_data: *mut c_void) -> u64;" %
+      [linkLibName]
+  )
+  lines.add(
+    "    pub fn $1_remove_event_listener(ctx: *mut c_void, listener_id: u64) -> c_int;" %
       [linkLibName]
   )
 
@@ -442,77 +453,105 @@ proc generateApiRs*(
   lines.add("}")
   lines.add("")
 
-  # ── Typed event handler struct + trampoline (only if events declared) ────
-  # The Events struct holds optional boxed closures, one per registered
-  # `{.ffiEvent.}`. The struct lives on the heap (Box::into_raw); its raw
-  # pointer is handed to the dylib as `user_data` for the event callback.
-  # The trampoline parses the CBOR `EventEnvelope`, picks the matching
-  # field on Events, decodes the payload as the registered type, and
-  # invokes the closure.
+  # ── Per-listener handler boxes + extern "C" trampolines ─────────────────
+  # Each registered listener owns a `Box<…Handler>` that is kept alive in
+  # `$1::listeners` (keyed by listener id). The raw pointer to the inner
+  # handler is handed to the dylib as `user_data` for the per-event or
+  # wildcard trampoline below.
   if events.len > 0:
-    lines.add("/// Typed event handlers for `$1`. Each field is `None` by" % [ctxTypeName])
-    lines.add("/// default; set the ones you care about and pass to")
-    lines.add("/// `$1::set_event_handlers`." % [ctxTypeName])
-    lines.add("#[allow(non_snake_case)]")
-    lines.add("pub struct Events {")
-    lines.add("    pub on_error: Option<Box<dyn Fn(&str) + Send + Sync>>,")
     for ev in events:
+      let handlerStruct = capitalizeFirstLetter(ev.nimProcName) & "Handler"
+      let trampolineName = camelToSnakeCase(ev.nimProcName) & "_trampoline"
+      lines.add("struct $1 {" % [handlerStruct])
       lines.add(
-        "    pub $1: Option<Box<dyn Fn(&$2) + Send + Sync>>," %
-          [ev.nimProcName, ev.payloadTypeName]
+        "    f: Box<dyn Fn(&$1) + Send + Sync>," % [ev.payloadTypeName]
       )
-    lines.add("}")
-    lines.add("")
-    lines.add("impl Default for Events {")
-    lines.add("    fn default() -> Self {")
-    lines.add("        Self { on_error: None, " &
-      events.mapIt(it.nimProcName & ": None").join(", ") & " }")
-    lines.add("    }")
-    lines.add("}")
-    lines.add("")
+      lines.add("}")
+      lines.add("")
+      lines.add("unsafe extern \"C\" fn $1(" % [trampolineName])
+      lines.add("    ret: c_int, msg: *const c_char, len: usize, ud: *mut c_void,")
+      lines.add(") {")
+      lines.add("    if ud.is_null() || ret != 0 || msg.is_null() || len == 0 {")
+      lines.add("        return;")
+      lines.add("    }")
+      lines.add("    let h = &*(ud as *const $1);" % [handlerStruct])
+      lines.add("    let bytes = slice::from_raw_parts(msg as *const u8, len);")
+      lines.add("    #[derive(serde::Deserialize)]")
+      lines.add(
+        "    struct Envelope { payload: $1 }" % [ev.payloadTypeName]
+      )
+      lines.add(
+        "    if let Ok(env) = ciborium::de::from_reader::<Envelope, _>(bytes) {"
+      )
+      lines.add("        (h.f)(&env.payload);")
+      lines.add("    }")
+      lines.add("}")
+      lines.add("")
 
-    # Trampoline — `extern "C"` free function. Deserialises the envelope
-    # twice: once for `eventType`, then with the typed payload via serde.
-    lines.add("unsafe extern \"C\" fn $1_event_trampoline(" % [libName])
+    # Wildcard handler — receives every event as raw envelope bytes,
+    # the FFI return code, and the `eventType` string pre-extracted
+    # from the CBOR envelope. `event_id` is empty when `ret != 0` or
+    # the envelope is malformed (the bytes are an error string, not a
+    # CBOR envelope, in that case).
+    lines.add("struct WildcardHandler {")
+    lines.add("    f: Box<dyn Fn(c_int, &str, &[u8]) + Send + Sync>,")
+    lines.add("}")
+    lines.add("")
+    lines.add("unsafe extern \"C\" fn $1_wildcard_trampoline(" % [libName])
     lines.add("    ret: c_int, msg: *const c_char, len: usize, ud: *mut c_void,")
     lines.add(") {")
     lines.add("    if ud.is_null() { return; }")
-    lines.add("    let events = &*(ud as *const Events);")
-    lines.add("    if ret != 0 {")
-    lines.add("        if let Some(ref on_err) = events.on_error {")
-    lines.add("            let bytes = if !msg.is_null() && len > 0 {")
-    lines.add("                slice::from_raw_parts(msg as *const u8, len)")
-    lines.add("            } else { &[] };")
-    lines.add("            let s = String::from_utf8_lossy(bytes);")
-    lines.add("            on_err(&s);")
+    lines.add("    let h = &*(ud as *const WildcardHandler);")
+    lines.add("    let bytes = if !msg.is_null() && len > 0 {")
+    lines.add("        slice::from_raw_parts(msg as *const u8, len)")
+    lines.add("    } else { &[] };")
+    lines.add("    let event_id = if ret == 0 && !bytes.is_empty() {")
+    lines.add("        #[derive(serde::Deserialize)]")
+    lines.add("        struct EnvelopeMeta {")
+    lines.add("            #[serde(rename = \"eventType\")]")
+    lines.add("            event_type: String,")
     lines.add("        }")
-    lines.add("        return;")
-    lines.add("    }")
-    lines.add("    if msg.is_null() || len == 0 { return; }")
-    lines.add("    let bytes = slice::from_raw_parts(msg as *const u8, len);")
-    lines.add("    #[derive(serde::Deserialize)]")
-    lines.add("    struct EnvelopeMeta {")
-    lines.add("        #[serde(rename = \"eventType\")]")
-    lines.add("        event_type: String,")
-    lines.add("    }")
-    lines.add("    let meta: EnvelopeMeta = match ciborium::de::from_reader(bytes) {")
-    lines.add("        Ok(m) => m,")
-    lines.add("        Err(_) => return,")
+    lines.add(
+      "        ciborium::de::from_reader::<EnvelopeMeta, _>(bytes)"
+    )
+    lines.add("            .map(|m| m.event_type).unwrap_or_default()")
+    lines.add("    } else {")
+    lines.add("        String::new()")
     lines.add("    };")
-    for ev in events:
-      lines.add("    if meta.event_type == \"$1\" {" % [ev.wireName])
-      lines.add("        #[derive(serde::Deserialize)]")
-      lines.add("        struct Envelope { payload: $1 }" % [ev.payloadTypeName])
-      lines.add(
-        "        if let Ok(env) = ciborium::de::from_reader::<Envelope, _>(bytes) {"
-      )
-      lines.add(
-        "            if let Some(ref h) = events.$1 { h(&env.payload); }" %
-          [ev.nimProcName]
-      )
-      lines.add("        }")
-      lines.add("        return;")
-      lines.add("    }")
+    lines.add("    (h.f)(ret, event_id.as_str(), bytes);")
+    lines.add("}")
+    lines.add("")
+
+    # Public handle returned by every add_…_listener call.
+    lines.add("#[derive(Debug, Clone, Copy)]")
+    lines.add("pub struct ListenerHandle { pub id: u64 }")
+    lines.add("")
+
+    # Helper: decode an event envelope's `payload` field into any typed
+    # `T` that the generated `types.rs` already derives `Deserialize` on.
+    # Pair with `add_event_listener` to lift raw envelope bytes into a
+    # typed payload without hand-rolling ciborium calls in each branch.
+    lines.add(
+      "/// Decode the `payload` field of a CBOR `EventEnvelope` as `T`."
+    )
+    lines.add(
+      "/// Returns `Err` if the envelope is empty / malformed / the payload"
+    )
+    lines.add("/// cannot be deserialised as `T`.")
+    lines.add(
+      "pub fn decode_event_payload<T: serde::de::DeserializeOwned>("
+    )
+    lines.add("    envelope: &[u8],")
+    lines.add(") -> Result<T, String> {")
+    lines.add("    #[derive(serde::Deserialize)]")
+    lines.add("    struct Envelope<T> { payload: T }")
+    lines.add(
+      "    let env: Envelope<T> = ciborium::de::from_reader(envelope)"
+    )
+    lines.add(
+      "        .map_err(|e| format!(\"decode event payload: {e}\"))?;"
+    )
+    lines.add("    Ok(env.payload)")
     lines.add("}")
     lines.add("")
 
@@ -522,7 +561,14 @@ proc generateApiRs*(
   lines.add("    ptr: *mut c_void,")
   lines.add("    timeout: Duration,")
   if events.len > 0:
-    lines.add("    events: *mut Events,")
+    # Keeps each registered handler box alive while its listener id is
+    # live on the Nim side. Removing an entry from the map drops the
+    # Box and frees the user's closure; the Nim-side registry has
+    # already guaranteed no callback for that id is in flight by the
+    # time `_remove_event_listener` returns.
+    lines.add(
+      "    listeners: std::sync::Mutex<std::collections::HashMap<u64, Box<dyn std::any::Any + Send>>>,"
+    )
   lines.add("}")
   lines.add("")
   # SAFETY block applies to both impls below (PR #23 Rust review, item 7).
@@ -559,13 +605,9 @@ proc generateApiRs*(
     lines.add("            unsafe { ffi::$1(self.ptr); }" % [dtorProcName])
     lines.add("            self.ptr = std::ptr::null_mut();")
     lines.add("        }")
-    # Reclaim the Events box after the dylib's destroy has torn down the
-    # FFI thread (no more events will fire by this point).
-    if events.len > 0:
-      lines.add("        if !self.events.is_null() {")
-      lines.add("            unsafe { drop(Box::from_raw(self.events)); }")
-      lines.add("            self.events = std::ptr::null_mut();")
-      lines.add("        }")
+    # `listeners` is dropped automatically after this body returns. By
+    # that point the dylib has joined its threads, so no callback is mid-
+    # flight against any of the raw pointers we handed it.
     lines.add("    }")
     lines.add("}")
     lines.add("")
@@ -622,7 +664,7 @@ proc generateApiRs*(
       "        let addr: usize = addr_str.parse().map_err(|e: std::num::ParseIntError| e.to_string())?;"
     )
     if events.len > 0:
-      lines.add("        Ok(Self { ptr: addr as *mut c_void, timeout, events: std::ptr::null_mut() })")
+      lines.add("        Ok(Self { ptr: addr as *mut c_void, timeout, listeners: std::sync::Mutex::new(std::collections::HashMap::new()) })")
     else:
       lines.add("        Ok(Self { ptr: addr as *mut c_void, timeout })")
     lines.add("    }")
@@ -648,31 +690,123 @@ proc generateApiRs*(
       "        let addr: usize = addr_str.parse().map_err(|e: std::num::ParseIntError| e.to_string())?;"
     )
     if events.len > 0:
-      lines.add("        Ok(Self { ptr: addr as *mut c_void, timeout, events: std::ptr::null_mut() })")
+      lines.add("        Ok(Self { ptr: addr as *mut c_void, timeout, listeners: std::sync::Mutex::new(std::collections::HashMap::new()) })")
     else:
       lines.add("        Ok(Self { ptr: addr as *mut c_void, timeout })")
     lines.add("    }")
     lines.add("")
 
-  # ── Typed event registration ───────────────────────────────────────────
+  # ── Listener-registration API ─────────────────────────────────────────
   if events.len > 0:
-    lines.add("    /// Attach typed event handlers. Replacing handlers calls the")
-    lines.add("    /// dylib's set_event_callback with a fresh trampoline target.")
-    lines.add("    /// The previously-installed Events box (if any) is dropped here,")
-    lines.add("    /// so callbacks in flight on the FFI thread must already be done.")
-    lines.add("    pub fn set_event_handlers(&mut self, handlers: Events) {")
-    lines.add("        if !self.events.is_null() {")
-    lines.add("            unsafe { drop(Box::from_raw(self.events)); }")
-    lines.add("            self.events = std::ptr::null_mut();")
-    lines.add("        }")
-    lines.add("        let raw = Box::into_raw(Box::new(handlers));")
-    lines.add("        self.events = raw;")
-    lines.add("        unsafe {")
+    for ev in events:
+      let methodName = "add_" & camelToSnakeCase(ev.nimProcName) & "_listener"
+      let handlerStruct = capitalizeFirstLetter(ev.nimProcName) & "Handler"
+      let trampolineName = camelToSnakeCase(ev.nimProcName) & "_trampoline"
+      lines.add(
+        "    /// Register a typed listener for `$1`. The returned handle can be" %
+          [ev.wireName]
+      )
+      lines.add("    /// passed to `remove_event_listener` to unregister.")
+      lines.add(
+        "    pub fn $1<F>(&self, handler: F) -> ListenerHandle" % [methodName]
+      )
+      lines.add(
+        "    where F: Fn(&$1) + Send + Sync + 'static," % [ev.payloadTypeName]
+      )
+      lines.add("    {")
+      lines.add(
+        "        let owned: Box<$1> = Box::new($1 { f: Box::new(handler) });" %
+          [handlerStruct]
+      )
+      lines.add("        let raw = &*owned as *const $1 as *mut c_void;" %
+        [handlerStruct])
+      lines.add("        let id = unsafe {")
+      lines.add(
+        "            ffi::$1_add_event_listener(" % [libName]
+      )
+      lines.add(
+        "                self.ptr, b\"$1\\0\".as_ptr() as *const c_char," %
+          [ev.wireName]
+      )
+      lines.add(
+        "                $1, raw)" % [trampolineName]
+      )
+      lines.add("        };")
+      lines.add("        if id != 0 {")
+      lines.add(
+        "            self.listeners.lock().unwrap().insert(id, owned);"
+      )
+      lines.add("        }")
+      lines.add("        ListenerHandle { id }")
+      lines.add("    }")
+      lines.add("")
+
+    # Generic wildcard listener — receives every event with the wire
+    # `eventType` string pre-extracted plus the raw envelope bytes. Pair
+    # with `decode_event_payload::<T>` to lift the payload into a typed
+    # value.
     lines.add(
-      "            ffi::$1_set_event_callback(self.ptr, $1_event_trampoline, raw as *mut c_void);" %
+      "    /// Register a catch-all listener that receives every event."
+    )
+    lines.add(
+      "    /// The handler arguments are (return_code, event_id, envelope_bytes):"
+    )
+    lines.add(
+      "    /// `event_id` is the wire `eventType` string extracted from the"
+    )
+    lines.add(
+      "    /// envelope (empty on error or malformed envelope); `envelope_bytes`"
+    )
+    lines.add(
+      "    /// is the full CBOR envelope, suitable for `decode_event_payload::<T>`."
+    )
+    lines.add(
+      "    pub fn add_event_listener<F>(&self, handler: F) -> ListenerHandle"
+    )
+    lines.add("    where F: Fn(c_int, &str, &[u8]) + Send + Sync + 'static,")
+    lines.add("    {")
+    lines.add(
+      "        let owned: Box<WildcardHandler> = Box::new(WildcardHandler { f: Box::new(handler) });"
+    )
+    lines.add(
+      "        let raw = &*owned as *const WildcardHandler as *mut c_void;"
+    )
+    lines.add("        let id = unsafe {")
+    lines.add("            ffi::$1_add_event_listener(" % [libName])
+    lines.add(
+      "                self.ptr, b\"\\0\".as_ptr() as *const c_char,"
+    )
+    lines.add(
+      "                $1_wildcard_trampoline, raw)" % [libName]
+    )
+    lines.add("        };")
+    lines.add("        if id != 0 {")
+    lines.add("            self.listeners.lock().unwrap().insert(id, owned);")
+    lines.add("        }")
+    lines.add("        ListenerHandle { id }")
+    lines.add("    }")
+    lines.add("")
+
+    # Remove by handle. Drops the Box (and the user's closure) after the
+    # C ABI confirms the listener has been unregistered.
+    lines.add(
+      "    /// Remove a previously-registered listener by handle. Returns true"
+    )
+    lines.add(
+      "    /// if the listener existed and was removed; false otherwise."
+    )
+    lines.add(
+      "    pub fn remove_event_listener(&self, handle: ListenerHandle) -> bool {"
+    )
+    lines.add("        if handle.id == 0 { return false; }")
+    lines.add("        let rc = unsafe {")
+    lines.add(
+      "            ffi::$1_remove_event_listener(self.ptr, handle.id)" %
         [libName]
     )
-    lines.add("        }")
+    lines.add("        };")
+    lines.add("        self.listeners.lock().unwrap().remove(&handle.id);")
+    lines.add("        rc == 0")
     lines.add("    }")
     lines.add("")
 

--- a/ffi/codegen/templates/cpp/header_prelude.hpp.tpl
+++ b/ffi/codegen/templates/cpp/header_prelude.hpp.tpl
@@ -12,6 +12,7 @@
 #include <optional>
 #include <type_traits>
 #include <cstring>
+#include <unordered_map>
 extern "C" {
 #include <tinycbor/cbor.h>
 }

--- a/ffi/ffi_context.nim
+++ b/ffi/ffi_context.nim
@@ -1,45 +1,12 @@
-{.pragma: exported, exportc, cdecl, raises: [].}
-{.pragma: callback, cdecl, raises: [], gcsafe.}
 {.passc: "-fPIC".}
 
 import std/[atomics, locks, json, tables]
 import chronicles, chronos, chronos/threadsync, taskpools/channels_spsc_single, results
-import ./ffi_types, ./ffi_thread_request, ./internal/ffi_macro, ./logging, ./cbor_serial
+import
+  ./ffi_types, ./ffi_events, ./ffi_thread_request, ./internal/ffi_macro, ./logging,
+  ./cbor_serial
 
-type FFICallbackState* = object
-  ## Holds the C event callback and its associated user-data pointer.
-  ## Embedded in FFIContext and referenced from the FFI thread via a
-  ## thread-local. `callback` / `userData` are written by
-  ## `{libName}_set_event_callback` from arbitrary caller threads and read
-  ## by every event dispatch on the FFI thread — `lock` exists so the
-  ## reader observes the pair atomically (and so the writes are visible
-  ## across threads at all under Nim's memory model).
-  callback*: pointer
-  userData*: pointer
-  lock*: Lock
-
-proc initCallbackState*(state: var FFICallbackState) =
-  state.lock.initLock()
-
-proc deinitCallbackState*(state: var FFICallbackState) =
-  state.lock.deinitLock()
-
-proc setCallback*(
-    state: var FFICallbackState, callback: pointer, userData: pointer
-) =
-  ## Locked writer used by the generated `_set_event_callback` proc.
-  withLock state.lock:
-    state.callback = callback
-    state.userData = userData
-
-proc snapshotCallback*(
-    state: var FFICallbackState
-): tuple[callback, userData: pointer] =
-  ## Locked reader: copies the (callback, userData) pair out as a single
-  ## consistent snapshot so dispatch code can invoke the callback without
-  ## holding the lock across user code.
-  withLock state.lock:
-    return (state.callback, state.userData)
+export ffi_events
 
 type FFIContext*[T] = object
   myLib*: ptr T
@@ -60,13 +27,10 @@ type FFIContext*[T] = object
     # this with a bounded timeout instead of joining unconditionally, so a
     # blocked event loop cannot hang the caller forever
   userData*: pointer
-  callbackState*: FFICallbackState
+  eventRegistry*: FFIEventRegistry
   running: Atomic[bool] # To control when the threads are running
   registeredRequests: ptr Table[cstring, FFIRequestProc]
     # Pointer to with the registered requests at compile time
-
-var ffiCurrentCallbackState* {.threadvar.}: ptr FFICallbackState
-  ## Set by ffiThreadBody at thread startup; read by dispatchFFIEvent.
 
 var onFFIThread* {.threadvar.}: bool
   ## True while executing inside `ffiThreadBody`. Used by
@@ -74,96 +38,6 @@ var onFFIThread* {.threadvar.}: bool
   ## (which would self-deadlock on `reqReceivedSignal`).
 
 const git_version* {.strdefine.} = "n/a"
-
-template callEventCallback*(ctx: ptr FFIContext, eventName: string, body: untyped) =
-  ## `body` may evaluate to a `string` or a `seq[byte]` — the cast to
-  ## `ptr cchar` accepts both `ptr char` and `ptr byte` source pointers.
-  let (cbPtr, ud) = snapshotCallback(ctx[].callbackState)
-  if isNil(cbPtr):
-    chronicles.error eventName & " - eventCallback is nil"
-    return
-
-  foreignThreadGc:
-    let cb = cast[FFICallBack](cbPtr)
-    try:
-      let event = body
-      cb(RET_OK, cast[ptr cchar](unsafeAddr event[0]), cast[csize_t](len(event)), ud)
-    except Exception, CatchableError:
-      let msg =
-        "Exception " & eventName & " when calling 'eventCallBack': " &
-        getCurrentExceptionMsg()
-      cb(RET_ERR, cast[ptr cchar](unsafeAddr msg[0]), cast[csize_t](len(msg)), ud)
-
-template dispatchFFIEvent*(eventName: string, body: untyped) =
-  ## Dispatches an FFI event to the callback registered via `{libName}_set_event_callback`.
-  ## `body` is evaluated lazily — only when a callback is registered.
-  ## `body` may produce a `string` (legacy JSON style) or a `seq[byte]` (CBOR).
-  ## Valid only on the FFI thread (i.e., inside {.ffi.} proc bodies and their async closures).
-  let ffiState = ffiCurrentCallbackState
-  if isNil(ffiState):
-    chronicles.error eventName & " - event callback not set"
-    return
-  let (cbPtr, ud) = snapshotCallback(ffiState[])
-  if isNil(cbPtr):
-    chronicles.error eventName & " - event callback not set"
-    return
-  foreignThreadGc:
-    let cb = cast[FFICallBack](cbPtr)
-    try:
-      let event = body
-      cb(RET_OK, cast[ptr cchar](unsafeAddr event[0]), cast[csize_t](len(event)), ud)
-    except Exception, CatchableError:
-      let msg = "Exception dispatching " & eventName & ": " & getCurrentExceptionMsg()
-      cb(RET_ERR, cast[ptr cchar](unsafeAddr msg[0]), cast[csize_t](len(msg)), ud)
-
-type EventEnvelope*[T] = object
-  ## Standard wire shape for CBOR-encoded FFI events:
-  ##   { eventType: tstr, payload: <T> }
-  ## Pair with `dispatchFFIEventCbor` (or call `cborEncode` directly).
-  eventType*: string
-  payload*: T
-
-template dispatchFFIEventCbor*(eventName: string, eventPayload: typed) =
-  ## Typed CBOR variant of `dispatchFFIEvent`. Wraps `eventPayload` in an
-  ## `EventEnvelope`, CBOR-encodes it into a `c_malloc` buffer, dispatches
-  ## the callback, then frees the buffer. The payload type should be a
-  ## `{.ffi.}`-annotated object so the binding generator emits a matching
-  ## codec.
-  ##
-  ## The buffer is `c_malloc`-backed (not Nim GC-owned) so the pointer
-  ## handed to the callback does not depend on the FFI thread's GC heap
-  ## remaining valid — matches the ownership story used by request payloads
-  ## (see `ffi_thread_request.nim`).
-  ##
-  ## NB: the template parameter is intentionally named `eventPayload`
-  ## rather than `payload` — Nim's template substitution would otherwise
-  ## also replace the `payload:` field name inside `EventEnvelope`.
-  let ffiState = ffiCurrentCallbackState
-  if ffiState.isNil():
-    chronicles.error eventName & " - event callback not set"
-    return
-  let (cbPtr, ud) = snapshotCallback(ffiState[])
-  if cbPtr.isNil():
-    chronicles.error eventName & " - event callback not set"
-    return
-  foreignThreadGc:
-    let cb = cast[FFICallBack](cbPtr)
-    try:
-      var (data, dataLen) = cborEncodeShared(
-        EventEnvelope[typeof(eventPayload)](eventType: eventName, payload: eventPayload)
-      )
-      defer:
-        cborFreeShared(data)
-      cb(RET_OK, cast[ptr cchar](data), cast[csize_t](dataLen), ud)
-    except Exception, CatchableError:
-      # Catching `Exception` also catches Defects (OOM, overflow, ...) so
-      # the C caller always gets RET_OK/RET_ERR. Requires `--panics:off`
-      # (Nim's default; don't enable `--panics:on` for this lib).
-
-      let msg = "Exception dispatching " & eventName & ": " & getCurrentExceptionMsg()
-      cb(
-        RET_ERR, cast[ptr cchar](unsafeAddr msg[0]), cast[csize_t](len(msg)), ud
-      )
 
 proc sendRequestToFFIThread*(
     ctx: ptr FFIContext, ffiRequest: ptr FFIThreadRequest, timeout = InfiniteDuration
@@ -227,8 +101,23 @@ proc `$`(event: JsonNotRespondingEvent): string =
   $(%*event)
 
 proc onNotResponding*(ctx: ptr FFIContext) =
-  callEventCallback(ctx, "onNotResponding"):
-    $JsonNotRespondingEvent.init()
+  ## Phase-1 shim: still emits the legacy JSON payload through the registry.
+  ## Phase 3 replaces this with a CBOR `NotRespondingEvent` dispatched
+  ## through the same registry under the reserved `__not_responding__`
+  ## wire name.
+  let snap = snapshotListeners(ctx[].eventRegistry, "onNotResponding")
+  if snap.len == 0:
+    chronicles.error "onNotResponding - no listener registered"
+    return
+  foreignThreadGc:
+    let event = $JsonNotRespondingEvent.init()
+    for listener in snap:
+      listener.callback(
+        RET_OK,
+        cast[ptr cchar](unsafeAddr event[0]),
+        cast[csize_t](len(event)),
+        listener.userData,
+      )
 
 proc watchdogThreadBody(ctx: ptr FFIContext) {.thread.} =
   ## Watchdog thread that monitors the FFI thread and notifies the library user if it hangs.
@@ -314,7 +203,7 @@ proc processRequest[T](
 
 proc ffiThreadBody[T](ctx: ptr FFIContext[T]) {.thread.} =
   ## FFI thread body that attends library user API requests
-  ffiCurrentCallbackState = addr ctx[].callbackState
+  ffiCurrentEventRegistry = addr ctx[].eventRegistry
   onFFIThread = true
 
   logging.setupLog(logging.LogLevel.DEBUG, logging.LogFormat.TEXT)
@@ -387,7 +276,7 @@ proc cleanUpResources[T](ctx: ptr FFIContext[T]): Result[void, string] =
   defer:
     freeShared(ctx)
   ctx.lock.deinitLock()
-  deinitCallbackState(ctx[].callbackState)
+  deinitEventRegistry(ctx[].eventRegistry)
   when defined(gcRefc):
     ## ThreadSignalPtr.close() is intentionally skipped under --mm:refc.
     ##
@@ -425,7 +314,7 @@ proc initContextResources*[T](ctx: ptr FFIContext[T]): Result[void, string] =
   ## On failure every partially-initialised resource is closed; the caller
   ## is responsible for releasing the slot (freeShared or pool.releaseSlot).
   ctx.lock.initLock()
-  initCallbackState(ctx[].callbackState)
+  initEventRegistry(ctx[].eventRegistry)
 
   var success = false
   defer:

--- a/ffi/ffi_events.nim
+++ b/ffi/ffi_events.nim
@@ -1,0 +1,246 @@
+## Event registry and dispatch primitives for FFI library-initiated events.
+##
+## This module owns two concerns so they can evolve together without dragging
+## in the rest of `FFIContext`:
+##
+## 1. A multi-listener registry. Each event name maps to a `seq` of listeners;
+##    the empty event name `""` is the wildcard channel and receives every
+##    dispatched event in addition to its own per-name subscribers.
+## 2. The dispatch templates (`dispatchFFIEvent`, `dispatchFFIEventCbor`) used
+##    by `{.ffiEvent.}`-generated procs. They snapshot the registry under its
+##    lock, then invoke each listener *outside* the lock so re-entrant
+##    add/remove from within a handler cannot self-deadlock.
+##
+## Phase 1 keeps dispatch synchronous on the FFI thread. A later phase will
+## route events through a bounded queue to a dedicated event thread; the
+## registry API does not change.
+
+{.pragma: callback, cdecl, raises: [], gcsafe.}
+
+import std/[locks, tables]
+import chronicles
+import ./ffi_types, ./cbor_serial
+
+# ---------------------------------------------------------------------------
+# Wire envelope
+# ---------------------------------------------------------------------------
+
+type EventEnvelope*[T] = object
+  ## Standard wire shape for CBOR-encoded FFI events:
+  ##   { eventType: tstr, payload: <T> }
+  ## Pair with `dispatchFFIEventCbor` (or call `cborEncode` directly).
+  eventType*: string
+  payload*: T
+
+# ---------------------------------------------------------------------------
+# Registry types
+# ---------------------------------------------------------------------------
+
+type
+  FFIEventListener* = object
+    id*: uint64
+    callback*: FFICallBack
+    userData*: pointer
+
+  FFIEventRegistry* = object
+    ## Per-context multi-listener registry. `lock` guards every mutation;
+    ## readers (dispatch path) acquire it only long enough to copy out the
+    ## listener slice for the event being dispatched.
+    lock*: Lock
+    nextId*: uint64
+      ## Monotonic id source. 0 is reserved as "invalid"; ids start at 1.
+    byEvent*: Table[string, seq[FFIEventListener]]
+    wildcard*: seq[FFIEventListener]
+
+const WildcardEventName* = ""
+  ## Empty string registers a wildcard listener that receives every event.
+
+# ---------------------------------------------------------------------------
+# Registry lifecycle and mutation
+# ---------------------------------------------------------------------------
+
+proc initEventRegistry*(reg: var FFIEventRegistry) =
+  reg.lock.initLock()
+  reg.nextId = 0'u64
+  reg.byEvent = initTable[string, seq[FFIEventListener]]()
+  reg.wildcard.setLen(0)
+
+proc deinitEventRegistry*(reg: var FFIEventRegistry) =
+  reg.lock.deinitLock()
+  reg.byEvent.clear()
+  reg.wildcard.setLen(0)
+
+proc addEventListener*(
+    reg: var FFIEventRegistry,
+    eventName: string,
+    callback: FFICallBack,
+    userData: pointer,
+): uint64 {.raises: [].} =
+  ## Registers `callback` for `eventName` and returns the listener's stable
+  ## id (always non-zero on success). `eventName == ""` registers a wildcard
+  ## listener that receives every dispatched event. Returns 0 if `callback`
+  ## is nil — the only documented failure mode.
+  var assigned: uint64 = 0
+  if callback.isNil():
+    return assigned
+
+  withLock reg.lock:
+    reg.nextId += 1
+    assigned = reg.nextId
+    let listener =
+      FFIEventListener(id: assigned, callback: callback, userData: userData)
+    if eventName.len == 0:
+      reg.wildcard.add(listener)
+    else:
+      # `mgetOrPut` lets us avoid a `[]` lookup that the effect tracker
+      # would otherwise see as raising `KeyError`.
+      reg.byEvent.mgetOrPut(eventName, @[]).add(listener)
+  return assigned
+
+proc removeEventListener*(reg: var FFIEventRegistry, id: uint64): bool {.raises: [].} =
+  ## Removes the listener with `id`. Returns true on success, false if no
+  ## listener with that id exists. Safe to call from inside a dispatch:
+  ## the in-flight snapshot still delivers exactly once to the listener
+  ## being removed.
+  var removed = false
+  if id == 0'u64:
+    return removed
+
+  withLock reg.lock:
+    for i in 0 ..< reg.wildcard.len:
+      if reg.wildcard[i].id == id:
+        reg.wildcard.delete(i)
+        removed = true
+        break
+    if not removed:
+      for listeners in reg.byEvent.mvalues:
+        var idx = -1
+        for i in 0 ..< listeners.len:
+          if listeners[i].id == id:
+            idx = i
+            break
+        if idx >= 0:
+          listeners.delete(idx)
+          removed = true
+          break
+  return removed
+
+proc removeAllEventListeners*(reg: var FFIEventRegistry) {.raises: [].} =
+  ## Drops every registered listener (per-event and wildcard). Does not
+  ## reset the listener-id counter — subsequent `addEventListener` calls
+  ## still return strictly increasing ids.
+  withLock reg.lock:
+    reg.wildcard.setLen(0)
+    reg.byEvent.clear()
+
+proc snapshotListeners*(
+    reg: var FFIEventRegistry, eventName: string
+): seq[FFIEventListener] {.raises: [].} =
+  ## Returns a copy of the listener slice for `eventName`, plus every
+  ## wildcard listener. The copy is what makes re-entrant add/remove from
+  ## inside a handler deadlock-free: dispatch holds the lock only for the
+  ## duration of the copy, then iterates the copy outside the lock.
+  var snap: seq[FFIEventListener] = @[]
+  withLock reg.lock:
+    if eventName.len > 0:
+      # `getOrDefault` returns an empty seq when the key is absent —
+      # avoids the raising `[]` operator path.
+      for l in reg.byEvent.getOrDefault(eventName):
+        snap.add(l)
+    for l in reg.wildcard:
+      snap.add(l)
+  return snap
+
+# ---------------------------------------------------------------------------
+# Dispatch templates (used by {.ffiEvent.}-generated procs)
+# ---------------------------------------------------------------------------
+
+var ffiCurrentEventRegistry* {.threadvar.}: ptr FFIEventRegistry
+  ## Set by the FFI thread at startup so dispatchFFIEvent / dispatchFFIEventCbor
+  ## can find their registry without taking a context pointer per call site.
+
+template dispatchFFIEvent*(eventName: string, body: untyped) =
+  ## Dispatches an FFI event to every listener for `eventName` plus every
+  ## wildcard listener. `body` may produce a `string` or a `seq[byte]` —
+  ## the cast to `ptr cchar` accepts both `ptr char` and `ptr byte`.
+  ##
+  ## Valid only on the FFI thread (i.e., inside {.ffi.} proc bodies and
+  ## their async closures, where `ffiCurrentEventRegistry` is set).
+  let regPtr = ffiCurrentEventRegistry
+  if regPtr.isNil():
+    chronicles.error eventName & " - event registry not set on this thread"
+  else:
+    let snap = snapshotListeners(regPtr[], eventName)
+    if snap.len == 0:
+      # Not an error: foreign-side code may legitimately not subscribe to
+      # every event the lib emits. Log at debug for diagnostics only.
+      chronicles.debug eventName & " - no listener registered"
+    else:
+      foreignThreadGc:
+        try:
+          let event = body
+          for listener in snap:
+            listener.callback(
+              RET_OK,
+              cast[ptr cchar](unsafeAddr event[0]),
+              cast[csize_t](len(event)),
+              listener.userData,
+            )
+        except Exception, CatchableError:
+          let msg =
+            "Exception dispatching " & eventName & ": " & getCurrentExceptionMsg()
+          for listener in snap:
+            listener.callback(
+              RET_ERR,
+              cast[ptr cchar](unsafeAddr msg[0]),
+              cast[csize_t](len(msg)),
+              listener.userData,
+            )
+
+template dispatchFFIEventCbor*(eventName: string, eventPayload: typed) =
+  ## Typed CBOR variant of `dispatchFFIEvent`. Wraps `eventPayload` in an
+  ## `EventEnvelope`, CBOR-encodes it into a `c_malloc` buffer once, and
+  ## fans the same buffer out to every registered listener.
+  ##
+  ## NB: the template parameter is intentionally named `eventPayload`
+  ## rather than `payload` — Nim's template substitution would otherwise
+  ## also replace the `payload:` field name inside `EventEnvelope`.
+  let regPtr = ffiCurrentEventRegistry
+  if regPtr.isNil():
+    chronicles.error eventName & " - event registry not set on this thread"
+  else:
+    let snap = snapshotListeners(regPtr[], eventName)
+    if snap.len == 0:
+      # Not an error: foreign-side code may legitimately not subscribe to
+      # every event the lib emits. Log at debug for diagnostics only.
+      chronicles.debug eventName & " - no listener registered"
+    else:
+      foreignThreadGc:
+        try:
+          var (data, dataLen) = cborEncodeShared(
+            EventEnvelope[typeof(eventPayload)](
+              eventType: eventName, payload: eventPayload
+            )
+          )
+          defer:
+            cborFreeShared(data)
+          for listener in snap:
+            listener.callback(
+              RET_OK,
+              cast[ptr cchar](data),
+              cast[csize_t](dataLen),
+              listener.userData,
+            )
+        except Exception, CatchableError:
+          # Catching `Exception` also catches Defects (OOM, overflow, ...) so
+          # the C caller always gets RET_OK / RET_ERR. Requires `--panics:off`
+          # (Nim's default; don't enable `--panics:on` for this lib).
+          let msg =
+            "Exception dispatching " & eventName & ": " & getCurrentExceptionMsg()
+          for listener in snap:
+            listener.callback(
+              RET_ERR,
+              cast[ptr cchar](unsafeAddr msg[0]),
+              cast[csize_t](len(msg)),
+              listener.userData,
+            )

--- a/ffi/internal/ffi_library.nim
+++ b/ffi/internal/ffi_library.nim
@@ -92,47 +92,85 @@ macro declareLibraryBase*(libraryName: static[string]): untyped =
   return res
 
 macro declareLibrary*(libraryName: static[string], libType: untyped): untyped =
-  ## Declares a library with the given name and automatically generates
-  ## `{libraryName}_set_event_callback`, a C-exported function that stores the
-  ## caller's event callback on the FFIContext.
+  ## Declares a library with the given name and emits the C-exported event
+  ## ABI on its `FFIContext`:
   ##
-  ## `libType` is the Nim type of the main library object (e.g. `Waku`). It is used
-  ## to type the `ctx: ptr FFIContext[libType]` parameter of the generated
-  ## `{libraryName}_set_event_callback` proc.
+  ## - `{libraryName}_add_event_listener(ctx, event_name, cb, ud) -> uint64`
+  ##   — registers `cb` for `event_name` and returns its stable id. An
+  ##   empty `event_name` subscribes `cb` to *every* event (catch-all).
+  ## - `{libraryName}_remove_event_listener(ctx, id) -> cint` — returns 0 on
+  ##   success, non-zero if no listener with that id exists.
+  ##
+  ## `libType` is the Nim type of the main library object, used to type
+  ## the `ctx: ptr FFIContext[libType]` parameter. See
+  ## `examples/timer/timer.nim` for a working call site.
   var stmts = newStmtList()
 
   # Emit the base bootstrap (pragmas, linker flags, NimMain, initializeLibrary)
   stmts.add(newCall(ident("declareLibraryBase"), newStrLitNode(libraryName)))
 
-  let funcName = libraryName & "_set_event_callback"
-  let funcIdent = ident(funcName)
-  let errorMsg = "error: invalid context in " & funcName
-
   let ctxType = nnkPtrTy.newTree(nnkBracketExpr.newTree(ident("FFIContext"), libType))
-
-  let procBody = quote:
-    if isNil(ctx):
-      echo `errorMsg`
-      return
-    setCallback(ctx[].callbackState, cast[pointer](callback), userData)
-
-  let procNode = newProc(
-    name = funcIdent,
-    params = @[
-      newEmptyNode(),
-      newIdentDefs(ident("ctx"), ctxType),
-      newIdentDefs(ident("callback"), ident("FFICallBack")),
-      newIdentDefs(ident("userData"), ident("pointer")),
-    ],
-    body = procBody,
-    pragmas = newTree(
-      nnkPragma,
-      ident("dynlib"),
-      ident("exportc"),
-      ident("cdecl"),
-      newTree(nnkExprColonExpr, ident("raises"), newTree(nnkBracket)),
-    ),
+  let cdeclExportPragma = newTree(
+    nnkPragma,
+    ident("dynlib"),
+    ident("exportc"),
+    ident("cdecl"),
+    newTree(nnkExprColonExpr, ident("raises"), newTree(nnkBracket)),
   )
 
-  stmts.add(procNode)
+  # {libraryName}_add_event_listener
+  let addName = libraryName & "_add_event_listener"
+  let addErr = "error: invalid context in " & addName
+  let addBody = quote:
+    var ret: uint64 = 0
+    if isNil(ctx):
+      echo `addErr`
+      return ret
+    let evtName = if eventName.isNil(): "" else: $eventName
+    ret = addEventListener(ctx[].eventRegistry, evtName, callback, userData)
+    return ret
+
+  stmts.add(
+    newProc(
+      name = ident(addName),
+      params = @[
+        ident("uint64"),
+        newIdentDefs(ident("ctx"), ctxType),
+        newIdentDefs(ident("eventName"), ident("cstring")),
+        newIdentDefs(ident("callback"), ident("FFICallBack")),
+        newIdentDefs(ident("userData"), ident("pointer")),
+      ],
+      body = addBody,
+      pragmas = cdeclExportPragma,
+    )
+  )
+
+  # --- {libraryName}_remove_event_listener --------------------------------
+  # Param is `listenerId`, not `id` — `id` collides with chronos's
+  # `futures.id` template under quote injection rules and the captured
+  # symbol wins over the injected one.
+  let removeName = libraryName & "_remove_event_listener"
+  let removeErr = "error: invalid context in " & removeName
+  let removeBody = quote:
+    var ret: cint = 1
+    if isNil(ctx):
+      echo `removeErr`
+      return ret
+    if removeEventListener(ctx[].eventRegistry, listenerId):
+      ret = 0
+    return ret
+
+  stmts.add(
+    newProc(
+      name = ident(removeName),
+      params = @[
+        ident("cint"),
+        newIdentDefs(ident("ctx"), ctxType),
+        newIdentDefs(ident("listenerId"), ident("uint64")),
+      ],
+      body = removeBody,
+      pragmas = cdeclExportPragma,
+    )
+  )
+
   return stmts

--- a/tests/e2e/cpp/test_timer_e2e.cpp
+++ b/tests/e2e/cpp/test_timer_e2e.cpp
@@ -165,22 +165,21 @@ TEST(TimerE2E, ThreadedHammer) {
     EXPECT_EQ(errors.load(), 0);
 }
 
-// Library-initiated events flow through the typed `MyTimerCtx::Events`
-// dispatcher: setting `onEchoFired` registers a CBOR-decoding trampoline
-// inside the context, and every successful `echo()` triggers it. The
-// promise here is fulfilled from the FFI thread; we wait synchronously
-// for it before destroying the context (the dtor tears down the FFI
-// thread and any further events).
+// Library-initiated events flow through `MyTimerCtx::addOnEchoFiredListener`:
+// the listener registers a CBOR-decoding trampoline inside the lib's
+// registry, and every successful `echo()` triggers it. The promise here
+// is fulfilled from the FFI thread; we wait synchronously for it before
+// destroying the context (the dtor tears down the FFI thread and any
+// further events).
 TEST(TimerE2E, TypedEventFiresAfterEcho) {
     auto ctx = makeCtx("events");
 
     std::promise<EchoEvent> evtPromise;
     auto evtFuture = evtPromise.get_future();
 
-    ctx->setEventHandlers({
-        .on_error = nullptr,
-        .onEchoFired = [&](const EchoEvent& evt) { evtPromise.set_value(evt); },
-    });
+    const auto handle = ctx->addOnEchoFiredListener(
+        [&](const EchoEvent& evt) { evtPromise.set_value(evt); });
+    ASSERT_NE(handle.id, 0u) << "addOnEchoFiredListener returned zero id";
 
     const auto resp = ctx->echo(EchoRequest{"event-msg", 1});
     EXPECT_EQ(resp.echoed, "event-msg");
@@ -191,4 +190,111 @@ TEST(TimerE2E, TypedEventFiresAfterEcho) {
     const auto evt = evtFuture.get();
     EXPECT_EQ(evt.message, "event-msg");
     EXPECT_EQ(evt.echoCount, 1);
+}
+
+// Multiple listeners on the same event each fire exactly once per emit.
+TEST(TimerE2E, MultipleTypedListenersAllFire) {
+    auto ctx = makeCtx("multi-listeners");
+
+    std::promise<EchoEvent> firstPromise;
+    std::promise<EchoEvent> secondPromise;
+    auto firstFuture = firstPromise.get_future();
+    auto secondFuture = secondPromise.get_future();
+
+    ctx->addOnEchoFiredListener(
+        [&](const EchoEvent& evt) { firstPromise.set_value(evt); });
+    ctx->addOnEchoFiredListener(
+        [&](const EchoEvent& evt) { secondPromise.set_value(evt); });
+
+    ctx->echo(EchoRequest{"fan-out", 1});
+
+    ASSERT_EQ(firstFuture.wait_for(std::chrono::seconds(2)), std::future_status::ready);
+    ASSERT_EQ(secondFuture.wait_for(std::chrono::seconds(2)), std::future_status::ready);
+    EXPECT_EQ(firstFuture.get().message, "fan-out");
+    EXPECT_EQ(secondFuture.get().message, "fan-out");
+}
+
+// Removing a listener stops it from firing on subsequent events while the
+// other listener keeps receiving them.
+TEST(TimerE2E, RemoveEventListenerStopsDelivery) {
+    auto ctx = makeCtx("remove-listener");
+
+    std::atomic<int> removedHits{0};
+    std::atomic<int> keptHits{0};
+
+    const auto removedHandle = ctx->addOnEchoFiredListener(
+        [&](const EchoEvent&) { removedHits.fetch_add(1); });
+    ctx->addOnEchoFiredListener(
+        [&](const EchoEvent&) { keptHits.fetch_add(1); });
+
+    ctx->echo(EchoRequest{"before-remove", 1});
+
+    // Give the FFI thread a beat to deliver the first event to both
+    // listeners before we yank one of them out.
+    for (int i = 0; i < 200 && (removedHits.load() == 0 || keptHits.load() == 0); ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    ASSERT_EQ(removedHits.load(), 1);
+    ASSERT_EQ(keptHits.load(), 1);
+
+    EXPECT_TRUE(ctx->removeEventListener(removedHandle));
+    EXPECT_FALSE(ctx->removeEventListener(removedHandle)) << "double remove must report false";
+
+    ctx->echo(EchoRequest{"after-remove", 1});
+
+    for (int i = 0; i < 200 && keptHits.load() < 2; ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    EXPECT_EQ(keptHits.load(), 2);
+    EXPECT_EQ(removedHits.load(), 1) << "removed listener fired after removeEventListener";
+}
+
+// The wildcard `addEventListener` overload receives every event with the
+// wire `eventId` pre-extracted plus the raw envelope bytes. The helper
+// `decodeEventPayload<T>` lifts the payload into a typed value.
+TEST(TimerE2E, WildcardListenerReceivesEventIdAndDecodesPayload) {
+    auto ctx = makeCtx("wildcard");
+
+    struct Capture {
+        int retCode;
+        std::string eventId;
+        std::size_t envelopeBytes;
+        std::optional<EchoEvent> decoded;
+    };
+
+    std::mutex mu;
+    std::vector<Capture> captured;
+    auto handle = ctx->addEventListener(
+        [&](int retCode, const std::string& eventId,
+            const std::vector<std::uint8_t>& envelope) {
+            Capture c{retCode, eventId, envelope.size(), std::nullopt};
+            if (retCode == 0 && eventId == "on_echo_fired") {
+                EchoEvent evt{};
+                if (decodeEventPayload(envelope, evt)) {
+                    c.decoded = evt;
+                }
+            }
+            std::lock_guard<std::mutex> lock(mu);
+            captured.push_back(std::move(c));
+        });
+    ASSERT_NE(handle.id, 0u);
+
+    ctx->echo(EchoRequest{"hello", 1});
+
+    for (int i = 0; i < 200; ++i) {
+        {
+            std::lock_guard<std::mutex> lock(mu);
+            if (!captured.empty()) break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+
+    std::lock_guard<std::mutex> lock(mu);
+    ASSERT_GE(captured.size(), 1u);
+    EXPECT_EQ(captured.front().retCode, 0);
+    EXPECT_EQ(captured.front().eventId, "on_echo_fired");
+    EXPECT_GT(captured.front().envelopeBytes, 0u);
+    ASSERT_TRUE(captured.front().decoded.has_value());
+    EXPECT_EQ(captured.front().decoded->message, "hello");
+    EXPECT_EQ(captured.front().decoded->echoCount, 1);
 }

--- a/tests/unit/test_event_dispatch.nim
+++ b/tests/unit/test_event_dispatch.nim
@@ -5,7 +5,7 @@
 ##
 ## Tests run end-to-end against a real FFI thread (via FFIContextPool +
 ## sendRequestToFFIThread) so we exercise the threadvar-backed
-## ffiCurrentCallbackState wiring, not just the templates in isolation.
+## ffiCurrentEventRegistry wiring, not just the templates in isolation.
 
 import std/[locks]
 import unittest2
@@ -85,10 +85,11 @@ registerReqFFI(EmitRawBytesEventRequest, lib: ptr TestEvtLib):
       @[byte 0x01, 0x02, 0x03]
     return ok("emitted")
 
-## Setter-thread worker for the FFICallbackState race regression test.
-## Hammers `setCallback` so a TSan-instrumented build can confirm
-## `FFICallbackState.lock` actually serialises the cross-thread mutation
-## against `snapshotCallback` reads from the FFI thread.
+## Setter-thread worker for the registry race regression test.
+## Each iteration adds then immediately removes a wildcard listener so a
+## TSan-instrumented build can confirm `FFIEventRegistry.lock` serialises
+## the cross-thread mutation against dispatch-time `snapshotListeners`
+## reads from the FFI thread.
 type SetterArgs = tuple
   ctx: ptr FFIContext[TestEvtLib]
   stop: ptr Atomic[bool]
@@ -96,7 +97,10 @@ type SetterArgs = tuple
 
 proc setterThreadBody(args: SetterArgs) {.thread.} =
   while not args.stop[].load():
-    setCallback(args.ctx[].callbackState, cast[pointer](captureCb), args.target)
+    let id = addEventListener(
+      args.ctx[].eventRegistry, WildcardEventName, captureCb, args.target
+    )
+    discard removeEventListener(args.ctx[].eventRegistry, id)
 
 suite "dispatchFFIEventCbor":
   test "delivers EventEnvelope-shaped CBOR payload to event callback":
@@ -112,9 +116,10 @@ suite "dispatchFFIEventCbor":
     defer:
       deinitCallbackData(evt)
 
-    # Register the event callback via the same locked helper that the
-    # codegen-emitted `{libname}_set_event_callback` uses.
-    setCallback(ctx[].callbackState, cast[pointer](captureCb), addr evt)
+    # Register the event callback through the multi-listener registry.
+    discard addEventListener(
+      ctx[].eventRegistry, WildcardEventName, captureCb, addr evt
+    )
 
     # Trigger the dispatch from the FFI thread; the response callback is
     # ignored (we only care that the request completed so we know the event
@@ -152,7 +157,9 @@ suite "dispatchFFIEvent with seq[byte]":
     defer:
       deinitCallbackData(evt)
 
-    setCallback(ctx[].callbackState, cast[pointer](captureCb), addr evt)
+    discard addEventListener(
+      ctx[].eventRegistry, WildcardEventName, captureCb, addr evt
+    )
 
     var rsp: CallbackData
     initCallbackData(rsp)
@@ -169,72 +176,85 @@ suite "dispatchFFIEvent with seq[byte]":
     check evt.retCode == RET_OK
     check callbackBytes(evt) == @[byte 0x01, 0x02, 0x03]
 
-suite "FFICallbackState concurrent access":
-  ## Regression test for PR #39 review comment r3288220895 / r3289285387:
-  ## `{lib}_set_event_callback` writes `callbackState.callback / .userData`
-  ## from foreign caller threads while the FFI thread reads them on every
-  ## dispatch. Without `FFICallbackState.lock` this is a data race.
-  ##
-  ## IMPORTANT: run this under ThreadSanitizer to actually validate the
-  ## fix:
-  ##
-  ##   NIM_FFI_SAN=tsan NIM_FFI_MM=orc nimble test_sanitized
-  ##
-  ## A regular build will silently pass either way — the racing reads and
-  ## writes are pointer-aligned, so on x86/arm64 they don't tear visibly
-  ## and the loop completes. Only tsan inspects the memory model and
-  ## flags the missing happens-before edge if the lock is removed.
-  ## Treat a clean tsan run on this test as the load-bearing signal.
-  test "concurrent setCallback writers vs dispatch reads stay race-free":
-    var pool: FFIContextPool[TestEvtLib]
-    let ctx = pool.createFFIContext().valueOr:
-      check false
-      return
-    defer:
-      discard pool.destroyFFIContext(ctx)
+when not defined(gcRefc):
+  ## Skipped under `--mm:refc`: each setter thread grows / shrinks
+  ## `reg.wildcard` (a `seq[FFIEventListener]`) via `addEventListener`,
+  ## and refc's per-thread GC heap ownership makes cross-thread seq
+  ## buffer reallocation unsafe even when the surrounding lock is held —
+  ## a buffer allocated by one thread can end up freed by another. ORC
+  ## (and the FFI thread + tsan combo this test was written for) does
+  ## not have that limitation. Production foreign-side code typically
+  ## registers listeners from a single thread, which is safe under both
+  ## memory managers; this test is the stress case that isn't.
+  suite "FFIEventRegistry concurrent access":
+    ## Regression test for PR #39 review comment r3288220895 / r3289285387:
+    ## foreign caller threads mutate the registry's wildcard list while
+    ## the FFI thread reads it on every dispatch. Without
+    ## `FFIEventRegistry.lock` this is a data race.
+    ##
+    ## IMPORTANT: run this under ThreadSanitizer to actually validate the
+    ## fix:
+    ##
+    ##   NIM_FFI_SAN=tsan NIM_FFI_MM=orc nimble test_sanitized
+    ##
+    ## A regular build will silently pass either way — the racing reads
+    ## and writes are pointer-aligned, so on x86/arm64 they don't tear
+    ## visibly and the loop completes. Only tsan inspects the memory
+    ## model and flags the missing happens-before edge if the lock is
+    ## removed. Treat a clean tsan run on this test as the load-bearing
+    ## signal.
+    test "concurrent add/remove writers vs dispatch reads stay race-free":
+      var pool: FFIContextPool[TestEvtLib]
+      let ctx = pool.createFFIContext().valueOr:
+        check false
+        return
+      defer:
+        discard pool.destroyFFIContext(ctx)
 
-    var evt: CallbackData
-    initCallbackData(evt)
-    defer:
-      deinitCallbackData(evt)
+      var evt: CallbackData
+      initCallbackData(evt)
+      defer:
+        deinitCallbackData(evt)
 
-    # Seed an initial callback so the FFI thread's first dispatch has a
-    # target. The setter threads will then repeatedly re-install the same
-    # (callback, userData) pair — what matters is the cross-thread write
-    # racing the FFI thread's read, not which pair "wins".
-    setCallback(ctx[].callbackState, cast[pointer](captureCb), addr evt)
-
-    const NumSetterThreads = 4
-    const NumDispatchIters = 200
-
-    var stop: Atomic[bool]
-    stop.store(false)
-    var setters: array[NumSetterThreads, Thread[SetterArgs]]
-    for i in 0 ..< NumSetterThreads:
-      createThread(setters[i], setterThreadBody, (ctx, addr stop, addr evt))
-
-    var rsp: CallbackData
-    initCallbackData(rsp)
-    defer:
-      deinitCallbackData(rsp)
-
-    for _ in 0 ..< NumDispatchIters:
-      # Reset rsp so each iteration's `waitCallback` blocks until the
-      # FFI thread fires the response — keeps the loop synchronous.
-      acquire(rsp.lock)
-      rsp.called = false
-      release(rsp.lock)
-
-      check sendRequestToFFIThread(
-        ctx, EmitCborEventRequest.ffiNewReq(captureCb, addr rsp)
+      # Seed an initial listener so the FFI thread's first dispatch has a
+      # target. The setter threads will then repeatedly add/remove their
+      # own listeners — what matters is the cross-thread mutation racing
+      # the FFI thread's read.
+      discard addEventListener(
+        ctx[].eventRegistry, WildcardEventName, captureCb, addr evt
       )
-        .isOk()
-      waitCallback(rsp)
 
-    stop.store(true)
-    for i in 0 ..< NumSetterThreads:
-      joinThread(setters[i])
+      const NumSetterThreads = 4
+      const NumDispatchIters = 200
 
-    # `evt` got hit by every dispatch above; just confirm at least one
-    # actually landed so a silently-broken dispatch loop is caught.
-    check evt.called
+      var stop: Atomic[bool]
+      stop.store(false)
+      var setters: array[NumSetterThreads, Thread[SetterArgs]]
+      for i in 0 ..< NumSetterThreads:
+        createThread(setters[i], setterThreadBody, (ctx, addr stop, addr evt))
+
+      var rsp: CallbackData
+      initCallbackData(rsp)
+      defer:
+        deinitCallbackData(rsp)
+
+      for _ in 0 ..< NumDispatchIters:
+        # Reset rsp so each iteration's `waitCallback` blocks until the
+        # FFI thread fires the response — keeps the loop synchronous.
+        acquire(rsp.lock)
+        rsp.called = false
+        release(rsp.lock)
+
+        check sendRequestToFFIThread(
+          ctx, EmitCborEventRequest.ffiNewReq(captureCb, addr rsp)
+        )
+          .isOk()
+        waitCallback(rsp)
+
+      stop.store(true)
+      for i in 0 ..< NumSetterThreads:
+        joinThread(setters[i])
+
+      # `evt` got hit by every dispatch above; just confirm at least one
+      # actually landed so a silently-broken dispatch loop is caught.
+      check evt.called

--- a/tests/unit/test_event_listener.nim
+++ b/tests/unit/test_event_listener.nim
@@ -1,0 +1,369 @@
+## Phase 1 unit tests for `FFIEventRegistry` — the multi-listener primitive
+## that backs `<lib>_add_event_listener` / `<lib>_remove_event_listener`.
+##
+## These tests exercise the registry directly (no FFI thread) so they stay
+## fast and isolate the registry semantics from the dispatch wiring. The
+## existing `test_event_dispatch.nim` covers the end-to-end FFI-thread path.
+
+import std/[atomics, locks]
+import unittest2
+import ffi
+
+# ---------------------------------------------------------------------------
+# Tiny helpers — a thread-safe sink each listener writes into so we can
+# assert which callbacks fired and in what order.
+# ---------------------------------------------------------------------------
+
+type Recorder = object
+  lock: Lock
+  hits: seq[string] # tag captured from `userData` per invocation
+  retCodes: seq[cint]
+  payloads: seq[string]
+
+proc initRecorder(r: var Recorder) =
+  r.lock.initLock()
+
+proc deinitRecorder(r: var Recorder) =
+  r.lock.deinitLock()
+
+proc record(r: var Recorder, tag: string, retCode: cint, payload: string) =
+  acquire(r.lock)
+  r.hits.add(tag)
+  r.retCodes.add(retCode)
+  r.payloads.add(payload)
+  release(r.lock)
+
+# Each listener is identified by a `Tag` passed through `userData`.
+type Tag = object
+  name: string
+  rec: ptr Recorder
+
+proc tagCb(
+    retCode: cint, msg: ptr cchar, len: csize_t, userData: pointer
+) {.cdecl, gcsafe, raises: [].} =
+  let t = cast[ptr Tag](userData)
+  var payload = newString(int(len))
+  if len > 0 and not msg.isNil:
+    copyMem(addr payload[0], msg, int(len))
+  record(t[].rec[], t[].name, retCode, payload)
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+suite "FFIEventRegistry mutation":
+  test "addEventListener assigns monotonically increasing non-zero ids":
+    var reg: FFIEventRegistry
+    initEventRegistry(reg)
+    defer:
+      deinitEventRegistry(reg)
+    var rec: Recorder
+    initRecorder(rec)
+    defer:
+      deinitRecorder(rec)
+    var t = Tag(name: "a", rec: addr rec)
+
+    let id1 = addEventListener(reg, "evt", tagCb, addr t)
+    let id2 = addEventListener(reg, "evt", tagCb, addr t)
+    let id3 = addEventListener(reg, "", tagCb, addr t)
+    check id1 == 1'u64
+    check id2 == 2'u64
+    check id3 == 3'u64
+
+  test "addEventListener returns 0 when callback is nil":
+    var reg: FFIEventRegistry
+    initEventRegistry(reg)
+    defer:
+      deinitEventRegistry(reg)
+    let id = addEventListener(reg, "evt", nil, nil)
+    check id == 0'u64
+
+  test "removeEventListener returns false for unknown ids":
+    var reg: FFIEventRegistry
+    initEventRegistry(reg)
+    defer:
+      deinitEventRegistry(reg)
+    check not removeEventListener(reg, 0'u64)
+    check not removeEventListener(reg, 99'u64)
+
+  test "removeEventListener removes from per-event seq and wildcard":
+    var reg: FFIEventRegistry
+    initEventRegistry(reg)
+    defer:
+      deinitEventRegistry(reg)
+    var rec: Recorder
+    initRecorder(rec)
+    defer:
+      deinitRecorder(rec)
+    var t = Tag(name: "a", rec: addr rec)
+
+    let id1 = addEventListener(reg, "evt", tagCb, addr t)
+    let id2 = addEventListener(reg, "", tagCb, addr t)
+
+    check removeEventListener(reg, id1)
+    check removeEventListener(reg, id2)
+    # Second remove of the same id is a no-op.
+    check not removeEventListener(reg, id1)
+
+    let snap = snapshotListeners(reg, "evt")
+    check snap.len == 0
+
+suite "FFIEventRegistry snapshot semantics":
+  test "snapshot includes both per-event listeners and wildcards":
+    var reg: FFIEventRegistry
+    initEventRegistry(reg)
+    defer:
+      deinitEventRegistry(reg)
+    var rec: Recorder
+    initRecorder(rec)
+    defer:
+      deinitRecorder(rec)
+    var a = Tag(name: "a", rec: addr rec)
+    var b = Tag(name: "b", rec: addr rec)
+    var c = Tag(name: "c", rec: addr rec)
+
+    discard addEventListener(reg, "evt", tagCb, addr a)
+    discard addEventListener(reg, "other", tagCb, addr b)
+    discard addEventListener(reg, "", tagCb, addr c)
+
+    let snapEvt = snapshotListeners(reg, "evt")
+    check snapEvt.len == 2 # listener for "evt" + wildcard
+
+    let snapOther = snapshotListeners(reg, "other")
+    check snapOther.len == 2 # listener for "other" + wildcard
+
+    let snapUnknown = snapshotListeners(reg, "no-subscriber")
+    check snapUnknown.len == 1 # only the wildcard
+
+  test "snapshot is a copy: post-snapshot mutation does not affect it":
+    var reg: FFIEventRegistry
+    initEventRegistry(reg)
+    defer:
+      deinitEventRegistry(reg)
+    var rec: Recorder
+    initRecorder(rec)
+    defer:
+      deinitRecorder(rec)
+    var t = Tag(name: "a", rec: addr rec)
+
+    let id1 = addEventListener(reg, "evt", tagCb, addr t)
+    let snap = snapshotListeners(reg, "evt")
+    check snap.len == 1
+
+    # Mutating the registry after the snapshot must not retroactively
+    # shrink or grow the snapshot we already captured.
+    check removeEventListener(reg, id1)
+    discard addEventListener(reg, "evt", tagCb, addr t)
+    check snap.len == 1
+    check snap[0].id == id1
+
+# ---------------------------------------------------------------------------
+# Dispatch-level tests (template-driven, single-thread).
+# ---------------------------------------------------------------------------
+
+# Per-thread registry pointer so the dispatch templates find a registry.
+# In production this threadvar is set by `ffiThreadBody`; here we set it
+# manually because we're not going through the FFI thread.
+template withRegistry(reg: var FFIEventRegistry, body: untyped) =
+  ffiCurrentEventRegistry = addr reg
+  try:
+    body
+  finally:
+    ffiCurrentEventRegistry = nil
+
+type CountedPayload {.ffi.} = object
+  value*: int
+
+# A re-entrancy harness: each listener can install/remove other listeners
+# while it is being dispatched.
+type ReentrantState = object
+  rec: ptr Recorder
+  reg: ptr FFIEventRegistry
+  newListenerId: uint64
+  targetId: uint64
+
+proc addedInsideDispatchCb(
+    retCode: cint, msg: ptr cchar, len: csize_t, userData: pointer
+) {.cdecl, gcsafe, raises: [].} =
+  ## The "freshly added" listener installed mid-dispatch by
+  ## `addInsideDispatchCb`. Just records that it ran.
+  let r = cast[ptr Recorder](userData)
+  record(r[], "added", retCode, "")
+
+proc addInsideDispatchCb(
+    retCode: cint, msg: ptr cchar, len: csize_t, userData: pointer
+) {.cdecl, gcsafe, raises: [].} =
+  let st = cast[ptr ReentrantState](userData)
+  record(st[].rec[], "outer", retCode, "")
+  # Install a brand new listener while we're mid-dispatch. The current
+  # snapshot must not pick it up — it should only fire on the *next*
+  # dispatch.
+  st[].newListenerId =
+    addEventListener(st[].reg[], "evt", addedInsideDispatchCb, st[].rec)
+
+proc removeInsideDispatchCb(
+    retCode: cint, msg: ptr cchar, len: csize_t, userData: pointer
+) {.cdecl, gcsafe, raises: [].} =
+  let st = cast[ptr ReentrantState](userData)
+  record(st[].rec[], "self-remove", retCode, "")
+  discard removeEventListener(st[].reg[], st[].targetId)
+
+suite "dispatch via FFIEventRegistry":
+  test "multiple listeners on one event all fire":
+    var reg: FFIEventRegistry
+    initEventRegistry(reg)
+    defer:
+      deinitEventRegistry(reg)
+    var rec: Recorder
+    initRecorder(rec)
+    defer:
+      deinitRecorder(rec)
+    var a = Tag(name: "a", rec: addr rec)
+    var b = Tag(name: "b", rec: addr rec)
+
+    discard addEventListener(reg, "evt", tagCb, addr a)
+    discard addEventListener(reg, "evt", tagCb, addr b)
+
+    withRegistry(reg):
+      dispatchFFIEventCbor("evt", CountedPayload(value: 42))
+
+    check rec.hits.len == 2
+    check ("a" in rec.hits) and ("b" in rec.hits)
+
+  test "listeners on different event names stay isolated":
+    var reg: FFIEventRegistry
+    initEventRegistry(reg)
+    defer:
+      deinitEventRegistry(reg)
+    var rec: Recorder
+    initRecorder(rec)
+    defer:
+      deinitRecorder(rec)
+    var a = Tag(name: "a", rec: addr rec)
+    var b = Tag(name: "b", rec: addr rec)
+
+    discard addEventListener(reg, "evt-a", tagCb, addr a)
+    discard addEventListener(reg, "evt-b", tagCb, addr b)
+
+    withRegistry(reg):
+      dispatchFFIEventCbor("evt-a", CountedPayload(value: 1))
+
+    check rec.hits == @["a"]
+
+  test "wildcard receives every event":
+    var reg: FFIEventRegistry
+    initEventRegistry(reg)
+    defer:
+      deinitEventRegistry(reg)
+    var rec: Recorder
+    initRecorder(rec)
+    defer:
+      deinitRecorder(rec)
+    var w = Tag(name: "wild", rec: addr rec)
+    var s = Tag(name: "specific", rec: addr rec)
+
+    discard addEventListener(reg, "", tagCb, addr w)
+    discard addEventListener(reg, "evt", tagCb, addr s)
+
+    withRegistry(reg):
+      dispatchFFIEventCbor("evt", CountedPayload(value: 1))
+      dispatchFFIEventCbor("other", CountedPayload(value: 2))
+
+    # evt → both specific + wildcard; other → only wildcard.
+    check rec.hits.len == 3
+    var wildCount = 0
+    var specificCount = 0
+    for h in rec.hits:
+      if h == "wild":
+        inc wildCount
+      elif h == "specific":
+        inc specificCount
+    check wildCount == 2
+    check specificCount == 1
+
+  test "addEventListener from inside a handler does not deadlock or fire on current event":
+    var reg: FFIEventRegistry
+    initEventRegistry(reg)
+    defer:
+      deinitEventRegistry(reg)
+    var rec: Recorder
+    initRecorder(rec)
+    defer:
+      deinitRecorder(rec)
+    var st =
+      ReentrantState(rec: addr rec, reg: addr reg, newListenerId: 0, targetId: 0)
+
+    discard addEventListener(reg, "evt", addInsideDispatchCb, addr st)
+
+    withRegistry(reg):
+      dispatchFFIEventCbor("evt", CountedPayload(value: 1))
+
+    # Only the original listener fired on this dispatch; the freshly-added
+    # listener does not appear in the in-flight snapshot.
+    check rec.hits == @["outer"]
+    check st.newListenerId != 0
+
+    # The next dispatch picks up both listeners (snapshot is rebuilt):
+    # the original "outer" handler runs again *and* the listener it
+    # installed during the previous dispatch now fires too.
+    withRegistry(reg):
+      dispatchFFIEventCbor("evt", CountedPayload(value: 2))
+    check rec.hits.len == 3
+    check "added" in rec.hits
+
+  test "removeEventListener from inside a handler does not deadlock; in-flight snapshot still fires":
+    var reg: FFIEventRegistry
+    initEventRegistry(reg)
+    defer:
+      deinitEventRegistry(reg)
+    var rec: Recorder
+    initRecorder(rec)
+    defer:
+      deinitRecorder(rec)
+    var other = Tag(name: "other", rec: addr rec)
+    var st =
+      ReentrantState(rec: addr rec, reg: addr reg, newListenerId: 0, targetId: 0)
+
+    let removerId =
+      addEventListener(reg, "evt", removeInsideDispatchCb, addr st)
+    let otherId = addEventListener(reg, "evt", tagCb, addr other)
+    st.targetId = otherId
+
+    withRegistry(reg):
+      dispatchFFIEventCbor("evt", CountedPayload(value: 1))
+
+    # The in-flight snapshot captured `other` before the remover ran, so
+    # `other` still fires exactly once on this dispatch even though it
+    # was removed mid-loop.
+    check ("self-remove" in rec.hits) and ("other" in rec.hits)
+    check rec.hits.len == 2
+
+    # On the next dispatch, the removed listener is gone.
+    let beforeLen = rec.hits.len
+    withRegistry(reg):
+      dispatchFFIEventCbor("evt", CountedPayload(value: 2))
+    check rec.hits.len == beforeLen + 1
+    check rec.hits[^1] == "self-remove"
+
+    # Suppress the unused-binding warning under DCE-stripped builds.
+    discard removerId
+
+suite "removeAllEventListeners":
+  test "drops every listener (per-event and wildcard)":
+    var reg: FFIEventRegistry
+    initEventRegistry(reg)
+    defer:
+      deinitEventRegistry(reg)
+    var rec: Recorder
+    initRecorder(rec)
+    defer:
+      deinitRecorder(rec)
+    var a = Tag(name: "a", rec: addr rec)
+    var b = Tag(name: "b", rec: addr rec)
+
+    discard addEventListener(reg, "evt", tagCb, addr a)
+    discard addEventListener(reg, WildcardEventName, tagCb, addr b)
+    removeAllEventListeners(reg)
+
+    check snapshotListeners(reg, "evt").len == 0
+    check snapshotListeners(reg, WildcardEventName).len == 0


### PR DESCRIPTION
## Improve event handling

Closes #40 (multi-listener registry + add/remove ABI). Lays the groundwork for #6 (follow-up PR).

## Summary

- Replaces the single-slot `<lib>_set_event_callback` C ABI with a multi-listener registry exposing `<lib>_add_event_listener(ctx, event_name, cb, ud) -> uint64` and `<lib>_remove_event_listener(ctx, id) -> cint`. Each listener gets a stable monotonic id and can be removed independently.
- Registry lives in a new module `ffi/ffi_events.nim`. `dispatchFFIEvent` / `dispatchFFIEventCbor` move there too; `ffi_context.nim` keeps only `FFIContext` + thread lifecycle plus an `eventRegistry: FFIEventRegistry` field.
- `declareLibrary` in `ffi/internal/ffi_library.nim` now emits the two listener-ABI procs. The legacy `_set_event_callback` is removed end-to-end (no Nim helper, no C ABI symbol, no foreign-side caller).

## Foreign-side bindings (C++ and Rust)

The codegen emits a richer, type-safe API per `{.ffiEvent.}`:

### Per-event typed methods

One method per declared event, with the payload type baked in at compile time:

```cpp
// C++
ListenerHandle addOnEchoFiredListener(std::function<void(const EchoEvent&)> handler);
```

```rust
// Rust
pub fn add_on_echo_fired_listener<F>(&self, handler: F) -> ListenerHandle
where F: Fn(&EchoEvent) + Send + Sync + 'static;
```

These are the recommended path — the handler receives the already-decoded payload, no CBOR work in user code.

### Wildcard (catch-all) listener

A single overload that subscribes to **every** event the lib emits, regardless of name. Internally registers with an empty `event_name` against the C ABI; the lib's wildcard trampoline pre-extracts the `eventType` field from the CBOR envelope so the consumer doesn't have to walk CBOR by hand.

```cpp
// C++
ListenerHandle addEventListener(
    std::function<void(int retCode,
                       const std::string& eventId,
                       const std::vector<std::uint8_t>& envelope)> handler);
```

```rust
// Rust
pub fn add_event_listener<F>(&self, handler: F) -> ListenerHandle
where F: Fn(c_int, &str, &[u8]) + Send + Sync + 'static;
```

The handler arguments:

| Arg | Meaning |
|---|---|
| `retCode` / `ret` | FFI return code. `0` = success (envelope is a valid CBOR `EventEnvelope`). Non-zero = error (the bytes are an error string, not a CBOR envelope; `eventId` will be empty). |
| `eventId` / `event_id` | Wire `eventType` string from the envelope (`"on_echo_fired"` for events declared `{.ffiEvent: "on_echo_fired".}`). Empty if `retCode != 0` or the envelope is malformed. |
| `envelope` | Full CBOR envelope bytes (`{ eventType: tstr, payload: <T> }`), suitable to pass to `decodeEventPayload<T>` for the matching event id. |

#### Why a wildcard?

Use cases that the typed per-event methods don't cover cleanly:

- **Diagnostics / logging**: one handler that prints every event the lib emits, without subscribing to each name individually. Doubles as a tracing hook.
- **Generic forwarders**: e.g. forwarding every event to a message bus / IPC channel where decoding by type isn't needed.
- **Future-proofing**: catches events introduced by a newer lib version that the binding wasn't recompiled against.
- **Error channel**: the wildcard sees `retCode != 0` events too. Per-event typed listeners skip those by design (the payload can't be decoded as the registered type), so the wildcard is the place to handle dispatch-time errors.

#### Decoding the payload by type

A helper is emitted alongside the codecs so wildcard handlers can lift the payload into a typed value without rolling their own CBOR walk:

```cpp
// C++
template <class T>
bool decodeEventPayload(const std::vector<std::uint8_t>& envelope, T& out);

// Usage from a wildcard handler:
ctx->addEventListener(
    [&](int retCode, const std::string& eventId, const std::vector<std::uint8_t>& envelope) {
        if (retCode != 0) { /* handle error */ return; }
        if (eventId == "on_echo_fired") {
            EchoEvent evt{};
            if (decodeEventPayload(envelope, evt)) {
                // use evt.message, evt.echoCount, ...
            }
        }
    });
```

```rust
// Rust
pub fn decode_event_payload<T: serde::de::DeserializeOwned>(envelope: &[u8]) -> Result<T, String>;

// Usage:
ctx.add_event_listener(move |ret, event_id, envelope| {
    if ret == 0 && event_id == "on_echo_fired" {
        if let Ok(evt) = decode_event_payload::<EchoEvent>(envelope) {
            // use evt.message, evt.echo_count, ...
        }
    }
});
```

`decodeEventPayload` / `decode_event_payload` understands any `{.ffi.}`-declared type already registered with the binding generator — same codecs the typed methods use under the hood.

### Remove by handle

```cpp
bool removeEventListener(ListenerHandle handle);   // C++
```

```rust
pub fn remove_event_listener(&self, handle: ListenerHandle) -> bool;   // Rust
```

Listeners are owned by the context — `std::unordered_map<uint64_t, std::unique_ptr<ListenerBase>>` in C++, `Mutex<HashMap<u64, Box<dyn Any + Send>>>` in Rust — so the user's closure stays alive until the matching `removeEventListener` call returns.

## Examples

- `examples/timer/cpp_bindings/main.cpp` — section [7] demonstrates typed listener + wildcard with `eventId` dispatch + `decodeEventPayload<EchoEvent>` + `removeEventListener`.
- `examples/timer/rust_bindings/examples/main.rs` — sync example.
- `examples/timer/rust_bindings/examples/tokio_main.rs` — async example via `#[tokio::main]` (Cargo.toml now ships a `[dev-dependencies]` block with `rt-multi-thread` + `macros` so `examples/` can use the macro without bloating the library's runtime deps).

## Tests

- `tests/unit/test_event_listener.nim` — **13 new tests** covering mutation, monotonic ids, snapshot semantics, multi-listener dispatch, wildcard, re-entrant add (does not fire on current dispatch), re-entrant remove (in-flight snapshot still delivers once), and unknown-id removal.
- `tests/unit/test_event_dispatch.nim` — migrated to `addEventListener`; concurrent stress suite gated to non-refc with a comment (refc's per-thread GC heaps can't safely grow a `seq[T]` across threads even under a lock).
- `tests/e2e/cpp/test_timer_e2e.cpp` — 3 new tests: `MultipleTypedListenersAllFire`, `RemoveEventListenerStopsDelivery`, `WildcardListenerReceivesEventIdAndDecodesPayload`. Total 14/14.

## Other small changes

- "No listener registered" log demoted from `error` to `debug` — foreign code legitimately not subscribing to every event isn't an error.
- `chronicles.error` on the FFI thread now reports only actual programmer errors (registry not bound to the thread).

## Known follow-ups (out of scope for this PR)

1. **Snapshot/invoke UAF window** — second concern in #40. `snapshotListeners` copies the listener seq under lock then iterates outside, so a foreign `removeEventListener` can free the listener's heap object before `cb(userData)` runs. Will be addressed in the #6 follow-up by switching to a recursive registry mutex held during invocation (cheap once dispatch lives on the dedicated event thread).
2. **#6** — move dispatch off the FFI thread (bounded MPSC queue + dedicated event thread + system events `__queue_near_full__` / `__queue_full__` / `__not_responding__`); fold the standalone watchdog into the new event thread.

## Test plan

- [x] `nimble test` — all suites green under `--mm:orc` and `--mm:refc`.
- [x] `nimble check_bindings_cpp` / `nimble check_bindings_rust` — checked-in bindings reproduce.
- [x] `nimble test_cpp_e2e` — 14/14 (including the 3 new event tests).
- [x] `cargo run --example main` / `cargo run --example tokio_main` from `examples/timer/rust_bindings`.
- [x] C++ `example` binary prints sections [1]–[7] cleanly.
- [ ] Optional: `NIM_FFI_SAN=asan-ubsan` and `=tsan` sanitizer passes (worth running given the #40 race history).
