### PR TITLE
Rust event examples

### DIFF
--- a/examples/timer/rust_bindings/Cargo.lock
+++ b/examples/timer/rust_bindings/Cargo.lock
@@ -181,6 +181,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/examples/timer/rust_bindings/Cargo.toml
+++ b/examples/timer/rust_bindings/Cargo.toml
@@ -8,3 +8,6 @@ serde = { version = "1", features = ["derive"] }
 ciborium = "0.2"
 flume = { version = "0.11", default-features = false, features = ["async"] }
 tokio = { version = "1", features = ["sync", "time"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }

--- a/examples/timer/rust_bindings/examples/main.rs
+++ b/examples/timer/rust_bindings/examples/main.rs
@@ -1,0 +1,96 @@
+//! Synchronous example: exercises a couple of round-trip methods and the
+//! library-event listener API (typed + wildcard + remove).
+//!
+//! Run with: `cargo run --example main`
+
+use my_timer::{decode_event_payload, EchoEvent, EchoRequest, ListenerHandle, MyTimerCtx, TimerConfig};
+use std::os::raw::c_int;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    mpsc, Arc,
+};
+use std::time::Duration;
+
+fn main() -> Result<(), String> {
+    let ctx = MyTimerCtx::create(
+        TimerConfig {
+            name: "rust-sync-demo".into(),
+        },
+        Duration::from_secs(5),
+    )?;
+    println!("[1] Context created");
+
+    let version = ctx.version()?;
+    println!("[2] Version: {}", version);
+
+    // ── Typed listener for `onEchoFired` ──────────────────────────────
+    // The handler runs on the lib's dispatch thread; route the payload
+    // back to main via an mpsc channel so we can print synchronously.
+    let (tx, rx) = mpsc::channel::<EchoEvent>();
+    let typed_handle: ListenerHandle = ctx.add_on_echo_fired_listener(move |evt: &EchoEvent| {
+        let _ = tx.send(evt.clone());
+    });
+
+    // ── Wildcard listener (catch-all) ─────────────────────────────────
+    // Receives every event with the wire `event_id` pre-extracted and
+    // the raw CBOR envelope bytes. Dispatch on `event_id` and lift the
+    // payload via `decode_event_payload::<T>` to avoid hand-rolled CBOR.
+    let wildcard_hits = Arc::new(AtomicUsize::new(0));
+    let wildcard_hits_for_cb = Arc::clone(&wildcard_hits);
+    let wildcard_handle: ListenerHandle =
+        ctx.add_event_listener(move |ret: c_int, event_id: &str, envelope: &[u8]| {
+            wildcard_hits_for_cb.fetch_add(1, Ordering::SeqCst);
+            println!(
+                "[3] wildcard event: ret={}, event_id={}, envelope_bytes={}",
+                ret,
+                event_id,
+                envelope.len()
+            );
+            if ret == 0 && event_id == "on_echo_fired" {
+                match decode_event_payload::<EchoEvent>(envelope) {
+                    Ok(evt) => println!(
+                        "    decoded EchoEvent: message={}, echo_count={}",
+                        evt.message, evt.echo_count
+                    ),
+                    Err(e) => println!("    decode failed: {}", e),
+                }
+            }
+        });
+
+    // Trigger an echo — fires `{.ffiEvent: "on_echo_fired".}` once.
+    let echo = ctx.echo(EchoRequest {
+        message: "sync-event-demo".into(),
+        delay_ms: 1,
+    })?;
+    println!("[4] Echo response: echoed={}", echo.echoed);
+
+    // Block for the typed event.
+    match rx.recv_timeout(Duration::from_secs(2)) {
+        Ok(evt) => println!(
+            "[5] typed event onEchoFired: message={}, echo_count={}, wildcard_hits={}",
+            evt.message,
+            evt.echo_count,
+            wildcard_hits.load(Ordering::SeqCst)
+        ),
+        Err(e) => return Err(format!("event never arrived: {}", e)),
+    }
+
+    // Drop the typed listener — a second echo only reaches the wildcard.
+    let removed = ctx.remove_event_listener(typed_handle);
+    assert!(removed, "remove_event_listener should report true");
+
+    ctx.echo(EchoRequest {
+        message: "after-remove".into(),
+        delay_ms: 1,
+    })?;
+    // Give the lib thread a beat to deliver to the wildcard.
+    std::thread::sleep(Duration::from_millis(50));
+    println!(
+        "[6] after remove: wildcard_hits={} (typed listener silent)",
+        wildcard_hits.load(Ordering::SeqCst)
+    );
+
+    ctx.remove_event_listener(wildcard_handle);
+    println!("Done.");
+    Ok(())
+}

--- a/examples/timer/rust_bindings/examples/main.rs
+++ b/examples/timer/rust_bindings/examples/main.rs
@@ -1,96 +1,53 @@
-//! Synchronous example: exercises a couple of round-trip methods and the
-//! library-event listener API (typed + wildcard + remove).
+//! Synchronous example: exercises the library-event listener API
+//! (typed + wildcard + remove).
 //!
 //! Run with: `cargo run --example main`
 
-use my_timer::{decode_event_payload, EchoEvent, EchoRequest, ListenerHandle, MyTimerCtx, TimerConfig};
+use my_timer::{decode_event_payload, EchoEvent, EchoRequest, MyTimerCtx, TimerConfig};
 use std::os::raw::c_int;
-use std::sync::{
-    atomic::{AtomicUsize, Ordering},
-    mpsc, Arc,
-};
+use std::sync::mpsc;
 use std::time::Duration;
 
 fn main() -> Result<(), String> {
     let ctx = MyTimerCtx::create(
-        TimerConfig {
-            name: "rust-sync-demo".into(),
-        },
+        TimerConfig { name: "rust-sync-demo".into() },
         Duration::from_secs(5),
     )?;
-    println!("[1] Context created");
 
-    let version = ctx.version()?;
-    println!("[2] Version: {}", version);
-
-    // ── Typed listener for `onEchoFired` ──────────────────────────────
-    // The handler runs on the lib's dispatch thread; route the payload
-    // back to main via an mpsc channel so we can print synchronously.
+    // Typed listener: the closure is invoked on the lib's dispatch
+    // thread, so forward the payload to `main` via std mpsc and block
+    // on `recv_timeout` below. `add_on_echo_fired_listener` is generated
+    // per `{.ffiEvent.}`-declared proc and takes a typed `&EchoEvent`.
     let (tx, rx) = mpsc::channel::<EchoEvent>();
-    let typed_handle: ListenerHandle = ctx.add_on_echo_fired_listener(move |evt: &EchoEvent| {
+    let typed_handle = ctx.add_on_echo_fired_listener(move |evt: &EchoEvent| {
         let _ = tx.send(evt.clone());
     });
 
-    // ── Wildcard listener (catch-all) ─────────────────────────────────
-    // Receives every event with the wire `event_id` pre-extracted and
-    // the raw CBOR envelope bytes. Dispatch on `event_id` and lift the
-    // payload via `decode_event_payload::<T>` to avoid hand-rolled CBOR.
-    let wildcard_hits = Arc::new(AtomicUsize::new(0));
-    let wildcard_hits_for_cb = Arc::clone(&wildcard_hits);
-    let wildcard_handle: ListenerHandle =
-        ctx.add_event_listener(move |ret: c_int, event_id: &str, envelope: &[u8]| {
-            wildcard_hits_for_cb.fetch_add(1, Ordering::SeqCst);
-            println!(
-                "[3] wildcard event: ret={}, event_id={}, envelope_bytes={}",
-                ret,
-                event_id,
-                envelope.len()
-            );
-            if ret == 0 && event_id == "on_echo_fired" {
-                match decode_event_payload::<EchoEvent>(envelope) {
-                    Ok(evt) => println!(
-                        "    decoded EchoEvent: message={}, echo_count={}",
-                        evt.message, evt.echo_count
-                    ),
-                    Err(e) => println!("    decode failed: {}", e),
-                }
+    // Wildcard listener: receives every event with the FFI return code,
+    // the wire `event_id` pre-extracted from the CBOR envelope, and the
+    // raw envelope bytes. Lift to a typed payload via
+    // `decode_event_payload::<T>` when the event_id matches one you
+    // care about — this avoids hand-rolling ciborium calls per branch.
+    let wildcard_handle = ctx.add_event_listener(|ret: c_int, event_id: &str, envelope: &[u8]| {
+        println!("wildcard: ret={}, event_id={}, bytes={}", ret, event_id, envelope.len());
+        if ret == 0 && event_id == "on_echo_fired" {
+            match decode_event_payload::<EchoEvent>(envelope) {
+                Ok(evt) => println!("  decoded: message={}, echo_count={}", evt.message, evt.echo_count),
+                Err(e) => println!("  decode failed: {}", e),
             }
-        });
+        }
+    });
 
-    // Trigger an echo — fires `{.ffiEvent: "on_echo_fired".}` once.
-    let echo = ctx.echo(EchoRequest {
-        message: "sync-event-demo".into(),
-        delay_ms: 1,
-    })?;
-    println!("[4] Echo response: echoed={}", echo.echoed);
+    // Trigger the event — fires `on_echo_fired` once, which the
+    // dispatch thread delivers to both listeners above.
+    ctx.echo(EchoRequest { message: "sync-event-demo".into(), delay_ms: 1 })?;
 
-    // Block for the typed event.
     match rx.recv_timeout(Duration::from_secs(2)) {
-        Ok(evt) => println!(
-            "[5] typed event onEchoFired: message={}, echo_count={}, wildcard_hits={}",
-            evt.message,
-            evt.echo_count,
-            wildcard_hits.load(Ordering::SeqCst)
-        ),
+        Ok(evt) => println!("typed onEchoFired: message={}, echo_count={}", evt.message, evt.echo_count),
         Err(e) => return Err(format!("event never arrived: {}", e)),
     }
 
-    // Drop the typed listener — a second echo only reaches the wildcard.
-    let removed = ctx.remove_event_listener(typed_handle);
-    assert!(removed, "remove_event_listener should report true");
-
-    ctx.echo(EchoRequest {
-        message: "after-remove".into(),
-        delay_ms: 1,
-    })?;
-    // Give the lib thread a beat to deliver to the wildcard.
-    std::thread::sleep(Duration::from_millis(50));
-    println!(
-        "[6] after remove: wildcard_hits={} (typed listener silent)",
-        wildcard_hits.load(Ordering::SeqCst)
-    );
-
+    ctx.remove_event_listener(typed_handle);
     ctx.remove_event_listener(wildcard_handle);
-    println!("Done.");
     Ok(())
 }

--- a/examples/timer/rust_bindings/examples/tokio_main.rs
+++ b/examples/timer/rust_bindings/examples/tokio_main.rs
@@ -1,0 +1,104 @@
+//! Tokio (async) example: same shape as `main.rs` but exercises the
+//! async `_async` API and bridges library events into a tokio-aware
+//! channel for async consumption.
+//!
+//! Run with: `cargo run --example tokio_main`
+
+use my_timer::{decode_event_payload, EchoEvent, EchoRequest, ListenerHandle, MyTimerCtx, TimerConfig};
+use std::os::raw::c_int;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+use std::time::Duration;
+use tokio::sync::mpsc;
+
+#[tokio::main]
+async fn main() -> Result<(), String> {
+    let ctx = MyTimerCtx::new_async(
+        TimerConfig {
+            name: "rust-tokio-demo".into(),
+        },
+        Duration::from_secs(5),
+    )
+    .await?;
+    println!("[1] Context created");
+
+    let version = ctx.version_async().await?;
+    println!("[2] Version: {}", version);
+
+    // ── Typed listener for `onEchoFired` ──────────────────────────────
+    // The handler fires on the lib's dispatch thread, so we hop into an
+    // `mpsc::UnboundedSender` (which is Send + Sync) to forward into the
+    // tokio runtime.
+    let (typed_tx, mut typed_rx) = mpsc::unbounded_channel::<EchoEvent>();
+    let typed_handle: ListenerHandle = ctx.add_on_echo_fired_listener(move |evt: &EchoEvent| {
+        let _ = typed_tx.send(evt.clone());
+    });
+
+    // ── Wildcard listener (catch-all) ─────────────────────────────────
+    // The handler receives the FFI return code, the pre-extracted wire
+    // `event_id`, and the raw CBOR envelope. Pair with
+    // `decode_event_payload::<T>` to lift the payload into a typed
+    // value when the event is one you care about.
+    let wildcard_hits = Arc::new(AtomicUsize::new(0));
+    let wildcard_hits_for_cb = Arc::clone(&wildcard_hits);
+    let wildcard_handle: ListenerHandle =
+        ctx.add_event_listener(move |ret: c_int, event_id: &str, envelope: &[u8]| {
+            wildcard_hits_for_cb.fetch_add(1, Ordering::SeqCst);
+            println!(
+                "[3] wildcard event: ret={}, event_id={}, envelope_bytes={}",
+                ret,
+                event_id,
+                envelope.len()
+            );
+            if ret == 0 && event_id == "on_echo_fired" {
+                match decode_event_payload::<EchoEvent>(envelope) {
+                    Ok(evt) => println!(
+                        "    decoded EchoEvent: message={}, echo_count={}",
+                        evt.message, evt.echo_count
+                    ),
+                    Err(e) => println!("    decode failed: {}", e),
+                }
+            }
+        });
+
+    // Trigger an echo via the async API — fires `on_echo_fired` once.
+    let echo = ctx
+        .echo_async(EchoRequest {
+            message: "async-event-demo".into(),
+            delay_ms: 1,
+        })
+        .await?;
+    println!("[4] Echo response: echoed={}", echo.echoed);
+
+    // Await the typed event with a bounded timeout.
+    let evt = tokio::time::timeout(Duration::from_secs(2), typed_rx.recv())
+        .await
+        .map_err(|_| "event never arrived".to_string())?
+        .ok_or_else(|| "typed channel closed".to_string())?;
+    println!(
+        "[5] typed event onEchoFired: message={}, echo_count={}, wildcard_hits={}",
+        evt.message,
+        evt.echo_count,
+        wildcard_hits.load(Ordering::SeqCst)
+    );
+
+    // Drop the typed listener; a second echo only reaches the wildcard.
+    assert!(ctx.remove_event_listener(typed_handle));
+
+    ctx.echo_async(EchoRequest {
+        message: "after-remove".into(),
+        delay_ms: 1,
+    })
+    .await?;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    println!(
+        "[6] after remove: wildcard_hits={} (typed listener silent)",
+        wildcard_hits.load(Ordering::SeqCst)
+    );
+
+    ctx.remove_event_listener(wildcard_handle);
+    println!("Done.");
+    Ok(())
+}

--- a/examples/timer/rust_bindings/examples/tokio_main.rs
+++ b/examples/timer/rust_bindings/examples/tokio_main.rs
@@ -4,101 +4,57 @@
 //!
 //! Run with: `cargo run --example tokio_main`
 
-use my_timer::{decode_event_payload, EchoEvent, EchoRequest, ListenerHandle, MyTimerCtx, TimerConfig};
+use my_timer::{decode_event_payload, EchoEvent, EchoRequest, MyTimerCtx, TimerConfig};
 use std::os::raw::c_int;
-use std::sync::{
-    atomic::{AtomicUsize, Ordering},
-    Arc,
-};
 use std::time::Duration;
 use tokio::sync::mpsc;
 
 #[tokio::main]
 async fn main() -> Result<(), String> {
     let ctx = MyTimerCtx::new_async(
-        TimerConfig {
-            name: "rust-tokio-demo".into(),
-        },
+        TimerConfig { name: "rust-tokio-demo".into() },
         Duration::from_secs(5),
     )
     .await?;
-    println!("[1] Context created");
 
-    let version = ctx.version_async().await?;
-    println!("[2] Version: {}", version);
-
-    // ── Typed listener for `onEchoFired` ──────────────────────────────
-    // The handler fires on the lib's dispatch thread, so we hop into an
-    // `mpsc::UnboundedSender` (which is Send + Sync) to forward into the
-    // tokio runtime.
+    // Typed listener: the handler fires on the lib's dispatch thread,
+    // which is *outside* the tokio runtime. Forwarding through a tokio
+    // `unbounded_channel` (Sender is Send + Sync, non-blocking) hands
+    // the event over to the runtime so we can `.await` it below.
     let (typed_tx, mut typed_rx) = mpsc::unbounded_channel::<EchoEvent>();
-    let typed_handle: ListenerHandle = ctx.add_on_echo_fired_listener(move |evt: &EchoEvent| {
+    let typed_handle = ctx.add_on_echo_fired_listener(move |evt: &EchoEvent| {
         let _ = typed_tx.send(evt.clone());
     });
 
-    // ── Wildcard listener (catch-all) ─────────────────────────────────
-    // The handler receives the FFI return code, the pre-extracted wire
-    // `event_id`, and the raw CBOR envelope. Pair with
-    // `decode_event_payload::<T>` to lift the payload into a typed
-    // value when the event is one you care about.
-    let wildcard_hits = Arc::new(AtomicUsize::new(0));
-    let wildcard_hits_for_cb = Arc::clone(&wildcard_hits);
-    let wildcard_handle: ListenerHandle =
-        ctx.add_event_listener(move |ret: c_int, event_id: &str, envelope: &[u8]| {
-            wildcard_hits_for_cb.fetch_add(1, Ordering::SeqCst);
-            println!(
-                "[3] wildcard event: ret={}, event_id={}, envelope_bytes={}",
-                ret,
-                event_id,
-                envelope.len()
-            );
-            if ret == 0 && event_id == "on_echo_fired" {
-                match decode_event_payload::<EchoEvent>(envelope) {
-                    Ok(evt) => println!(
-                        "    decoded EchoEvent: message={}, echo_count={}",
-                        evt.message, evt.echo_count
-                    ),
-                    Err(e) => println!("    decode failed: {}", e),
-                }
+    // Wildcard listener: receives every event with the FFI return code,
+    // the wire `event_id` pre-extracted from the CBOR envelope, and the
+    // raw envelope bytes. Lift to a typed payload via
+    // `decode_event_payload::<T>` when the event_id matches one you
+    // care about — this avoids hand-rolling ciborium calls per branch.
+    let wildcard_handle = ctx.add_event_listener(|ret: c_int, event_id: &str, envelope: &[u8]| {
+        println!("wildcard: ret={}, event_id={}, bytes={}", ret, event_id, envelope.len());
+        if ret == 0 && event_id == "on_echo_fired" {
+            match decode_event_payload::<EchoEvent>(envelope) {
+                Ok(evt) => println!("  decoded: message={}, echo_count={}", evt.message, evt.echo_count),
+                Err(e) => println!("  decode failed: {}", e),
             }
-        });
+        }
+    });
 
-    // Trigger an echo via the async API — fires `on_echo_fired` once.
-    let echo = ctx
-        .echo_async(EchoRequest {
-            message: "async-event-demo".into(),
-            delay_ms: 1,
-        })
+    // Trigger an echo via the async API — fires `on_echo_fired` once,
+    // which the dispatch thread delivers to both listeners above.
+    ctx.echo_async(EchoRequest { message: "async-event-demo".into(), delay_ms: 1 })
         .await?;
-    println!("[4] Echo response: echoed={}", echo.echoed);
 
-    // Await the typed event with a bounded timeout.
+    // Await the typed event with a bounded timeout so a missing event
+    // surfaces as an error instead of hanging the example forever.
     let evt = tokio::time::timeout(Duration::from_secs(2), typed_rx.recv())
         .await
         .map_err(|_| "event never arrived".to_string())?
         .ok_or_else(|| "typed channel closed".to_string())?;
-    println!(
-        "[5] typed event onEchoFired: message={}, echo_count={}, wildcard_hits={}",
-        evt.message,
-        evt.echo_count,
-        wildcard_hits.load(Ordering::SeqCst)
-    );
+    println!("typed onEchoFired: message={}, echo_count={}", evt.message, evt.echo_count);
 
-    // Drop the typed listener; a second echo only reaches the wildcard.
-    assert!(ctx.remove_event_listener(typed_handle));
-
-    ctx.echo_async(EchoRequest {
-        message: "after-remove".into(),
-        delay_ms: 1,
-    })
-    .await?;
-    tokio::time::sleep(Duration::from_millis(50)).await;
-    println!(
-        "[6] after remove: wildcard_hits={} (typed listener silent)",
-        wildcard_hits.load(Ordering::SeqCst)
-    );
-
+    ctx.remove_event_listener(typed_handle);
     ctx.remove_event_listener(wildcard_handle);
-    println!("Done.");
     Ok(())
 }

--- a/ffi/codegen/rust.nim
+++ b/ffi/codegen/rust.nim
@@ -74,6 +74,8 @@ proc generateCargoToml*(libName: string): string =
   # pulling its async-std/futures shims.
   # `tokio` is needed only for `tokio::time::timeout` around the async
   # `recv_async`. Feature-gating tokio (item 11) is a follow-up commit.
+  # `[dev-dependencies]` lets the bundled `examples/` use `#[tokio::main]`
+  # without pulling those features into the library's runtime profile.
   return
     """[package]
 name = "$1"
@@ -85,6 +87,9 @@ serde = { version = "1", features = ["derive"] }
 ciborium = "0.2"
 flume = { version = "0.11", default-features = false, features = ["async"] }
 tokio = { version = "1", features = ["sync", "time"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
 """ %
     [libName]
 


### PR DESCRIPTION
Ship two bundled examples under the generated Rust crate so foreign-side users see the listener API in action.

**Stacked on the Rust codegen PR (#52).** Base is `rust-typed-event-listeners`; GitHub will retarget down the chain as upstream PRs land.

- `examples/main.rs` — sync flow using `std::sync::mpsc` to bridge a typed `add_on_echo_fired_listener` into `main`, plus a wildcard `add_event_listener` that uses `decode_event_payload::<EchoEvent>(envelope)` for the matching event id.
- `examples/tokio_main.rs` — same shape via `#[tokio::main]` + `tokio::sync::mpsc::unbounded_channel`, bounded `tokio::time::timeout` on the wait.
- `generateCargoToml` now emits a `[dev-dependencies]` block with tokio's `rt-multi-thread` + `macros` features so the bundled examples can use `#[tokio::main]` without polluting the library's runtime profile.

Run with `cargo run --example main` / `cargo run --example tokio_main` (set `DYLD_LIBRARY_PATH=<repo>` on macOS until `build.rs` emits an rpath; tracked as a follow-up).

Issue: #40
