### PR TITLE
refactor(codegen): Rust crate names follow native=bare / cbor=_cbor

### DIFF
--- a/examples/timer/rust_bindings/Cargo.toml
+++ b/examples/timer/rust_bindings/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "my_timer"
+name = "my_timer_cbor"
 version = "0.1.0"
 edition = "2021"
 

--- a/examples/timer/rust_bindings/README.md
+++ b/examples/timer/rust_bindings/README.md
@@ -31,7 +31,8 @@ The `rust_client` example consumes this crate:
 
 ```toml
 [dependencies]
-my_timer = { path = "../rust_bindings" }
+# CBOR (inter-process) crate carries the `_cbor` suffix; the native crate is the bare `my_timer`.
+my_timer_cbor = { path = "../rust_bindings" }
 ```
 
 ## Do Not Edit

--- a/examples/timer/rust_client/Cargo.lock
+++ b/examples/timer/rust_client/Cargo.lock
@@ -97,7 +97,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "my_timer"
+name = "my_timer_cbor"
 version = "0.1.0"
 dependencies = [
  "ciborium",
@@ -134,7 +134,7 @@ dependencies = [
 name = "rust_client"
 version = "0.1.0"
 dependencies = [
- "my_timer",
+ "my_timer_cbor",
  "serde_json",
  "tokio",
 ]

--- a/examples/timer/rust_client/Cargo.toml
+++ b/examples/timer/rust_client/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-my_timer = { path = "../rust_bindings" }
+my_timer_cbor = { path = "../rust_bindings" }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 

--- a/examples/timer/rust_client/src/main.rs
+++ b/examples/timer/rust_client/src/main.rs
@@ -6,7 +6,7 @@
 // To regenerate the `rust_bindings` crate:
 //   nimble genbindings_rust
 use std::time::Duration;
-use my_timer::{
+use my_timer_cbor::{
     EchoRequest, JobSpec, MyTimerCtx, RetryPolicy, ScheduleConfig, TimerConfig,
 };
 

--- a/examples/timer/rust_client/src/tokio_main.rs
+++ b/examples/timer/rust_client/src/tokio_main.rs
@@ -1,5 +1,5 @@
 use std::time::Duration;
-use my_timer::{
+use my_timer_cbor::{
     EchoRequest, JobSpec, MyTimerCtx, RetryPolicy, ScheduleConfig, TimerConfig,
 };
 

--- a/examples/timer/rust_native_bindings/Cargo.toml
+++ b/examples/timer/rust_native_bindings/Cargo.toml
@@ -1,4 +1,4 @@
 [package]
-name = "my_timer_native"
+name = "my_timer"
 version = "0.1.0"
 edition = "2021"

--- a/examples/timer/rust_native_bindings/examples/demo.rs
+++ b/examples/timer/rust_native_bindings/examples/demo.rs
@@ -1,4 +1,4 @@
-use my_timer_native::*;
+use my_timer::*;
 fn main() {
     let node = MyTimerNode::new(TimerConfig { name: "rust-native-gen".into() }).unwrap();
     println!("version: {}", node.version().unwrap());

--- a/ffi/codegen/rust_cbor.nim
+++ b/ffi/codegen/rust_cbor.nim
@@ -74,9 +74,13 @@ proc generateCargoToml*(libName: string): string =
   # pulling its async-std/futures shims.
   # `tokio` is needed only for `tokio::time::timeout` around the async
   # `recv_async`. Feature-gating tokio (item 11) is a follow-up commit.
+  # CBOR (inter-process) crate carries the `_cbor` suffix, matching the
+  # `<name>_cbor` symbol naming and the C `<lib>_cbor.h` header; the native
+  # crate is the bare `<lib>`. The linked dylib is still `lib<lib>.dylib`
+  # (see generateBuildRs / the `#[link]` name) — only the crate name changes.
   return
     """[package]
-name = "$1"
+name = "$1_cbor"
 version = "0.1.0"
 edition = "2021"
 

--- a/ffi/codegen/rust_native.nim
+++ b/ffi/codegen/rust_native.nim
@@ -1,7 +1,8 @@
 ## Native (zero-serialization) Rust binding generator.
 ##
-## Emits a `<lib>_native` crate that wraps the *native* C ABI (the `<name>`
-## entry points + flat C-POD structs) — no CBOR. Each `{.ffi.}` type is a
+## Emits a bare `<lib>` crate that wraps the *native* C ABI (the `<name>`
+## entry points + flat C-POD structs) — no CBOR; the CBOR crate is `<lib>_cbor`.
+## Each `{.ffi.}` type is a
 ## `#[repr(C)]` mirror (`ffi`) plus an idiomatic Rust struct with `to_c`/`from_c`
 ## (`types`), and `<Lib>Node` marshals typed args in / reads typed struct
 ## returns out (`api`). Counterpart of the CBOR generator in `rust_cbor.nim`, and
@@ -452,8 +453,10 @@ proc generateRustNativeCrate*(
     events: seq[FFIEventMeta] = @[],
 ) =
   createDir(outputDir / "src")
+  # Native (same-process) crate is the bare `<lib>`, matching the `<name>`
+  # symbol naming and the C `<lib>.h` header; the CBOR crate is `<lib>_cbor`.
   writeFile(outputDir / "Cargo.toml",
-    "[package]\nname = \"" & libName & "_native\"\nversion = \"0.1.0\"\nedition = \"2021\"\n")
+    "[package]\nname = \"" & libName & "\"\nversion = \"0.1.0\"\nedition = \"2021\"\n")
   writeFile(outputDir / "src" / "lib.rs",
     "mod ffi;\nmod types;\nmod api;\npub use types::*;\npub use api::*;\n")
   writeFile(outputDir / "src" / "ffi.rs", emitFfiRs(procs, types, libName, events))


### PR DESCRIPTION
## What

Reconciles the **Rust** crate names with the C generator and the symbol naming. The native (zero-serialization, same-process) crate is the bare `<lib>`; the CBOR (inter-process) crate carries the `_cbor` suffix — mirroring `<lib>.h` / `<lib>_cbor.h` and the `<name>` / `<name>_cbor` exports.

Previously the native crate was `<lib>_native` and the CBOR crate was the bare `<lib>` — backwards from the convention. Only the Cargo package name changes; the linked dylib stays `lib<lib>.dylib` (the `#[link]` name and build.rs are untouched).

Consumers updated: `rust_client` depends on `my_timer_cbor` and imports from it; the native demo imports from the bare `my_timer`.

## Test

- `rust_client` builds against the renamed CBOR crate.
- Native demo round-trips version / echo / event / complex / schedule against the bare crate.
- `check_bindings_rust` regen is deterministic.

Stacked on #64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)