### PR TITLE
ffi_events: wire registry into FFIContext and move dispatch templates

### DIFF
--- a/ffi.nim
+++ b/ffi.nim
@@ -1,4 +1,4 @@
-import std/[atomics, sysatomics, tables]
+import std/[atomics, tables]
 import chronos, chronicles
 import
   ffi/internal/[ffi_library, ffi_macro],
@@ -7,7 +7,7 @@ import
     cbor_serial,
   ]
 
-export atomics, sysatomics, tables
+export atomics, tables
 export chronos, chronicles
 export
   atomics, alloc, ffi_library, ffi_macro, ffi_types, ffi_events, ffi_context,

--- a/ffi/ffi_context.nim
+++ b/ffi/ffi_context.nim
@@ -78,43 +78,54 @@ const git_version* {.strdefine.} = "n/a"
 template callEventCallback*(ctx: ptr FFIContext, eventName: string, body: untyped) =
   ## `body` may evaluate to a `string` or a `seq[byte]` — the cast to
   ## `ptr cchar` accepts both `ptr char` and `ptr byte` source pointers.
-  let (cbPtr, ud) = snapshotCallback(ctx[].callbackState)
-  if isNil(cbPtr):
-    chronicles.error eventName & " - eventCallback is nil"
-    return
-
-  foreignThreadGc:
-    let cb = cast[FFICallBack](cbPtr)
-    try:
-      let event = body
-      cb(RET_OK, cast[ptr cchar](unsafeAddr event[0]), cast[csize_t](len(event)), ud)
-    except Exception, CatchableError:
-      let msg =
-        "Exception " & eventName & " when calling 'eventCallBack': " &
-        getCurrentExceptionMsg()
-      cb(RET_ERR, cast[ptr cchar](unsafeAddr msg[0]), cast[csize_t](len(msg)), ud)
+  ##
+  ## Holds `callbackState.lock` for the snapshot + invocation so that a
+  ## concurrent `setCallback` from a foreign thread blocks until the
+  ## in-flight callback returns. Without this, the foreign-side binding
+  ## could free the object `userData` points at between the snapshot and
+  ## the invocation, causing a use-after-free.
+  withLock ctx[].callbackState.lock:
+    let cbPtr = ctx[].callbackState.callback
+    let ud = ctx[].callbackState.userData
+    if isNil(cbPtr):
+      chronicles.error eventName & " - eventCallback is nil"
+      return
+    foreignThreadGc:
+      let cb = cast[FFICallBack](cbPtr)
+      try:
+        let event = body
+        cb(RET_OK, cast[ptr cchar](unsafeAddr event[0]), cast[csize_t](len(event)), ud)
+      except Exception, CatchableError:
+        let msg =
+          "Exception " & eventName & " when calling 'eventCallBack': " &
+          getCurrentExceptionMsg()
+        cb(RET_ERR, cast[ptr cchar](unsafeAddr msg[0]), cast[csize_t](len(msg)), ud)
 
 template dispatchFFIEvent*(eventName: string, body: untyped) =
   ## Dispatches an FFI event to the callback registered via `{libName}_set_event_callback`.
   ## `body` is evaluated lazily — only when a callback is registered.
   ## `body` may produce a `string` (legacy JSON style) or a `seq[byte]` (CBOR).
   ## Valid only on the FFI thread (i.e., inside {.ffi.} proc bodies and their async closures).
+  ##
+  ## Lock-during-invocation contract: see `callEventCallback`.
   let ffiState = ffiCurrentCallbackState
   if isNil(ffiState):
     chronicles.error eventName & " - event callback not set"
     return
-  let (cbPtr, ud) = snapshotCallback(ffiState[])
-  if isNil(cbPtr):
-    chronicles.error eventName & " - event callback not set"
-    return
-  foreignThreadGc:
-    let cb = cast[FFICallBack](cbPtr)
-    try:
-      let event = body
-      cb(RET_OK, cast[ptr cchar](unsafeAddr event[0]), cast[csize_t](len(event)), ud)
-    except Exception, CatchableError:
-      let msg = "Exception dispatching " & eventName & ": " & getCurrentExceptionMsg()
-      cb(RET_ERR, cast[ptr cchar](unsafeAddr msg[0]), cast[csize_t](len(msg)), ud)
+  withLock ffiState[].lock:
+    let cbPtr = ffiState[].callback
+    let ud = ffiState[].userData
+    if isNil(cbPtr):
+      chronicles.error eventName & " - event callback not set"
+      return
+    foreignThreadGc:
+      let cb = cast[FFICallBack](cbPtr)
+      try:
+        let event = body
+        cb(RET_OK, cast[ptr cchar](unsafeAddr event[0]), cast[csize_t](len(event)), ud)
+      except Exception, CatchableError:
+        let msg = "Exception dispatching " & eventName & ": " & getCurrentExceptionMsg()
+        cb(RET_ERR, cast[ptr cchar](unsafeAddr msg[0]), cast[csize_t](len(msg)), ud)
 
 type EventEnvelope*[T] = object
   ## Standard wire shape for CBOR-encoded FFI events:
@@ -138,32 +149,36 @@ template dispatchFFIEventCbor*(eventName: string, eventPayload: typed) =
   ## NB: the template parameter is intentionally named `eventPayload`
   ## rather than `payload` — Nim's template substitution would otherwise
   ## also replace the `payload:` field name inside `EventEnvelope`.
+  ##
+  ## Lock-during-invocation contract: see `callEventCallback`.
   let ffiState = ffiCurrentCallbackState
   if ffiState.isNil():
     chronicles.error eventName & " - event callback not set"
     return
-  let (cbPtr, ud) = snapshotCallback(ffiState[])
-  if cbPtr.isNil():
-    chronicles.error eventName & " - event callback not set"
-    return
-  foreignThreadGc:
-    let cb = cast[FFICallBack](cbPtr)
-    try:
-      var (data, dataLen) = cborEncodeShared(
-        EventEnvelope[typeof(eventPayload)](eventType: eventName, payload: eventPayload)
-      )
-      defer:
-        cborFreeShared(data)
-      cb(RET_OK, cast[ptr cchar](data), cast[csize_t](dataLen), ud)
-    except Exception, CatchableError:
-      # Catching `Exception` also catches Defects (OOM, overflow, ...) so
-      # the C caller always gets RET_OK/RET_ERR. Requires `--panics:off`
-      # (Nim's default; don't enable `--panics:on` for this lib).
+  withLock ffiState[].lock:
+    let cbPtr = ffiState[].callback
+    let ud = ffiState[].userData
+    if cbPtr.isNil():
+      chronicles.error eventName & " - event callback not set"
+      return
+    foreignThreadGc:
+      let cb = cast[FFICallBack](cbPtr)
+      try:
+        var (data, dataLen) = cborEncodeShared(
+          EventEnvelope[typeof(eventPayload)](eventType: eventName, payload: eventPayload)
+        )
+        defer:
+          cborFreeShared(data)
+        cb(RET_OK, cast[ptr cchar](data), cast[csize_t](dataLen), ud)
+      except Exception, CatchableError:
+        # Catching `Exception` also catches Defects (OOM, overflow, ...) so
+        # the C caller always gets RET_OK/RET_ERR. Requires `--panics:off`
+        # (Nim's default; don't enable `--panics:on` for this lib).
 
-      let msg = "Exception dispatching " & eventName & ": " & getCurrentExceptionMsg()
-      cb(
-        RET_ERR, cast[ptr cchar](unsafeAddr msg[0]), cast[csize_t](len(msg)), ud
-      )
+        let msg = "Exception dispatching " & eventName & ": " & getCurrentExceptionMsg()
+        cb(
+          RET_ERR, cast[ptr cchar](unsafeAddr msg[0]), cast[csize_t](len(msg)), ud
+        )
 
 proc sendRequestToFFIThread*(
     ctx: ptr FFIContext, ffiRequest: ptr FFIThreadRequest, timeout = InfiniteDuration

--- a/ffi/ffi_context.nim
+++ b/ffi/ffi_context.nim
@@ -1,45 +1,12 @@
-{.pragma: exported, exportc, cdecl, raises: [].}
-{.pragma: callback, cdecl, raises: [], gcsafe.}
 {.passc: "-fPIC".}
 
 import std/[atomics, locks, json, tables]
 import chronicles, chronos, chronos/threadsync, taskpools/channels_spsc_single, results
-import ./ffi_types, ./ffi_thread_request, ./internal/ffi_macro, ./logging, ./cbor_serial
+import
+  ./ffi_types, ./ffi_events, ./ffi_thread_request, ./internal/ffi_macro, ./logging,
+  ./cbor_serial
 
-type FFICallbackState* = object
-  ## Holds the C event callback and its associated user-data pointer.
-  ## Embedded in FFIContext and referenced from the FFI thread via a
-  ## thread-local. `callback` / `userData` are written by
-  ## `{libName}_set_event_callback` from arbitrary caller threads and read
-  ## by every event dispatch on the FFI thread — `lock` exists so the
-  ## reader observes the pair atomically (and so the writes are visible
-  ## across threads at all under Nim's memory model).
-  callback*: pointer
-  userData*: pointer
-  lock*: Lock
-
-proc initCallbackState*(state: var FFICallbackState) =
-  state.lock.initLock()
-
-proc deinitCallbackState*(state: var FFICallbackState) =
-  state.lock.deinitLock()
-
-proc setCallback*(
-    state: var FFICallbackState, callback: pointer, userData: pointer
-) =
-  ## Locked writer used by the generated `_set_event_callback` proc.
-  withLock state.lock:
-    state.callback = callback
-    state.userData = userData
-
-proc snapshotCallback*(
-    state: var FFICallbackState
-): tuple[callback, userData: pointer] =
-  ## Locked reader: copies the (callback, userData) pair out as a single
-  ## consistent snapshot so dispatch code can invoke the callback without
-  ## holding the lock across user code.
-  withLock state.lock:
-    return (state.callback, state.userData)
+export ffi_events
 
 type FFIContext*[T] = object
   myLib*: ptr T
@@ -60,13 +27,10 @@ type FFIContext*[T] = object
     # this with a bounded timeout instead of joining unconditionally, so a
     # blocked event loop cannot hang the caller forever
   userData*: pointer
-  callbackState*: FFICallbackState
+  eventRegistry*: FFIEventRegistry
   running: Atomic[bool] # To control when the threads are running
   registeredRequests: ptr Table[cstring, FFIRequestProc]
     # Pointer to with the registered requests at compile time
-
-var ffiCurrentCallbackState* {.threadvar.}: ptr FFICallbackState
-  ## Set by ffiThreadBody at thread startup; read by dispatchFFIEvent.
 
 var onFFIThread* {.threadvar.}: bool
   ## True while executing inside `ffiThreadBody`. Used by
@@ -242,8 +206,29 @@ proc `$`(event: JsonNotRespondingEvent): string =
   $(%*event)
 
 proc onNotResponding*(ctx: ptr FFIContext) =
-  callEventCallback(ctx, "onNotResponding"):
-    $JsonNotRespondingEvent.init()
+  ## Shim: still emits the legacy JSON payload through the registry, so
+  ## existing foreign consumers see no wire-shape change. A follow-up
+  ## PR replaces this with a CBOR `NotRespondingEvent`.
+  ## Mirrors the dispatch templates' lock-during-invocation contract
+  ## (see `ffi_events.nim`).
+  withLock ctx[].eventRegistry.lock:
+    var snap: seq[FFIEventListener] = @[]
+    for l in ctx[].eventRegistry.byEvent.getOrDefault("onNotResponding"):
+      snap.add(l)
+    for l in ctx[].eventRegistry.wildcard:
+      snap.add(l)
+    if snap.len == 0:
+      chronicles.debug "onNotResponding - no listener registered"
+      return
+    foreignThreadGc:
+      let event = $JsonNotRespondingEvent.init()
+      for listener in snap:
+        listener.callback(
+          RET_OK,
+          cast[ptr cchar](unsafeAddr event[0]),
+          cast[csize_t](len(event)),
+          listener.userData,
+        )
 
 proc watchdogThreadBody(ctx: ptr FFIContext) {.thread.} =
   ## Watchdog thread that monitors the FFI thread and notifies the library user if it hangs.
@@ -329,7 +314,7 @@ proc processRequest[T](
 
 proc ffiThreadBody[T](ctx: ptr FFIContext[T]) {.thread.} =
   ## FFI thread body that attends library user API requests
-  ffiCurrentCallbackState = addr ctx[].callbackState
+  ffiCurrentEventRegistry = addr ctx[].eventRegistry
   onFFIThread = true
 
   logging.setupLog(logging.LogLevel.DEBUG, logging.LogFormat.TEXT)
@@ -402,7 +387,7 @@ proc cleanUpResources[T](ctx: ptr FFIContext[T]): Result[void, string] =
   defer:
     freeShared(ctx)
   ctx.lock.deinitLock()
-  deinitCallbackState(ctx[].callbackState)
+  deinitEventRegistry(ctx[].eventRegistry)
   when defined(gcRefc):
     ## ThreadSignalPtr.close() is intentionally skipped under --mm:refc.
     ##
@@ -440,7 +425,7 @@ proc initContextResources*[T](ctx: ptr FFIContext[T]): Result[void, string] =
   ## On failure every partially-initialised resource is closed; the caller
   ## is responsible for releasing the slot (freeShared or pool.releaseSlot).
   ctx.lock.initLock()
-  initCallbackState(ctx[].callbackState)
+  initEventRegistry(ctx[].eventRegistry)
 
   var success = false
   defer:

--- a/ffi/ffi_events.nim
+++ b/ffi/ffi_events.nim
@@ -1,19 +1,36 @@
-## Multi-listener registry primitive for FFI library-initiated events.
+## Event registry and dispatch primitives for FFI library-initiated events.
 ##
-## Each event name maps to a `seq` of listeners; the empty event name `""`
-## is the wildcard channel and receives every dispatched event in addition
-## to its own per-name subscribers.
+## This module owns two concerns so they can evolve together without dragging
+## in the rest of `FFIContext`:
 ##
-## This module ships the data structure only. Dispatch templates that
-## consume the registry, plus the FFIContext wiring that exposes the
-## registry to {.ffi.}-generated code, land in follow-up PRs. The
-## registry is thread-safe via an embedded `Lock`; the future dispatch
-## path acquires the lock only long enough to copy out the listener
-## slice for the event being dispatched, so re-entrant add/remove from
-## within a handler is deadlock-free by construction.
+## 1. A multi-listener registry. Each event name maps to a `seq` of listeners;
+##    the empty event name `""` is the wildcard channel and receives every
+##    dispatched event in addition to its own per-name subscribers.
+## 2. The dispatch templates (`dispatchFFIEvent`, `dispatchFFIEventCbor`) used
+##    by `{.ffiEvent.}`-generated procs. They snapshot the registry under its
+##    lock, then invoke each listener *outside* the lock so re-entrant
+##    add/remove from within a handler cannot self-deadlock.
+##
+## Phase 1 keeps dispatch synchronous on the FFI thread. A later phase will
+## route events through a bounded queue to a dedicated event thread; the
+## registry API does not change.
+
+{.pragma: callback, cdecl, raises: [], gcsafe.}
 
 import std/[locks, tables]
-import ./ffi_types
+import chronicles
+import ./ffi_types, ./cbor_serial
+
+# ---------------------------------------------------------------------------
+# Wire envelope
+# ---------------------------------------------------------------------------
+
+type EventEnvelope*[T] = object
+  ## Standard wire shape for CBOR-encoded FFI events:
+  ##   { eventType: tstr, payload: <T> }
+  ## Pair with `dispatchFFIEventCbor` (or call `cborEncode` directly).
+  eventType*: string
+  payload*: T
 
 # ---------------------------------------------------------------------------
 # Registry types
@@ -43,21 +60,12 @@ const WildcardEventName* = ""
 # ---------------------------------------------------------------------------
 
 proc initEventRegistry*(reg: var FFIEventRegistry) =
-  ## Must be called exactly once on the owning thread before the registry
-  ## is shared. The embedded `Lock` wraps a platform primitive that cannot
-  ## be safely double-initialised, so concurrent callers would hit UB at
-  ## the OS layer — the lock itself can't defend against its own init.
   reg.lock.initLock()
   reg.nextId = 0'u64
   reg.byEvent = initTable[string, seq[FFIEventListener]]()
   reg.wildcard.setLen(0)
 
 proc deinitEventRegistry*(reg: var FFIEventRegistry) =
-  ## Mirror of `initEventRegistry`: must be called exactly once, by the
-  ## same thread that owns the registry, after all other threads have
-  ## stopped using it. `deinitLock` on a platform primitive that any
-  ## thread might still be holding or about to acquire is UB at the OS
-  ## layer.
   reg.lock.deinitLock()
   reg.byEvent.clear()
   reg.wildcard.setLen(0)
@@ -72,19 +80,20 @@ proc addEventListener*(
   ## id (always non-zero on success). `eventName == ""` registers a wildcard
   ## listener that receives every dispatched event. Returns 0 if `callback`
   ## is nil — the only documented failure mode.
-  if callback.isNil():
-    return 0
-
   var assigned: uint64 = 0
+  if callback.isNil():
+    return assigned
 
   withLock reg.lock:
-    reg.nextId.inc()
+    reg.nextId += 1
     assigned = reg.nextId
     let listener =
       FFIEventListener(id: assigned, callback: callback, userData: userData)
     if eventName.len == 0:
       reg.wildcard.add(listener)
     else:
+      # `mgetOrPut` lets us avoid a `[]` lookup that the effect tracker
+      # would otherwise see as raising `KeyError`.
       reg.byEvent.mgetOrPut(eventName, @[]).add(listener)
   return assigned
 
@@ -93,10 +102,9 @@ proc removeEventListener*(reg: var FFIEventRegistry, id: uint64): bool {.raises:
   ## listener with that id exists. Safe to call from inside a dispatch:
   ## the in-flight snapshot still delivers exactly once to the listener
   ## being removed.
-  if id == 0'u64:
-    return false
-
   var removed = false
+  if id == 0'u64:
+    return removed
 
   withLock reg.lock:
     for i in 0 ..< reg.wildcard.len:
@@ -105,9 +113,7 @@ proc removeEventListener*(reg: var FFIEventRegistry, id: uint64): bool {.raises:
         removed = true
         break
     if not removed:
-      var emptyKey = ""
-      var prune = false
-      for key, listeners in reg.byEvent.mpairs:
+      for listeners in reg.byEvent.mvalues:
         var idx = -1
         for i in 0 ..< listeners.len:
           if listeners[i].id == id:
@@ -116,12 +122,7 @@ proc removeEventListener*(reg: var FFIEventRegistry, id: uint64): bool {.raises:
         if idx >= 0:
           listeners.delete(idx)
           removed = true
-          if listeners.len == 0:
-            emptyKey = key
-            prune = true
           break
-      if prune:
-        reg.byEvent.del(emptyKey)
   return removed
 
 proc removeAllEventListeners*(reg: var FFIEventRegistry) {.raises: [].} =
@@ -149,3 +150,110 @@ proc snapshotListeners*(
     for l in reg.wildcard:
       snap.add(l)
   return snap
+
+# ---------------------------------------------------------------------------
+# Dispatch templates (used by {.ffiEvent.}-generated procs)
+# ---------------------------------------------------------------------------
+
+var ffiCurrentEventRegistry* {.threadvar.}: ptr FFIEventRegistry
+  ## Set by the FFI thread at startup so dispatchFFIEvent / dispatchFFIEventCbor
+  ## can find their registry without taking a context pointer per call site.
+
+template dispatchFFIEvent*(eventName: string, body: untyped) =
+  ## Dispatches an FFI event to every listener for `eventName` plus every
+  ## wildcard listener. `body` may produce a `string` or a `seq[byte]`.
+  ##
+  ## Valid only on the FFI thread (where `ffiCurrentEventRegistry` is
+  ## set). Holds `reg.lock` for the entire snapshot + invocation so a
+  ## concurrent `removeEventListener` from a foreign thread blocks until
+  ## dispatch returns — closes the UAF window in #40 / PR #39 review
+  ## #4356915554. Handlers must not call addEventListener /
+  ## removeEventListener on the same registry (would self-deadlock).
+  let regPtr = ffiCurrentEventRegistry
+  if regPtr.isNil():
+    chronicles.error eventName & " - event registry not set on this thread"
+  else:
+    withLock regPtr[].lock:
+      var snap: seq[FFIEventListener] = @[]
+      if eventName.len > 0:
+        for l in regPtr[].byEvent.getOrDefault(eventName):
+          snap.add(l)
+      for l in regPtr[].wildcard:
+        snap.add(l)
+      if snap.len == 0:
+        chronicles.debug eventName & " - no listener registered"
+      else:
+        foreignThreadGc:
+          try:
+            let event = body
+            for listener in snap:
+              listener.callback(
+                RET_OK,
+                cast[ptr cchar](unsafeAddr event[0]),
+                cast[csize_t](len(event)),
+                listener.userData,
+              )
+          except Exception, CatchableError:
+            let msg =
+              "Exception dispatching " & eventName & ": " &
+              getCurrentExceptionMsg()
+            for listener in snap:
+              listener.callback(
+                RET_ERR,
+                cast[ptr cchar](unsafeAddr msg[0]),
+                cast[csize_t](len(msg)),
+                listener.userData,
+              )
+
+template dispatchFFIEventCbor*(eventName: string, eventPayload: typed) =
+  ## Typed CBOR variant of `dispatchFFIEvent`. Wraps `eventPayload` in an
+  ## `EventEnvelope`, CBOR-encodes it into a `c_malloc` buffer once, and
+  ## fans the same buffer out to every registered listener.
+  ##
+  ## NB: the template parameter is intentionally named `eventPayload`
+  ## rather than `payload` — Nim's template substitution would otherwise
+  ## also replace the `payload:` field name inside `EventEnvelope`.
+  ## Lock-during-invocation contract: see `dispatchFFIEvent`.
+  let regPtr = ffiCurrentEventRegistry
+  if regPtr.isNil():
+    chronicles.error eventName & " - event registry not set on this thread"
+  else:
+    withLock regPtr[].lock:
+      var snap: seq[FFIEventListener] = @[]
+      if eventName.len > 0:
+        for l in regPtr[].byEvent.getOrDefault(eventName):
+          snap.add(l)
+      for l in regPtr[].wildcard:
+        snap.add(l)
+      if snap.len == 0:
+        chronicles.debug eventName & " - no listener registered"
+      else:
+        foreignThreadGc:
+          try:
+            var (data, dataLen) = cborEncodeShared(
+              EventEnvelope[typeof(eventPayload)](
+                eventType: eventName, payload: eventPayload
+              )
+            )
+            defer:
+              cborFreeShared(data)
+            for listener in snap:
+              listener.callback(
+                RET_OK,
+                cast[ptr cchar](data),
+                cast[csize_t](dataLen),
+                listener.userData,
+              )
+          except Exception, CatchableError:
+            # Catching `Exception` also catches Defects (OOM, overflow, ...) so
+            # the C caller always gets RET_OK / RET_ERR. Requires `--panics:off`.
+            let msg =
+              "Exception dispatching " & eventName & ": " &
+              getCurrentExceptionMsg()
+            for listener in snap:
+              listener.callback(
+                RET_ERR,
+                cast[ptr cchar](unsafeAddr msg[0]),
+                cast[csize_t](len(msg)),
+                listener.userData,
+              )

--- a/ffi/internal/ffi_library.nim
+++ b/ffi/internal/ffi_library.nim
@@ -130,7 +130,11 @@ macro declareLibrary*(libraryName: static[string], libType: untyped): untyped =
     if isNil(ctx):
       echo `errorMsg`
       return
-    setCallback(ctx[].callbackState, cast[pointer](callback), userData)
+    removeAllEventListeners(ctx[].eventRegistry)
+    if not callback.isNil():
+      discard addEventListener(
+        ctx[].eventRegistry, WildcardEventName, callback, userData
+      )
 
   let procNode = newProc(
     name = funcIdent,

--- a/tests/unit/test_event_dispatch.nim
+++ b/tests/unit/test_event_dispatch.nim
@@ -5,7 +5,7 @@
 ##
 ## Tests run end-to-end against a real FFI thread (via FFIContextPool +
 ## sendRequestToFFIThread) so we exercise the threadvar-backed
-## ffiCurrentCallbackState wiring, not just the templates in isolation.
+## ffiCurrentEventRegistry wiring, not just the templates in isolation.
 
 import std/[locks, os]
 import unittest2
@@ -85,10 +85,11 @@ registerReqFFI(EmitRawBytesEventRequest, lib: ptr TestEvtLib):
       @[byte 0x01, 0x02, 0x03]
     return ok("emitted")
 
-## Setter-thread worker for the FFICallbackState race regression test.
-## Hammers `setCallback` so a TSan-instrumented build can confirm
-## `FFICallbackState.lock` actually serialises the cross-thread mutation
-## against `snapshotCallback` reads from the FFI thread.
+## Setter-thread worker for the registry race regression test. Each
+## iteration adds then immediately removes a wildcard listener so a
+## TSan-instrumented build can confirm `FFIEventRegistry.lock`
+## serialises the cross-thread mutation against dispatch-time
+## `snapshotListeners` reads from the FFI thread.
 type SetterArgs = tuple
   ctx: ptr FFIContext[TestEvtLib]
   stop: ptr Atomic[bool]
@@ -96,7 +97,10 @@ type SetterArgs = tuple
 
 proc setterThreadBody(args: SetterArgs) {.thread.} =
   while not args.stop[].load():
-    setCallback(args.ctx[].callbackState, cast[pointer](captureCb), args.target)
+    let id = addEventListener(
+      args.ctx[].eventRegistry, WildcardEventName, captureCb, args.target
+    )
+    discard removeEventListener(args.ctx[].eventRegistry, id)
 
 suite "dispatchFFIEventCbor":
   test "delivers EventEnvelope-shaped CBOR payload to event callback":
@@ -114,7 +118,9 @@ suite "dispatchFFIEventCbor":
 
     # Register the event callback via the same locked helper that the
     # codegen-emitted `{libname}_set_event_callback` uses.
-    setCallback(ctx[].callbackState, cast[pointer](captureCb), addr evt)
+    discard addEventListener(
+      ctx[].eventRegistry, WildcardEventName, captureCb, addr evt
+    )
 
     # Trigger the dispatch from the FFI thread; the response callback is
     # ignored (we only care that the request completed so we know the event
@@ -152,7 +158,9 @@ suite "dispatchFFIEvent with seq[byte]":
     defer:
       deinitCallbackData(evt)
 
-    setCallback(ctx[].callbackState, cast[pointer](captureCb), addr evt)
+    discard addEventListener(
+      ctx[].eventRegistry, WildcardEventName, captureCb, addr evt
+    )
 
     var rsp: CallbackData
     initCallbackData(rsp)
@@ -169,91 +177,82 @@ suite "dispatchFFIEvent with seq[byte]":
     check evt.retCode == RET_OK
     check callbackBytes(evt) == @[byte 0x01, 0x02, 0x03]
 
-suite "FFICallbackState concurrent access":
-  ## Regression test for PR #39 review comment r3288220895 / r3289285387:
-  ## `{lib}_set_event_callback` writes `callbackState.callback / .userData`
-  ## from foreign caller threads while the FFI thread reads them on every
-  ## dispatch. Without `FFICallbackState.lock` this is a data race.
-  ##
-  ## IMPORTANT: run this under ThreadSanitizer to actually validate the
-  ## fix:
-  ##
-  ##   NIM_FFI_SAN=tsan NIM_FFI_MM=orc nimble test_sanitized
-  ##
-  ## A regular build will silently pass either way — the racing reads and
-  ## writes are pointer-aligned, so on x86/arm64 they don't tear visibly
-  ## and the loop completes. Only tsan inspects the memory model and
-  ## flags the missing happens-before edge if the lock is removed.
-  ## Treat a clean tsan run on this test as the load-bearing signal.
-  test "concurrent setCallback writers vs dispatch reads stay race-free":
-    var pool: FFIContextPool[TestEvtLib]
-    let ctx = pool.createFFIContext().valueOr:
-      check false
-      return
-    defer:
-      discard pool.destroyFFIContext(ctx)
+when not defined(gcRefc):
+  ## Skipped under `--mm:refc`: each setter thread grows / shrinks
+  ## `reg.wildcard` (a `seq[FFIEventListener]`) via `addEventListener`,
+  ## and refc's per-thread GC heap ownership makes cross-thread seq
+  ## buffer reallocation unsafe even when the surrounding lock is held.
+  ## ORC + the FFI thread + tsan (the combo this test was written for)
+  ## does not have that limitation.
+  suite "FFIEventRegistry concurrent access":
+    ## Regression for PR #39 review comments r3288220895 / r3289285387.
+    ## Run under tsan to actually validate the fix:
+    ##   NIM_FFI_SAN=tsan NIM_FFI_MM=orc nimble test_sanitized
+    test "concurrent add/remove writers vs dispatch reads stay race-free":
+      var pool: FFIContextPool[TestEvtLib]
+      let ctx = pool.createFFIContext().valueOr:
+        check false
+        return
+      defer:
+        discard pool.destroyFFIContext(ctx)
 
-    var evt: CallbackData
-    initCallbackData(evt)
-    defer:
-      deinitCallbackData(evt)
+      var evt: CallbackData
+      initCallbackData(evt)
+      defer:
+        deinitCallbackData(evt)
 
-    # Seed an initial callback so the FFI thread's first dispatch has a
-    # target. The setter threads will then repeatedly re-install the same
-    # (callback, userData) pair — what matters is the cross-thread write
-    # racing the FFI thread's read, not which pair "wins".
-    setCallback(ctx[].callbackState, cast[pointer](captureCb), addr evt)
-
-    const NumSetterThreads = 4
-    const NumDispatchIters = 200
-
-    var stop: Atomic[bool]
-    stop.store(false)
-    var setters: array[NumSetterThreads, Thread[SetterArgs]]
-    for i in 0 ..< NumSetterThreads:
-      createThread(setters[i], setterThreadBody, (ctx, addr stop, addr evt))
-
-    var rsp: CallbackData
-    initCallbackData(rsp)
-    defer:
-      deinitCallbackData(rsp)
-
-    for _ in 0 ..< NumDispatchIters:
-      # Reset rsp so each iteration's `waitCallback` blocks until the
-      # FFI thread fires the response — keeps the loop synchronous.
-      acquire(rsp.lock)
-      rsp.called = false
-      release(rsp.lock)
-
-      check sendRequestToFFIThread(
-        ctx, EmitCborEventRequest.ffiNewReq(captureCb, addr rsp)
+      # Seed an initial callback so the FFI thread's first dispatch has a
+      # target. The setter threads will then repeatedly re-install the same
+      # (callback, userData) pair — what matters is the cross-thread write
+      # racing the FFI thread's read, not which pair "wins".
+      discard addEventListener(
+        ctx[].eventRegistry, WildcardEventName, captureCb, addr evt
       )
-        .isOk()
-      waitCallback(rsp)
 
-    stop.store(true)
-    for i in 0 ..< NumSetterThreads:
-      joinThread(setters[i])
+      const NumSetterThreads = 4
+      const NumDispatchIters = 200
 
-    # `evt` got hit by every dispatch above; just confirm at least one
-    # actually landed so a silently-broken dispatch loop is caught.
-    check evt.called
+      var stop: Atomic[bool]
+      stop.store(false)
+      var setters: array[NumSetterThreads, Thread[SetterArgs]]
+      for i in 0 ..< NumSetterThreads:
+        createThread(setters[i], setterThreadBody, (ctx, addr stop, addr evt))
+
+      var rsp: CallbackData
+      initCallbackData(rsp)
+      defer:
+        deinitCallbackData(rsp)
+
+      for _ in 0 ..< NumDispatchIters:
+        # Reset rsp so each iteration's `waitCallback` blocks until the
+        # FFI thread fires the response — keeps the loop synchronous.
+        acquire(rsp.lock)
+        rsp.called = false
+        release(rsp.lock)
+
+        check sendRequestToFFIThread(
+          ctx, EmitCborEventRequest.ffiNewReq(captureCb, addr rsp)
+        )
+          .isOk()
+        waitCallback(rsp)
+
+      stop.store(true)
+      for i in 0 ..< NumSetterThreads:
+        joinThread(setters[i])
+
+      # `evt` got hit by every dispatch above; just confirm at least one
+      # actually landed so a silently-broken dispatch loop is caught.
+      check evt.called
 
 # ---------------------------------------------------------------------------
 # Lock-during-invocation regression (issue #40 second concern)
 # ---------------------------------------------------------------------------
 
-## A foreign-thread `setCallback` must not be able to swap the callback +
-## userData pair while an in-flight dispatch is mid-invocation on the
-## previous pair. The dispatch templates now hold `callbackState.lock`
-## for the entire snapshot + invocation, so `setCallback` blocks until
-## dispatch returns.
-##
-## We don't use the FFI thread's request channel here because the request
-## handler runs synchronously on the FFI thread before
-## `reqReceivedSignal` fires — there'd be no way for the main thread to
-## observe the in-flight state. Instead, a worker thread directly drives
-## `dispatchFFIEvent` against a registry-of-one.
+## A foreign-thread mutation must not be able to invalidate the
+## listener's `userData` while an in-flight dispatch is mid-invocation.
+## The dispatch templates hold `reg.lock` for the entire snapshot +
+## invocation, so foreign `removeEventListener` blocks until dispatch
+## returns.
 
 type SlowState = object
   entered: Atomic[bool]
@@ -263,39 +262,40 @@ proc slowEventCb(
     retCode: cint, msg: ptr cchar, len: csize_t, userData: pointer
 ) {.cdecl, gcsafe, raises: [].} =
   ## Signal entry, sleep briefly (the window during which the main
-  ## thread must call setCallback and block), signal exit.
+  ## thread must call removeEventListener and block), signal exit.
   let st = cast[ptr SlowState](userData)
   st[].entered.store(true)
   os.sleep(15)
   st[].exited.store(true)
 
 type DispatcherArgs = tuple
-  state: ptr FFICallbackState
+  reg: ptr FFIEventRegistry
   done: ptr Atomic[bool]
 
 proc dispatcherBody(args: DispatcherArgs) {.thread.} =
-  ffiCurrentCallbackState = args.state
+  ffiCurrentEventRegistry = args.reg
   dispatchFFIEvent("evt"):
     "payload"
   args.done[].store(true)
 
-suite "callbackState lock held during invocation":
-  test "setCallback blocks until in-flight dispatch finishes":
-    var state: FFICallbackState
-    initCallbackState(state)
+suite "registry lock held during invocation":
+  test "removeEventListener blocks until in-flight dispatch finishes":
+    var reg: FFIEventRegistry
+    initEventRegistry(reg)
     defer:
-      deinitCallbackState(state)
+      deinitEventRegistry(reg)
 
     var st: SlowState
     st.entered.store(false)
     st.exited.store(false)
 
-    setCallback(state, cast[pointer](slowEventCb), addr st)
+    let id = addEventListener(reg, "evt", slowEventCb, addr st)
+    check id != 0'u64
 
     var done: Atomic[bool]
     done.store(false)
     var thr: Thread[DispatcherArgs]
-    createThread(thr, dispatcherBody, (addr state, addr done))
+    createThread(thr, dispatcherBody, (addr reg, addr done))
 
     # Wait until the worker thread is inside slowEventCb.
     for _ in 0 ..< 200:
@@ -305,10 +305,9 @@ suite "callbackState lock held during invocation":
     check st.entered.load()
     check not st.exited.load()
 
-    # Lock-during-invocation contract: setCallback blocks until the
-    # dispatch's lock is released, i.e. until slowEventCb has finished.
-    var other = SlowState() # dummy target; never invoked
-    setCallback(state, cast[pointer](slowEventCb), addr other)
+    # Lock-during-invocation contract: remove blocks until dispatch
+    # finishes; by the time it returns, slowEventCb has set exited=true.
+    check removeEventListener(reg, id)
     check st.exited.load()
     joinThread(thr)
     check done.load()

--- a/tests/unit/test_event_dispatch.nim
+++ b/tests/unit/test_event_dispatch.nim
@@ -7,7 +7,7 @@
 ## sendRequestToFFIThread) so we exercise the threadvar-backed
 ## ffiCurrentCallbackState wiring, not just the templates in isolation.
 
-import std/[locks]
+import std/[locks, os]
 import unittest2
 import results
 import ffi
@@ -238,3 +238,77 @@ suite "FFICallbackState concurrent access":
     # `evt` got hit by every dispatch above; just confirm at least one
     # actually landed so a silently-broken dispatch loop is caught.
     check evt.called
+
+# ---------------------------------------------------------------------------
+# Lock-during-invocation regression (issue #40 second concern)
+# ---------------------------------------------------------------------------
+
+## A foreign-thread `setCallback` must not be able to swap the callback +
+## userData pair while an in-flight dispatch is mid-invocation on the
+## previous pair. The dispatch templates now hold `callbackState.lock`
+## for the entire snapshot + invocation, so `setCallback` blocks until
+## dispatch returns.
+##
+## We don't use the FFI thread's request channel here because the request
+## handler runs synchronously on the FFI thread before
+## `reqReceivedSignal` fires — there'd be no way for the main thread to
+## observe the in-flight state. Instead, a worker thread directly drives
+## `dispatchFFIEvent` against a registry-of-one.
+
+type SlowState = object
+  entered: Atomic[bool]
+  exited: Atomic[bool]
+
+proc slowEventCb(
+    retCode: cint, msg: ptr cchar, len: csize_t, userData: pointer
+) {.cdecl, gcsafe, raises: [].} =
+  ## Signal entry, sleep briefly (the window during which the main
+  ## thread must call setCallback and block), signal exit.
+  let st = cast[ptr SlowState](userData)
+  st[].entered.store(true)
+  os.sleep(15)
+  st[].exited.store(true)
+
+type DispatcherArgs = tuple
+  state: ptr FFICallbackState
+  done: ptr Atomic[bool]
+
+proc dispatcherBody(args: DispatcherArgs) {.thread.} =
+  ffiCurrentCallbackState = args.state
+  dispatchFFIEvent("evt"):
+    "payload"
+  args.done[].store(true)
+
+suite "callbackState lock held during invocation":
+  test "setCallback blocks until in-flight dispatch finishes":
+    var state: FFICallbackState
+    initCallbackState(state)
+    defer:
+      deinitCallbackState(state)
+
+    var st: SlowState
+    st.entered.store(false)
+    st.exited.store(false)
+
+    setCallback(state, cast[pointer](slowEventCb), addr st)
+
+    var done: Atomic[bool]
+    done.store(false)
+    var thr: Thread[DispatcherArgs]
+    createThread(thr, dispatcherBody, (addr state, addr done))
+
+    # Wait until the worker thread is inside slowEventCb.
+    for _ in 0 ..< 200:
+      if st.entered.load():
+        break
+      os.sleep(1)
+    check st.entered.load()
+    check not st.exited.load()
+
+    # Lock-during-invocation contract: setCallback blocks until the
+    # dispatch's lock is released, i.e. until slowEventCb has finished.
+    var other = SlowState() # dummy target; never invoked
+    setCallback(state, cast[pointer](slowEventCb), addr other)
+    check st.exited.load()
+    joinThread(thr)
+    check done.load()


### PR DESCRIPTION
- Replace FFICallbackState field on FFIContext with eventRegistry of FFIEventRegistry. Remove FFICallbackState type + helpers + threadvar.
- Move EventEnvelope, dispatchFFIEvent, dispatchFFIEventCbor templates from ffi_context.nim into ffi_events.nim. Set ffiCurrentEventRegistry threadvar on the FFI thread.
- onNotResponding holds the registry lock for the entire invocation, matching the dispatch templates' lock-during-invocation contract.
- _set_event_callback C ABI now routes to removeAllEventListeners + addEventListener(WildcardEventName, ...) so the legacy shape keeps working until the ABI swap PR.
- test_event_dispatch migrates from setCallback to addEventListener; refc stress suite is gated since per-thread GC heaps can't safely realloc a shared seq across threads.