### PR TITLE
add changelog for 0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,38 +11,50 @@ robustness fixes around context lifetime and memory safety.
 ### Added
 - **CBOR serialization** as the FFI wire format ([#23](https://github.com/waku-org/nim-ffi/pull/23)).
 - **C++ binding generator** with end-to-end tests driven by CMake/CTest
-  ([#15](https://github.com/waku-org/nim-ffi/pull/15),
-  [#27](https://github.com/waku-org/nim-ffi/pull/27)).
-- **Rust binding generator** for simplified FFI authoring
-  ([#15](https://github.com/waku-org/nim-ffi/pull/15)).
+  ([#27](https://github.com/waku-org/nim-ffi/pull/27)).
 - **CDDL schema generator** for the FFI types
   ([#24](https://github.com/waku-org/nim-ffi/pull/24)).
 - **CI pipeline**: first GitHub Actions workflow
-  ([#12](https://github.com/waku-org/nim-ffi/pull/12)), parallel test
+  parallel test
   execution ([#26](https://github.com/waku-org/nim-ffi/pull/26)), and
   AddressSanitizer / UndefinedBehaviorSanitizer / ThreadSanitizer jobs
   ([#34](https://github.com/waku-org/nim-ffi/pull/34)).
-- Tests run under both `--mm:orc` and `--mm:refc`
-  ([#20](https://github.com/waku-org/nim-ffi/pull/20)).
 
 ### Changed
-- FFI contexts now use a **fixed-size array** instead of dynamically allocated
-  slots, so creating many contexts no longer exhausts file descriptors
-  ([#14](https://github.com/waku-org/nim-ffi/pull/14)).
 - Removed the redundant `ffiType` macro; the `ffi` macro is now the single
   authoring entry point
   ([#22](https://github.com/waku-org/nim-ffi/pull/22)).
-- Dropped `CatchableError` usage in favour of more specific exception types
-  ([#19](https://github.com/waku-org/nim-ffi/pull/19)).
+
+## [0.1.4] - 2026-06-02
+
+[Full changelog](https://github.com/logos-messaging/nim-ffi/compare/v0.1.3...v0.1.4)
+
+### Added
+
+- Simplified FFI authoring with auto-generated C++ and Rust language bindings,
+  including new `ffi/codegen/cpp.nim`, `ffi/codegen/rust.nim` and shared
+  `ffi/codegen/meta.nim` helpers (#15).
+- Rust example bindings and clients under `examples/nim_timer/` (`rust_bindings`
+  and `rust_client`, the latter with a Tokio async variant) (#15).
+- CBOR serialization support via `ffi/serial.nim`, with `tests/test_serial.nim`
+  coverage.
+- FFI context pool (`ffi/ffi_context_pool.nim`) using a fixed array of contexts.
+- Test suite expansion: `test_alloc.nim`, `test_ctx_validation.nim`,
+  `test_ffi_context.nim`, `test_gc_compat.nim`.
+- Continuous integration pipeline (#12).
 
 ### Fixed
-- Context buffer overflow when handling large payloads
-  ([#21](https://github.com/waku-org/nim-ffi/pull/21)).
-- Several memory leaks in request dispatch, context creation/destruction,
-  and `handleRes` under ARC/ORC; tightened lock initialization and resource
-  cleanup ([#11](https://github.com/waku-org/nim-ffi/pull/11)).
-- macOS dylibs are now built with a relocatable `install_name` instead of
-  hard-coded paths ([#8](https://github.com/waku-org/nim-ffi/pull/8)).
+
+- Context buffer overflow (#21).
+- Use a fixed array of contexts to avoid consuming all file descriptors (#14).
+- Memory leaks (#11).
+- Add `install_name` for macOS shared libraries (#8).
+
+### Changed
+
+- Run tests with the `refc` garbage collector (#20).
+- Remove `CatchableError` usage (#19).
+- Update license files to comply with Logos licensing requirements.
 
 ## [0.1.3] - 2026-01-23
 


### PR DESCRIPTION
v0.1.4 is the max version that we want to use in logos-delivery integration even though there are more recent changes.
The CBOR support and the rest of improvements (present in master now) will be introduced post testnet v0.2 (in July.)