### PR TITLE
feat(ffi): native event delivery + dual-ABI event symbols (C + Go)

### DIFF
--- a/examples/echo/cpp_bindings/echo.hpp
+++ b/examples/echo/cpp_bindings/echo.hpp
@@ -407,7 +407,7 @@ void* echo_create_cbor(const uint8_t* req_cbor, size_t req_cbor_len, FFICallback
 int echo_shout_cbor(void* ctx, FFICallback callback, void* user_data, const uint8_t* req_cbor, size_t req_cbor_len);
 int echo_version_cbor(void* ctx, FFICallback callback, void* user_data, const uint8_t* req_cbor, size_t req_cbor_len);
 int echo_destroy(void* ctx);
-uint64_t echo_add_event_listener(void* ctx, const char* event_name, FFICallback callback, void* user_data);
+uint64_t echo_add_event_listener_cbor(void* ctx, const char* event_name, FFICallback callback, void* user_data);
 int echo_remove_event_listener(void* ctx, uint64_t listener_id);
 } // extern "C"
 

--- a/examples/timer/c_bindings/my_timer.h
+++ b/examples/timer/c_bindings/my_timer.h
@@ -111,6 +111,8 @@ int my_timer_schedule(void *ctx, FFICallBack callback, void *userData, JobSpec j
 
 int my_timer_destroy(void *ctx);
 
+// Native event payloads — cast the callback's msg accordingly:
+//   "on_echo_fired"  ->  const EchoEvent *
 uint64_t my_timer_add_event_listener(void *ctx, const char *eventName, FFICallBack callback, void *userData);
 int my_timer_remove_event_listener(void *ctx, uint64_t listenerId);
 

--- a/examples/timer/c_bindings/my_timer_cbor.h
+++ b/examples/timer/c_bindings/my_timer_cbor.h
@@ -168,7 +168,7 @@ int my_timer_schedule_cbor(void *ctx, FFICallBack callback, void *userData, cons
 
 int my_timer_destroy(void *ctx);
 
-uint64_t my_timer_add_event_listener(void *ctx, const char *eventName, FFICallBack callback, void *userData);
+uint64_t my_timer_add_event_listener_cbor(void *ctx, const char *eventName, FFICallBack callback, void *userData);
 int my_timer_remove_event_listener(void *ctx, uint64_t listenerId);
 
 #ifdef __cplusplus

--- a/examples/timer/cpp_bindings/my_timer.hpp
+++ b/examples/timer/cpp_bindings/my_timer.hpp
@@ -708,7 +708,7 @@ int my_timer_version_cbor(void* ctx, FFICallback callback, void* user_data, cons
 int my_timer_complex_cbor(void* ctx, FFICallback callback, void* user_data, const uint8_t* req_cbor, size_t req_cbor_len);
 int my_timer_schedule_cbor(void* ctx, FFICallback callback, void* user_data, const uint8_t* req_cbor, size_t req_cbor_len);
 int my_timer_destroy(void* ctx);
-uint64_t my_timer_add_event_listener(void* ctx, const char* event_name, FFICallback callback, void* user_data);
+uint64_t my_timer_add_event_listener_cbor(void* ctx, const char* event_name, FFICallback callback, void* user_data);
 int my_timer_remove_event_listener(void* ctx, uint64_t listener_id);
 } // extern "C"
 
@@ -846,7 +846,7 @@ public:
     ListenerHandle addOnEchoFiredListener(std::function<void(const EchoEvent&)> handler) {
         auto owned = std::make_unique<TypedListener<EchoEvent>>(std::move(handler));
         auto* raw = owned.get();
-        const auto id = my_timer_add_event_listener(
+        const auto id = my_timer_add_event_listener_cbor(
             ptr_, "on_echo_fired", &MyTimerCtx::typedTrampoline<EchoEvent>, raw);
         if (id == 0) return ListenerHandle{0};
         listeners_.emplace(id, std::move(owned));
@@ -856,7 +856,7 @@ public:
     ListenerHandle addEventListener(std::function<void(int, const std::string&, std::span<const std::uint8_t>)> handler) {
         auto owned = std::make_unique<WildcardListener>(std::move(handler));
         auto* raw = owned.get();
-        const auto id = my_timer_add_event_listener(
+        const auto id = my_timer_add_event_listener_cbor(
             ptr_, "", &MyTimerCtx::wildcardTrampoline, raw);
         if (id == 0) return ListenerHandle{0};
         listeners_.emplace(id, std::move(owned));

--- a/examples/timer/go_bindings/example/main.go
+++ b/examples/timer/go_bindings/example/main.go
@@ -31,11 +31,22 @@ func main() {
 		fmt.Printf("version: %s\n", v)
 	}
 
+	// Native typed event: Echo fires onEchoFired(EchoEvent) inside the library.
+	// Register a typed handler — the payload arrives as a Go struct, no CBOR.
+	events := make(chan timer.EchoEvent, 4)
+	node.OnEchoFired(func(e timer.EchoEvent) { events <- e })
+
 	// Struct param + typed struct return: EchoResponse { Echoed; TimerName }.
 	if resp, err := node.Echo(timer.EchoRequest{Message: "hello from Go", DelayMs: 5}); err != nil {
 		log.Printf("echo: %v", err)
 	} else {
 		fmt.Printf("echo: echoed=%q timerName=%q\n", resp.Echoed, resp.TimerName)
+	}
+	select {
+	case e := <-events:
+		fmt.Printf("event OnEchoFired: message=%q echoCount=%d\n", e.Message, e.EchoCount)
+	default:
+		fmt.Println("event OnEchoFired: (none received)")
 	}
 
 	// Deeply nested param + typed return: slice of structs, slice of strings,

--- a/examples/timer/go_bindings/my_timer.go
+++ b/examples/timer/go_bindings/my_timer.go
@@ -10,6 +10,7 @@ package my_timer
 #include <pthread.h>
 
 extern void my_timerGoEvent(int ret, char* msg, size_t len, void* userData);
+extern uint64_t my_timer_add_event_listener_cbor(void* ctx, const char* eventName, FFICallBack callback, void* userData);
 extern void my_timerResultEcho(int ret, char* msg, size_t len, void* ud);
 extern void my_timerResultComplex(int ret, char* msg, size_t len, void* ud);
 extern void my_timerResultSchedule(int ret, char* msg, size_t len, void* ud);
@@ -60,7 +61,7 @@ static int my_timerCall_my_timer_version(void* ctx, My_timerResp* r) {
   return rc;
 }
 static int my_timerCall_my_timer_destroy(void* ctx) { return my_timer_destroy(ctx); }
-static uint64_t my_timerRegisterEvents(void* ctx) { return my_timer_add_event_listener(ctx, "", (FFICallBack)my_timerGoEvent, ctx); }
+static uint64_t my_timerRegisterEvents(void* ctx) { return my_timer_add_event_listener_cbor(ctx, "", (FFICallBack)my_timerGoEvent, ctx); }
 */
 import "C"
 

--- a/examples/timer/go_bindings/my_timer.go
+++ b/examples/timer/go_bindings/my_timer.go
@@ -14,6 +14,7 @@ extern uint64_t my_timer_add_event_listener_cbor(void* ctx, const char* eventNam
 extern void my_timerResultEcho(int ret, char* msg, size_t len, void* ud);
 extern void my_timerResultComplex(int ret, char* msg, size_t len, void* ud);
 extern void my_timerResultSchedule(int ret, char* msg, size_t len, void* ud);
+extern void my_timerEvtOnEchoFired(int ret, char* msg, size_t len, void* ud);
 
 typedef struct {
   int ret; char* msg; size_t len; int done;
@@ -471,6 +472,28 @@ func my_timerGoEvent(ret C.int, msg *C.char, length C.size_t, userData unsafe.Po
 	eventMu.Unlock()
 	if h != nil && ret == C.RET_OK {
 		h(C.GoStringN(msg, C.int(length)))
+	}
+}
+
+var evtOnEchoFiredHandler func(EchoEvent)
+
+// OnEchoFired installs the native typed handler for the "on_echo_fired" event.
+func (n *My_timerNode) OnEchoFired(h func(EchoEvent)) {
+	eventMu.Lock()
+	evtOnEchoFiredHandler = h
+	eventMu.Unlock()
+	cn := C.CString("on_echo_fired")
+	defer C.free(unsafe.Pointer(cn))
+	C.my_timer_add_event_listener(n.ctx, cn, C.FFICallBack(C.my_timerEvtOnEchoFired), n.ctx)
+}
+
+//export my_timerEvtOnEchoFired
+func my_timerEvtOnEchoFired(ret C.int, msg *C.char, length C.size_t, ud unsafe.Pointer) {
+	eventMu.Lock()
+	h := evtOnEchoFiredHandler
+	eventMu.Unlock()
+	if h != nil && ret == C.RET_OK {
+		h(EchoEventFromC((*C.EchoEvent)(unsafe.Pointer(msg))))
 	}
 }
 

--- a/examples/timer/rust_bindings/src/api.rs
+++ b/examples/timer/rust_bindings/src/api.rs
@@ -219,7 +219,7 @@ impl MyTimerCtx {
         owned: Box<dyn std::any::Any + Send>,
     ) -> ListenerHandle {
         let id = unsafe {
-            ffi::my_timer_add_event_listener(self.ptr, event_name, callback, raw)
+            ffi::my_timer_add_event_listener_cbor(self.ptr, event_name, callback, raw)
         };
         if id != 0 {
             self.listeners.lock().unwrap().insert(id, owned);

--- a/examples/timer/rust_bindings/src/ffi.rs
+++ b/examples/timer/rust_bindings/src/ffi.rs
@@ -15,6 +15,6 @@ extern "C" {
     pub fn my_timer_complex_cbor(ctx: *mut c_void, callback: FFICallback, user_data: *mut c_void, req_cbor: *const u8, req_cbor_len: usize) -> c_int;
     pub fn my_timer_schedule_cbor(ctx: *mut c_void, callback: FFICallback, user_data: *mut c_void, req_cbor: *const u8, req_cbor_len: usize) -> c_int;
     pub fn my_timer_destroy(ctx: *mut c_void) -> c_int;
-    pub fn my_timer_add_event_listener(ctx: *mut c_void, event_name: *const c_char, callback: FFICallback, user_data: *mut c_void) -> u64;
+    pub fn my_timer_add_event_listener_cbor(ctx: *mut c_void, event_name: *const c_char, callback: FFICallback, user_data: *mut c_void) -> u64;
     pub fn my_timer_remove_event_listener(ctx: *mut c_void, listener_id: u64) -> c_int;
 }

--- a/ffi.nimble
+++ b/ffi.nimble
@@ -146,19 +146,22 @@ task genbindings_rust, "Generate Rust bindings for the timer example":
     " -d:ffiSrcPath=../timer.nim" &
     " -o:/dev/null examples/timer/timer.nim"
 
-task genbindings_c, "Generate C bindings for the timer example":
-  exec "nim c " & nimFlagsOrc &
-    " --app:lib --noMain --nimMainPrefix:libmy_timer" &
-    " -d:ffiGenBindings -d:targetLang=c" &
-    " -d:ffiOutputDir=examples/timer/c_bindings" &
-    " -d:ffiSrcPath=../timer.nim" &
-    " -o:/dev/null examples/timer/timer.nim"
-  exec "nim c " & nimFlagsRefc &
-    " --app:lib --noMain --nimMainPrefix:libmy_timer" &
-    " -d:ffiGenBindings -d:targetLang=c" &
-    " -d:ffiOutputDir=examples/timer/c_bindings" &
-    " -d:ffiSrcPath=../timer.nim" &
-    " -o:/dev/null examples/timer/timer.nim"
+# `mode` selects the ABI to emit: "native", "cbor", or "both" (-d:ffiMode).
+proc genC(mode: string) =
+  for flags in [nimFlagsOrc, nimFlagsRefc]:
+    exec "nim c " & flags & " --app:lib --noMain --nimMainPrefix:libmy_timer" &
+      " -d:ffiGenBindings -d:targetLang=c -d:ffiMode=" & mode &
+      " -d:ffiOutputDir=examples/timer/c_bindings -d:ffiSrcPath=../timer.nim" &
+      " -o:/dev/null examples/timer/timer.nim"
+
+task genbindings_c, "Generate C bindings (native + CBOR) for the timer example":
+  genC("both")
+
+task genbindings_c_native, "Generate only the native C bindings (<lib>.h)":
+  genC("native")
+
+task genbindings_c_cbor, "Generate only the CBOR C bindings (<lib>_cbor.h)":
+  genC("cbor")
 
 task genbindings_go, "Generate Go (cgo) bindings for the timer example":
   exec "nim c " & nimFlagsOrc &

--- a/ffi/codegen/c.nim
+++ b/ffi/codegen/c.nim
@@ -167,8 +167,13 @@ proc generateCHeader*(
     lines.add("")
 
   # `declareLibrary` always exports the listener-registration ABI. The native
-  # header advertises the native listener: the callback's msg is a typed
-  # `const <Event>*` (cast it), not CBOR.
+  # listener delivers the payload as a typed struct: on RET_OK the callback's
+  # `msg` is a `const <Event>*` (cast it; valid only for the callback), keyed by
+  # the registered event name below.
+  if events.len > 0:
+    lines.add("// Native event payloads — cast the callback's msg accordingly:")
+    for e in events:
+      lines.add("//   \"" & e.wireName & "\"  ->  const " & e.payloadTypeName & " *")
   lines.add(
     "uint64_t " & libName &
       "_add_event_listener(void *ctx, const char *eventName, FFICallBack callback, void *userData);"
@@ -401,12 +406,14 @@ proc generateCBindings*(
     nimSrcRelPath: string,
     events: seq[FFIEventMeta] = @[],
 ) =
-  # Emit both ABIs so consumers can choose per call site: the native (zero-copy,
-  # same-process) one and the CBOR (boundary-crossing / generic) one.
-  writeFile(
-    outputDir / (libName & ".h"), generateCHeader(procs, types, libName, events)
-  )
-  writeFile(
-    outputDir / (libName & "_cbor.h"),
-    generateCborCHeader(procs, types, libName, events),
-  )
+  # Emit the ABI(s) selected by -d:ffiMode (default both): the native (zero-copy,
+  # same-process) header and/or the CBOR (boundary-crossing / generic) one.
+  if ffiEmitNative():
+    writeFile(
+      outputDir / (libName & ".h"), generateCHeader(procs, types, libName, events)
+    )
+  if ffiEmitCbor():
+    writeFile(
+      outputDir / (libName & "_cbor.h"),
+      generateCborCHeader(procs, types, libName, events),
+    )

--- a/ffi/codegen/c.nim
+++ b/ffi/codegen/c.nim
@@ -166,7 +166,9 @@ proc generateCHeader*(
       )
     lines.add("")
 
-  # `declareLibrary` always exports the listener-registration ABI.
+  # `declareLibrary` always exports the listener-registration ABI. The native
+  # header advertises the native listener: the callback's msg is a typed
+  # `const <Event>*` (cast it), not CBOR.
   lines.add(
     "uint64_t " & libName &
       "_add_event_listener(void *ctx, const char *eventName, FFICallBack callback, void *userData);"
@@ -378,7 +380,7 @@ proc generateCborCHeader*(
 
   lines.add(
     "uint64_t " & libName &
-      "_add_event_listener(void *ctx, const char *eventName, FFICallBack callback, void *userData);"
+      "_add_event_listener_cbor(void *ctx, const char *eventName, FFICallBack callback, void *userData);"
   )
   lines.add(
     "int " & libName & "_remove_event_listener(void *ctx, uint64_t listenerId);"

--- a/ffi/codegen/cpp.nim
+++ b/ffi/codegen/cpp.nim
@@ -178,7 +178,7 @@ proc emitEventDispatcher(
     )
     lines.add("        auto* raw = owned.get();")
     lines.add(
-      "        const auto id = $1_add_event_listener(" % [libName]
+      "        const auto id = $1_add_event_listener_cbor(" % [libName]
     )
     lines.add(
       "            ptr_, \"$1\", &$2::typedTrampoline<$3>, raw);" %
@@ -204,7 +204,7 @@ proc emitEventDispatcher(
     "        auto owned = std::make_unique<WildcardListener>(std::move(handler));"
   )
   lines.add("        auto* raw = owned.get();")
-  lines.add("        const auto id = $1_add_event_listener(" % [libName])
+  lines.add("        const auto id = $1_add_event_listener_cbor(" % [libName])
   lines.add(
     "            ptr_, \"\", &$1::wildcardTrampoline, raw);" % [ctxTypeName]
   )
@@ -429,7 +429,7 @@ proc generateCppHeader*(
   # `declareLibrary` always exports the listener-registration ABI. Declare
   # it here so the typed event-handler wiring below can call into it.
   lines.add(
-    "uint64_t $1_add_event_listener(void* ctx, const char* event_name, FFICallback callback, void* user_data);" %
+    "uint64_t $1_add_event_listener_cbor(void* ctx, const char* event_name, FFICallback callback, void* user_data);" %
       [libName]
   )
   lines.add(

--- a/ffi/codegen/go.nim
+++ b/ffi/codegen/go.nim
@@ -385,6 +385,14 @@ proc generateGoFile*(
         "extern void " & libName & "Result" & methodName(p.procName, libName) &
           "(int ret, char* msg, size_t len, void* ud);"
       )
+  # One exported Go callback per event (native typed delivery): msg is a typed
+  # `const <Payload>*` that the callback reads into a Go value.
+  for e in events:
+    if isFFIStruct(e.payloadTypeName, types):
+      L.add(
+        "extern void " & libName & "Evt" & snakeToPascalCase(e.wireName) &
+          "(int ret, char* msg, size_t len, void* ud);"
+      )
   L.add("")
   L.add("typedef struct {")
   L.add("  int ret; char* msg; size_t len; int done;")
@@ -564,6 +572,47 @@ proc generateGoFile*(
   L.add("\t}")
   L.add("}")
   L.add("")
+
+  # ---- per-event NATIVE typed handlers -------------------------------------
+  # `On<Event>(h)` registers a native listener; the library delivers the typed
+  # `<Payload>` POD, which the exported callback reads into a Go value and hands
+  # to `h`. No CBOR — this is the same-process path (cf. SetEventHandler).
+  for e in events:
+    if not isFFIStruct(e.payloadTypeName, types):
+      continue
+    let pascal = snakeToPascalCase(e.wireName)
+    let goType = e.payloadTypeName
+    let handlerVar = "evt" & pascal & "Handler"
+    let cbName = libName & "Evt" & pascal
+    L.add("var " & handlerVar & " func(" & goType & ")")
+    L.add("")
+    L.add("// " & pascal & " installs the native typed handler for the \"" &
+      e.wireName & "\" event.")
+    L.add("func (n *" & nodeType & ") " & pascal & "(h func(" & goType & ")) {")
+    L.add("\teventMu.Lock()")
+    L.add("\t" & handlerVar & " = h")
+    L.add("\teventMu.Unlock()")
+    L.add("\tcn := C.CString(\"" & e.wireName & "\")")
+    L.add("\tdefer C.free(unsafe.Pointer(cn))")
+    L.add(
+      "\tC." & libName & "_add_event_listener(n.ctx, cn, C.FFICallBack(C." & cbName &
+        "), n.ctx)"
+    )
+    L.add("}")
+    L.add("")
+    L.add("//export " & cbName)
+    L.add(
+      "func " & cbName &
+        "(ret C.int, msg *C.char, length C.size_t, ud unsafe.Pointer) {"
+    )
+    L.add("\teventMu.Lock()")
+    L.add("\th := " & handlerVar)
+    L.add("\teventMu.Unlock()")
+    L.add("\tif h != nil && ret == C.RET_OK {")
+    L.add("\t\th(" & goType & "FromC((*C." & goType & ")(unsafe.Pointer(msg))))")
+    L.add("\t}")
+    L.add("}")
+    L.add("")
 
   # ---- constructor ---------------------------------------------------------
   if haveCtor:

--- a/ffi/codegen/go.nim
+++ b/ffi/codegen/go.nim
@@ -370,6 +370,12 @@ proc generateGoFile*(
   L.add(
     "extern void " & libName & "GoEvent(int ret, char* msg, size_t len, void* userData);"
   )
+  # The Go wrapper consumes events over CBOR; the native header only declares the
+  # native listener, so forward-declare the CBOR registration we call below.
+  L.add(
+    "extern uint64_t " & libName &
+      "_add_event_listener_cbor(void* ctx, const char* eventName, FFICallBack callback, void* userData);"
+  )
   # One exported Go result callback per struct-returning proc (it reads the typed
   # return POD in-callback). Forward-declared here so cgo's `char*` shape matches.
   for p in procs:
@@ -491,7 +497,7 @@ proc generateGoFile*(
     )
   L.add(
     "static uint64_t " & libName & "RegisterEvents(void* ctx) { return " & libName &
-      "_add_event_listener(ctx, \"\", (FFICallBack)" & libName & "GoEvent, ctx); }"
+      "_add_event_listener_cbor(ctx, \"\", (FFICallBack)" & libName & "GoEvent, ctx); }"
   )
   L.add("*/")
   L.add("import \"C\"")

--- a/ffi/codegen/meta.nim
+++ b/ffi/codegen/meta.nim
@@ -49,6 +49,16 @@ var currentLibName* {.compileTime.}: string
 # Target language for binding generation; override with -d:targetLang=cpp
 const targetLang* {.strdefine.} = "rust"
 
+# Which ABI(s) to emit: "native" (zero-serialization C structs), "cbor"
+# (inter-process), or "both" (default). Override with -d:ffiMode=native.
+const ffiMode* {.strdefine.} = "both"
+
+func ffiEmitNative*(): bool =
+  ffiMode == "native" or ffiMode == "both"
+
+func ffiEmitCbor*(): bool =
+  ffiMode == "cbor" or ffiMode == "both"
+
 # Output directory for generated bindings; set with -d:ffiOutputDir=path/to/dir
 const ffiOutputDir* {.strdefine.} = ""
 

--- a/ffi/codegen/rust.nim
+++ b/ffi/codegen/rust.nim
@@ -213,7 +213,7 @@ proc generateFFIRs*(procs: seq[FFIProcMeta]): string =
   # Listener-registration ABI — emitted on the Nim side by `declareLibrary`,
   # always present in the dylib.
   lines.add(
-    "    pub fn $1_add_event_listener(ctx: *mut c_void, event_name: *const c_char, callback: FFICallback, user_data: *mut c_void) -> u64;" %
+    "    pub fn $1_add_event_listener_cbor(ctx: *mut c_void, event_name: *const c_char, callback: FFICallback, user_data: *mut c_void) -> u64;" %
       [linkLibName]
   )
   lines.add(
@@ -709,7 +709,7 @@ proc generateApiRs*(
     lines.add("    ) -> ListenerHandle {")
     lines.add("        let id = unsafe {")
     lines.add(
-      "            ffi::$1_add_event_listener(self.ptr, event_name, callback, raw)" %
+      "            ffi::$1_add_event_listener_cbor(self.ptr, event_name, callback, raw)" %
         [libName]
     )
     lines.add("        };")

--- a/ffi/ffi_events.nim
+++ b/ffi/ffi_events.nim
@@ -41,6 +41,10 @@ type
     id*: uint64
     callback*: FFICallBack
     userData*: pointer
+    native*: bool
+      ## true  -> deliver the payload as a typed `<T>Pod` by pointer (zero
+      ##          serialization, same-process). false -> deliver the CBOR
+      ##          `EventEnvelope` bytes (inter-process).
 
   FFIEventRegistry* = object
     ## Per-context multi-listener registry. `lock` guards every mutation;
@@ -88,11 +92,13 @@ proc addEventListener*(
     eventName: string,
     callback: FFICallBack,
     userData: pointer,
+    native = false,
 ): uint64 {.raises: [].} =
   ## Registers `callback` for `eventName` and returns the listener's stable
   ## id (always non-zero on success). `eventName == ""` registers a wildcard
-  ## listener that receives every dispatched event. Returns 0 if `callback`
-  ## is nil — the only documented failure mode.
+  ## listener that receives every dispatched event. `native` selects the
+  ## payload form delivered on dispatch (typed `<T>Pod` pointer vs CBOR bytes).
+  ## Returns 0 if `callback` is nil — the only documented failure mode.
   if callback.isNil():
     return 0
 
@@ -101,8 +107,9 @@ proc addEventListener*(
   withLock reg.lock:
     reg.nextId.inc()
     assigned = reg.nextId
-    let listener =
-      FFIEventListener(id: assigned, callback: callback, userData: userData)
+    let listener = FFIEventListener(
+      id: assigned, callback: callback, userData: userData, native: native
+    )
     if eventName.len == 0:
       reg.wildcard.add(listener)
     else:
@@ -251,3 +258,45 @@ template dispatchFFIEventCbor*(eventName: string, eventPayload: typed) =
       listener.callback(
         RET_OK, cast[ptr cchar](data), cast[csize_t](dataLen), listener.userData
       )
+
+template dispatchFFIEventDual*(eventName: string, eventPayload: typed) =
+  ## Dual-ABI event dispatch used by `{.ffiEvent.}` procs — the event-side
+  ## mirror of the native/CBOR request split. Native listeners get the payload
+  ## as a typed `<T>Pod` by pointer (zero serialization, valid only for the
+  ## callback's lifetime); CBOR listeners get the `EventEnvelope` bytes. Each
+  ## form is built at most once per dispatch and fanned out to its listeners.
+  ##
+  ## `nimToPod`/`freePod` are the per-type POD machinery generated next to each
+  ## `{.ffi.}` event type; `mixin` resolves them in the dispatching module.
+  mixin nimToPod, freePod
+  withFFIEventDispatch(eventName, listeners):
+    var nativeBuilt = false
+    var nativePod: typeof(nimToPod(eventPayload))
+    var cborBuilt = false
+    var cborData: ptr UncheckedArray[byte]
+    var cborLen: int
+    defer:
+      if nativeBuilt:
+        freePod(nativePod)
+      if cborBuilt:
+        cborFreeShared(cborData)
+    for listener in listeners:
+      if listener.native:
+        if not nativeBuilt:
+          nativePod = nimToPod(eventPayload)
+          nativeBuilt = true
+        listener.callback(
+          RET_OK, cast[ptr cchar](addr nativePod), sizeof(nativePod).csize_t,
+          listener.userData,
+        )
+      else:
+        if not cborBuilt:
+          (cborData, cborLen) = cborEncodeShared(
+            EventEnvelope[typeof(eventPayload)](
+              eventType: eventName, payload: eventPayload
+            )
+          )
+          cborBuilt = true
+        listener.callback(
+          RET_OK, cast[ptr cchar](cborData), cborLen.csize_t, listener.userData
+        )

--- a/ffi/internal/ffi_library.nim
+++ b/ffi/internal/ffi_library.nim
@@ -134,7 +134,21 @@ macro declareLibrary*(libraryName: static[string], libType: untyped): untyped =
     newTree(nnkExprColonExpr, ident("raises"), newTree(nnkBracket)),
   )
 
-  # {libraryName}_add_event_listener
+  # Event registration mirrors the request naming convention: the bare
+  # `<lib>_add_event_listener` is the NATIVE (typed `<T>Pod` payload) entry
+  # point; `<lib>_add_event_listener_cbor` is the CBOR (EventEnvelope bytes) one.
+  # Both are exported — native for same-process consumers, CBOR for inter-process.
+  # Fresh param nodes per proc — AST nodes must not be shared across two procs.
+  proc evtParams(): seq[NimNode] =
+    @[
+      ident("uint64"),
+      newIdentDefs(ident("ctx"), ctxType.copyNimTree()),
+      newIdentDefs(ident("eventName"), ident("cstring")),
+      newIdentDefs(ident("callback"), ident("FFICallBack")),
+      newIdentDefs(ident("userData"), ident("pointer")),
+    ]
+
+  # {libraryName}_add_event_listener (native)
   let addName = libraryName & "_add_event_listener"
   let addErr = "error: invalid context in " & addName
   let addBody = quote:
@@ -143,20 +157,33 @@ macro declareLibrary*(libraryName: static[string], libType: untyped): untyped =
       echo `addErr`
       return ret
     let evtName = if eventName.isNil(): "" else: $eventName
+    ret = addEventListener(
+      ctx[].eventRegistry, evtName, callback, userData, native = true
+    )
+    return ret
+
+  stmts.add(
+    newProc(
+      name = ident(addName), params = evtParams(), body = addBody,
+      pragmas = cdeclExportPragma,
+    )
+  )
+
+  # {libraryName}_add_event_listener_cbor (CBOR / inter-process)
+  let addCborName = libraryName & "_add_event_listener_cbor"
+  let addCborErr = "error: invalid context in " & addCborName
+  let addCborBody = quote:
+    var ret: uint64 = 0
+    if isNil(ctx):
+      echo `addCborErr`
+      return ret
+    let evtName = if eventName.isNil(): "" else: $eventName
     ret = addEventListener(ctx[].eventRegistry, evtName, callback, userData)
     return ret
 
   stmts.add(
     newProc(
-      name = ident(addName),
-      params = @[
-        ident("uint64"),
-        newIdentDefs(ident("ctx"), ctxType),
-        newIdentDefs(ident("eventName"), ident("cstring")),
-        newIdentDefs(ident("callback"), ident("FFICallBack")),
-        newIdentDefs(ident("userData"), ident("pointer")),
-      ],
-      body = addBody,
+      name = ident(addCborName), params = evtParams(), body = addCborBody,
       pragmas = cdeclExportPragma,
     )
   )

--- a/ffi/internal/ffi_macro.nim
+++ b/ffi/internal/ffi_macro.nim
@@ -1887,10 +1887,11 @@ macro ffiEvent*(wireName: static[string], prc: untyped): untyped =
   if procName.kind == nnkPostfix:
     userProcName = procName[1]
 
-  # The generated body: dispatchFFIEventCbor("wire_name", payload).
+  # The generated body: dispatchFFIEventDual("wire_name", payload) — delivers a
+  # typed POD to native listeners and CBOR bytes to CBOR listeners.
   let wireNameLit = newStrLitNode(wireName)
   let dispatchBody =
-    newStmtList(newCall(ident("dispatchFFIEventCbor"), wireNameLit, payloadParamName))
+    newStmtList(newCall(ident("dispatchFFIEventDual"), wireNameLit, payloadParamName))
 
   var newParams = newSeq[NimNode]()
   newParams.add(formalParams[0]) # return type (typically empty/void)

--- a/tests/unit/test_native_events.nim
+++ b/tests/unit/test_native_events.nim
@@ -1,0 +1,165 @@
+## Native (zero-serialization) event delivery: a `{.ffiEvent.}` now fans out to
+## both kinds of listener at once — native listeners receive the payload as a
+## typed `<T>Pod` by pointer, CBOR listeners receive the `EventEnvelope` bytes.
+## Mirrors the native/CBOR split already in place for requests.
+##
+## The CBOR side is covered more broadly in test_event_dispatch; here we pin the
+## *native* path and that both fire from one dispatch. Runs under orc + refc.
+
+import std/[locks]
+import unittest2
+import results
+import ffi
+
+type EvtLib = object
+
+type NativeEvt {.ffi.} = object
+  message: string
+  count: int
+  tags: seq[string]
+  ok: bool
+
+proc onNativeEvt(evt: NativeEvt) {.ffiEvent: "native_evt".}
+
+proc sampleEvt(): NativeEvt =
+  NativeEvt(message: "hello", count: 7, tags: @["a", "", "ccc"], ok: true)
+
+# A request that fires the event from the FFI thread, then returns.
+registerReqFFI(EmitEvtRequest, lib: ptr EvtLib):
+  proc(): Future[Result[string, string]] {.async.} =
+    onNativeEvt(sampleEvt())
+    return ok("emitted")
+
+# --- native listener capture (clone the typed POD off the FFI thread) -------
+type NativeCap = object
+  lock: Lock
+  cond: Cond
+  done: bool
+  ret: cint
+  pod: NativeEvtPod
+  hasPod: bool
+
+proc initNativeCap(c: var NativeCap) =
+  c.lock.initLock()
+  c.cond.initCond()
+proc deinitNativeCap(c: var NativeCap) =
+  c.cond.deinitCond()
+  c.lock.deinitLock()
+proc waitNativeCap(c: var NativeCap) =
+  acquire(c.lock)
+  while not c.done:
+    wait(c.cond, c.lock)
+  release(c.lock)
+
+proc nativeEvtCb(
+    ret: cint, msg: ptr cchar, len: csize_t, ud: pointer
+) {.cdecl, gcsafe, raises: [].} =
+  let c = cast[ptr NativeCap](ud)
+  acquire(c[].lock)
+  c[].ret = ret
+  if ret == RET_OK and not msg.isNil:
+    # Native ABI: msg is a `ptr NativeEvtPod`; deep-copy it off the FFI thread.
+    c[].pod = clonePod(cast[ptr NativeEvtPod](msg)[])
+    c[].hasPod = true
+  c[].done = true
+  signal(c[].cond)
+  release(c[].lock)
+
+# --- CBOR listener capture --------------------------------------------------
+type CborCap = object
+  lock: Lock
+  cond: Cond
+  done: bool
+  ret: cint
+  msg: array[2048, byte]
+  msgLen: int
+
+proc initCborCap(c: var CborCap) =
+  c.lock.initLock()
+  c.cond.initCond()
+proc deinitCborCap(c: var CborCap) =
+  c.cond.deinitCond()
+  c.lock.deinitLock()
+proc waitCborCap(c: var CborCap) =
+  acquire(c.lock)
+  while not c.done:
+    wait(c.cond, c.lock)
+  release(c.lock)
+proc bytes(c: var CborCap): seq[byte] =
+  var b = newSeq[byte](c.msgLen)
+  if c.msgLen > 0:
+    copyMem(addr b[0], addr c.msg[0], c.msgLen)
+  return b
+
+proc cborEvtCb(
+    ret: cint, msg: ptr cchar, len: csize_t, ud: pointer
+) {.cdecl, gcsafe, raises: [].} =
+  let c = cast[ptr CborCap](ud)
+  acquire(c[].lock)
+  c[].ret = ret
+  let n = min(int(len), c[].msg.len)
+  if n > 0 and not msg.isNil:
+    copyMem(addr c[].msg[0], msg, n)
+  c[].msgLen = n
+  c[].done = true
+  signal(c[].cond)
+  release(c[].lock)
+
+# A throwaway response callback to know the request (and thus the dispatch) ran.
+proc rspCb(
+    ret: cint, msg: ptr cchar, len: csize_t, ud: pointer
+) {.cdecl, gcsafe, raises: [].} =
+  let c = cast[ptr CborCap](ud)
+  acquire(c[].lock)
+  c[].done = true
+  signal(c[].cond)
+  release(c[].lock)
+
+suite "native event delivery":
+  test "one dispatch delivers a typed POD to native + CBOR to cbor listeners":
+    var pool: FFIContextPool[EvtLib]
+    let ctx = pool.createFFIContext().valueOr:
+      check false
+      return
+    defer:
+      discard pool.destroyFFIContext(ctx)
+
+    var ncap: NativeCap
+    initNativeCap(ncap)
+    defer:
+      deinitNativeCap(ncap)
+    var ccap: CborCap
+    initCborCap(ccap)
+    defer:
+      deinitCborCap(ccap)
+
+    # Same event, two listeners of different formats.
+    check addEventListener(
+      ctx[].eventRegistry, "native_evt", nativeEvtCb, addr ncap, native = true
+    ) != 0'u64
+    check addEventListener(
+      ctx[].eventRegistry, "native_evt", cborEvtCb, addr ccap, native = false
+    ) != 0'u64
+
+    var rsp: CborCap
+    initCborCap(rsp)
+    defer:
+      deinitCborCap(rsp)
+    check sendRequestToFFIThread(ctx, EmitEvtRequest.ffiNewReq(rspCb, addr rsp)).isOk()
+    waitCborCap(rsp)
+    waitNativeCap(ncap)
+    waitCborCap(ccap)
+
+    # Native listener: the typed POD round-trips to the original value.
+    check ncap.ret == RET_OK
+    check ncap.hasPod
+    let got = podToNim(ncap.pod)
+    freePod(ncap.pod)
+    check got == sampleEvt()
+
+    # CBOR listener: the EventEnvelope decodes to the same value.
+    check ccap.ret == RET_OK
+    let decoded = cborDecode(bytes(ccap), EventEnvelope[NativeEvt])
+    check decoded.isOk()
+    check decoded.value.eventType == "native_evt"
+    check decoded.value.payload == sampleEvt()


### PR DESCRIPTION
## What

Foundation for emitting both the **native** (zero-serialization C-POD) and **CBOR** ABIs side-by-side for `{.ffiEvent.}` events, completing the request-side dual ABI from the earlier PRs in this stack.

- **Dual event dispatch** — one `{.ffiEvent.}` declaration now fires both a native typed-POD listener and a CBOR listener from a single dispatch. Native listeners get the payload built once via `nimToPod`/`freePod`; CBOR is serialized once for the rest.
- **Dual-ABI symbol naming** mirrors requests: bare `<lib>_add_event_listener` is native, `<lib>_add_event_listener_cbor` is CBOR.
- **`-d:ffiMode=native|cbor|both`** strdefine (default `both`) gates which ABI each generator emits, with `genbindings_*_native` / `_cbor` nimble tasks.
- **C** generator documents native event payloads (`"on_echo_fired" -> const EchoEvent *`) and routes the CBOR header to `_add_event_listener_cbor`.
- **Go** generator emits per-event typed native handlers `On<Event>(func(<Payload>))` with exported callbacks + `fromC`.

Native is the same-process path; CBOR is IPC-only.

## Test

`test_native_events`, `test_native_pod_types`, and the C native+CBOR concurrency stress harness pass (ASAN/TSAN clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)