### PR TITLE
fix(pool): recycle contexts to stop per-cycle fd leak

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master, main]
+    branches: [master, main, 'release/*']
   pull_request:
-    branches: [master, main]
+    branches: [master, main, 'release/*']
 
 env:
   NIM_VERSION: '2.2.4'

--- a/ffi/ffi_context.nim
+++ b/ffi/ffi_context.nim
@@ -361,7 +361,7 @@ proc signalStop*[T](ctx: ptr FFIContext[T]): Result[void, string] =
 
 ## If the FFI thread's event loop is blocked by a synchronous handler
 ## (e.g. blocking I/O), it cannot process reqSignal in time to exit.
-## clearContext waits on threadExitSignal up to this bound; on timeout it
+## stopAndJoinThreads waits on threadExitSignal up to this bound; on timeout it
 ## returns err and skips joinThread/cleanup (leaking the thread + ctx slot)
 ## rather than hanging the caller forever.
 const ThreadExitTimeout* = 1500.milliseconds
@@ -384,12 +384,4 @@ proc stopAndJoinThreads*[T](ctx: ptr FFIContext[T]): Result[void, string] =
 
   joinThread(ctx.ffiThread)
   joinThread(ctx.watchdogThread)
-  return ok()
-
-proc clearContext[T](ctx: ptr FFIContext[T]): Result[void, string] =
-  ## Stops the FFI context that was created via createFFIContext[T]() (heap).
-  ctx.stopAndJoinThreads().isOkOr:
-    return err("clearContext: " & $error)
-  ctx.cleanUpResources().isOkOr:
-    return err("cleanUpResources failed: " & $error)
   return ok()

--- a/ffi/ffi_context.nim
+++ b/ffi/ffi_context.nim
@@ -14,7 +14,7 @@ type FFICallbackState* = object
 
 type CtxLifecycle {.pure.} = enum
   ## Request-acceptance + recycle handshake for a pooled context, held as an
-  ## Atomic on FFIContext. ("Recycle" = drain the context and return its slot to
+  ## Atomic on FFIContext. ("Recycle" = drain the context and return its context to
   ## the pool for reuse, keeping the worker alive — unlike destroyFFIContext, which
   ## fully tears the threads down.) Invariants:
   ##   * Requests are accepted ONLY in `Active`; the gate in sendRequestToFFIThread
@@ -23,7 +23,7 @@ type CtxLifecycle {.pure.} = enum
   ##       Active         -> RecyclePending   requestRecycle (caller, under `lock`)
   ##       RecyclePending -> Recycling        the FFI loop   (one-shot compareExchange)
   ##       Recycling      -> Active           markReacquired (caller, on reuse)
-  ##     (initContextResources starts a slot in `Active`.)
+  ##     (initContextResources starts a context in `Active`.)
   ##   * The gate stays closed across BOTH RecyclePending and Recycling, so no
   ##     request can dispatch onto a context being recycled or about to be reused.
   ##   * Only the FFI loop makes the RecyclePending -> Recycling move, so the
@@ -61,8 +61,8 @@ type FFIContext*[T] = object
     # RET_OK once drained, RET_ERR if it timed out. Set by requestRecycle.
   recycleUserData: pointer
   inUse: Atomic[bool]
-    # Whether the slot is claimed. createFFIContext claims it (false -> true); the
-    # recycle handler clears it once drained. On the slot so the owning thread can
+    # Whether the context is claimed. createFFIContext claims it (false -> true); the
+    # recycle handler clears it once drained. On the context so the owning thread can
     # release it without reaching into the pool.
   registeredRequests: ptr Table[cstring, FFIRequestProc]
     # Pointer to with the registered requests at compile time
@@ -129,7 +129,7 @@ proc sendRequestToFFIThread*(
     ctx.lock.release()
 
   ## A recycle closes this gate (under the same lock), so a queued or late sender
-  ## bails here instead of dispatching onto a slot about to be reused.
+  ## bails here instead of dispatching onto a context about to be reused.
   if ctx.lifecycle.load() != CtxLifecycle.Active:
     deleteRequest(ffiRequest)
     return err("FFI context is not accepting requests (being recycled)")
@@ -293,7 +293,7 @@ proc recycleContext[T](
     ctx: ptr FFIContext[T], pending: ptr seq[Future[void]]
 ) {.async.} =
   ## Recycle handler, on the FFI thread (requestRecycle already closed the gate):
-  ## drain the in-flight handlers, free the lib object, release the slot for reuse,
+  ## drain the in-flight handlers, free the lib object, release the context for reuse,
   ## and fire the callback with the outcome. Never blocks the caller.
   ##
   ## `pending` is the run loop's seq of handler Futures, by ptr (async procs can't
@@ -306,7 +306,7 @@ proc recycleContext[T](
     naturallyDrained = await allFutures(pending[]).withTimeout(RecycleTimeout)
 
   ## 2. If any are wedged, cancel them and give the cancellations a bounded moment
-  ##    to unwind, so the slot can be reclaimed rather than leaked.
+  ##    to unwind, so the context can be reclaimed rather than leaked.
   var safeToRecycle = naturallyDrained
   if not naturallyDrained:
     for fut in pending[]:
@@ -319,7 +319,7 @@ proc recycleContext[T](
   ctx.recycleCallback = nil
 
   if safeToRecycle:
-    ## Nothing can touch the context now. Free the lib here, then release the slot
+    ## Nothing can touch the context now. Free the lib here, then release the context
     ## BEFORE the callback (the atomic store publishes these writes to whoever
     ## reclaims it) so a caller reacquiring on the callback finds it already free.
     freeLib(ctx)
@@ -361,7 +361,7 @@ proc ffiThreadBody[T](ctx: ptr FFIContext[T]) {.thread.} =
     while ctx.running.load():
       ## Recycle requested: claim it (RecyclePending -> Recycling, one-shot) and run
       ## the recycle on this owning thread, then keep looping so the worker stays
-      ## alive for the slot's next reuse.
+      ## alive for the context's next reuse.
       var expected = CtxLifecycle.RecyclePending
       if ctx.lifecycle.compareExchange(expected, CtxLifecycle.Recycling):
         await recycleContext(ctx, addr pending)
@@ -425,9 +425,9 @@ proc cleanUpResources[T](ctx: ptr FFIContext[T]): Result[void, string] =
   return ok()
 
 proc initContextResources*[T](ctx: ptr FFIContext[T]): Result[void, string] =
-  ## Initialises all resources inside an already-allocated FFIContext slot.
+  ## Initialises all resources inside an already-allocated FFIContext.
   ## On failure every partially-initialised resource is closed; the caller
-  ## is responsible for releasing the slot (freeShared or pool.releaseSlot).
+  ## is responsible for releasing the context (freeShared or ctx.unclaim()).
   ctx.lock.initLock()
 
   var success = false
@@ -491,7 +491,7 @@ proc signalStop*[T](ctx: ptr FFIContext[T]): Result[void, string] =
 ## If the FFI thread's event loop is blocked by a synchronous handler
 ## (e.g. blocking I/O), it cannot process reqSignal in time to exit.
 ## stopAndJoinThreads waits on threadExitSignal up to this bound; on timeout it
-## returns err and skips joinThread/cleanup (leaking the thread + ctx slot)
+## returns err and skips joinThread/cleanup (leaking the thread + ctx)
 ## rather than hanging the caller forever.
 const ThreadExitTimeout* = 1500.milliseconds
 
@@ -537,22 +537,22 @@ proc requestRecycle*[T](
   return ok()
 
 proc markReacquired*[T](ctx: ptr FFIContext[T]) =
-  ## Re-arms a recycled context when its slot is reacquired by createFFIContext:
+  ## Re-arms a recycled context when its context is reacquired by createFFIContext:
   ## moves Recycling -> Active (re-opening the gate). The FFI thread's `pending`
   ## seq was already drained and myLib freed by the recycle handler.
   ctx.lifecycle.store(CtxLifecycle.Active)
 
 proc tryClaim*[T](ctx: ptr FFIContext[T]): bool =
-  ## Atomically claim this slot (false -> true). Returns true if we won it, false
-  ## if it was already claimed. Used by createFFIContext to hand out a free slot.
+  ## Atomically claim this context (false -> true). Returns true if we won it, false
+  ## if it was already claimed. Used by createFFIContext to hand out a free context.
   var expected = false
   ctx.inUse.compareExchange(expected, true)
 
 proc unclaim*[T](ctx: ptr FFIContext[T]) =
-  ## Mark the slot free for reuse. Called by the recycle handler on the FFI thread
+  ## Mark the context free for reuse. Called by the recycle handler on the FFI thread
   ## once teardown is done, and on creation failure / full teardown.
   ctx.inUse.store(false)
 
 proc isClaimed*[T](ctx: ptr FFIContext[T]): bool =
-  ## Whether the slot is currently claimed by a consumer.
+  ## Whether the context is currently claimed by a consumer.
   ctx.inUse.load()

--- a/ffi/ffi_context.nim
+++ b/ffi/ffi_context.nim
@@ -2,7 +2,7 @@
 {.pragma: callback, cdecl, raises: [], gcsafe.}
 {.passc: "-fPIC".}
 
-import std/[atomics, locks, json, tables]
+import std/[atomics, locks, json, tables, sequtils]
 import chronicles, chronos, chronos/threadsync, taskpools/channels_spsc_single, results
 import ./ffi_types, ./ffi_thread_request, ./internal/ffi_macro, ./logging
 
@@ -11,6 +11,26 @@ type FFICallbackState* = object
   ## Embedded in FFIContext and referenced from the FFI thread via a thread-local.
   callback*: pointer
   userData*: pointer
+
+type CtxLifecycle {.pure.} = enum
+  ## Request-acceptance + recycle handshake for a pooled context, held as an
+  ## Atomic on FFIContext. ("Recycle" = drain the context and return its slot to
+  ## the pool for reuse, keeping the worker alive — unlike destroyFFIContext, which
+  ## fully tears the threads down.) Invariants:
+  ##   * Requests are accepted ONLY in `Active`; the gate in sendRequestToFFIThread
+  ##     and the watchdog ping both test `== Active`.
+  ##   * Legal transitions, and who performs them:
+  ##       Active         -> RecyclePending   requestRecycle (caller, under `lock`)
+  ##       RecyclePending -> Recycling        the FFI loop   (one-shot compareExchange)
+  ##       Recycling      -> Active           markReacquired (caller, on reuse)
+  ##     (initContextResources starts a slot in `Active`.)
+  ##   * The gate stays closed across BOTH RecyclePending and Recycling, so no
+  ##     request can dispatch onto a context being recycled or about to be reused.
+  ##   * Only the FFI loop makes the RecyclePending -> Recycling move, so the
+  ##     recycle runs exactly once per request.
+  Active            ## serving requests
+  RecyclePending    ## recycle requested; FFI loop hasn't claimed it yet
+  Recycling         ## FFI loop claimed it: draining handlers, then freeing
 
 type FFIContext*[T] = object
   myLib*: ptr T
@@ -33,6 +53,17 @@ type FFIContext*[T] = object
   userData*: pointer
   callbackState*: FFICallbackState
   running: Atomic[bool] # To control when the threads are running
+  lifecycle: Atomic[CtxLifecycle]
+    # Request gate + recycle handshake in one. See CtxLifecycle for the states,
+    # transitions and invariants.
+  recycleCallback: FFICallBack
+    # The destructor's callback, fired by the recycle handler with the outcome:
+    # RET_OK once drained, RET_ERR if it timed out. Set by requestRecycle.
+  recycleUserData: pointer
+  inUse: Atomic[bool]
+    # Whether the slot is claimed. createFFIContext claims it (false -> true); the
+    # recycle handler clears it once drained. On the slot so the owning thread can
+    # release it without reaching into the pool.
   registeredRequests: ptr Table[cstring, FFIRequestProc]
     # Pointer to with the registered requests at compile time
 
@@ -96,6 +127,12 @@ proc sendRequestToFFIThread*(
   # requests concurrently and spare us the need of locks
   defer:
     ctx.lock.release()
+
+  ## A recycle closes this gate (under the same lock), so a queued or late sender
+  ## bails here instead of dispatching onto a slot about to be reused.
+  if ctx.lifecycle.load() != CtxLifecycle.Active:
+    deleteRequest(ffiRequest)
+    return err("FFI context is not accepting requests (being recycled)")
 
   ## Sending the request
   let sentOk = ctx.reqChannel.trySend(ffiRequest)
@@ -162,6 +199,11 @@ proc watchdogThreadBody(ctx: ptr FFIContext) {.thread.} =
         debug "Watchdog thread exiting because FFIContext is not running"
         break
 
+      if ctx.lifecycle.load() != CtxLifecycle.Active:
+        ## Gate closed (being recycled, not yet reused): a ping would just fail
+        ## and spuriously trip onNotResponding. Skip until reused.
+        continue
+
       let callback = proc(
           callerRet: cint, msg: ptr cchar, len: csize_t, userData: pointer
       ) {.cdecl, gcsafe, raises: [].} =
@@ -186,6 +228,8 @@ proc processRequest[T](
     request: ptr FFIThreadRequest, ctx: ptr FFIContext[T]
 ) {.async.} =
   ## Invoked within the FFI thread to process a request coming from the FFI API consumer thread.
+  ## ffiThreadBody keeps this proc's Future in the run loop's `pending` seq so a
+  ## destroy can await (or cancel) it before freeing myLib.
 
   let reqId = $request[].reqId
     ## The reqId determines which proc will handle the request.
@@ -206,6 +250,10 @@ proc processRequest[T](
   let res =
     try:
       await retFut
+    except CancelledError as exc:
+      ## Destroy timed out and cancelled us: turn it into an error so handleRes
+      ## still fires the callback and frees the request.
+      Result[string, string].err("Request cancelled during destroy: " & exc.msg)
     except AsyncError as exc:
       Result[string, string].err(
         "Async error in processRequest for " & reqId & ": " & exc.msg
@@ -218,6 +266,78 @@ proc processRequest[T](
     handleRes(res, request)
   except Exception as exc:
     error "Unexpected exception in handleRes", error = exc.msg
+
+proc freeLib[T](ctx: ptr FFIContext[T]) {.gcsafe.} =
+  ## Frees the createShared'd library object in ctx.myLib. Runs on the FFI
+  ## thread, which is what makes destroying its GC fields safe.
+  if ctx.myLib.isNil():
+    return
+  when not defined(gcRefc):
+    ## orc: shared heap, so run the destructor here. The hook isn't inferred
+    ## gcsafe but only touches this (owning-thread) object, so assert it.
+    {.cast(gcsafe).}:
+      `=destroy`(ctx.myLib[])
+  else:
+    ## refc: `=destroy` here hits the unsafe Selector path (see cleanUpResources).
+    ## Reclaim only the wrapper; leak the inner fields, like the signal fds.
+    discard
+  freeShared(ctx.myLib)
+  ctx.myLib = nil
+
+var RecycleTimeout* = 1500.milliseconds
+  ## Upper bound the recycle handler waits for in-flight handlers before it
+  ## cancels them and reports the ctx as stuck. The drain returns as soon as they
+  ## finish, so this only bounds a *stuck* handler. A `var` so tests can shorten it.
+
+proc recycleContext[T](
+    ctx: ptr FFIContext[T], pending: ptr seq[Future[void]]
+) {.async.} =
+  ## Recycle handler, on the FFI thread (requestRecycle already closed the gate):
+  ## drain the in-flight handlers, free the lib object, release the slot for reuse,
+  ## and fire the callback with the outcome. Never blocks the caller.
+  ##
+  ## `pending` is the run loop's seq of handler Futures, by ptr (async procs can't
+  ## take `var`); holding the instances lets us await and cancel them.
+  pending[].keepItIf(not it.finished())
+
+  ## 1. Let the in-flight handlers finish on their own, bounded by RecycleTimeout.
+  var naturallyDrained = pending[].len == 0
+  if not naturallyDrained:
+    naturallyDrained = await allFutures(pending[]).withTimeout(RecycleTimeout)
+
+  ## 2. If any are wedged, cancel them and give the cancellations a bounded moment
+  ##    to unwind, so the slot can be reclaimed rather than leaked.
+  var safeToRecycle = naturallyDrained
+  if not naturallyDrained:
+    for fut in pending[]:
+      if not fut.finished():
+        fut.cancelSoon()
+    safeToRecycle = await allFutures(pending[]).withTimeout(RecycleTimeout)
+
+  let cb = ctx.recycleCallback
+  let ud = ctx.recycleUserData
+  ctx.recycleCallback = nil
+
+  if safeToRecycle:
+    ## Nothing can touch the context now. Free the lib here, then release the slot
+    ## BEFORE the callback (the atomic store publishes these writes to whoever
+    ## reclaims it) so a caller reacquiring on the callback finds it already free.
+    freeLib(ctx)
+    ctx.callbackState = default(FFICallbackState)
+    pending[].setLen(0)
+    ctx.unclaim()
+
+  if not cb.isNil():
+    foreignThreadGc:
+      ## Never hand the callback nil: empty string on success, reason on timeout.
+      ## An empty string's cstring still points at a '\0', so msg[0] is a safe
+      ## address with len 0.
+      let msg =
+        if naturallyDrained: ""
+        else: "recycle: in-flight requests did not finish in time"
+      let cmsg = msg.cstring
+      let retCode = if naturallyDrained: RET_OK else: RET_ERR
+      cb(retCode, unsafeAddr cmsg[0], cast[csize_t](msg.len), ud)
 
 proc ffiThreadBody[T](ctx: ptr FFIContext[T]) {.thread.} =
   ## FFI thread body that attends library user API requests
@@ -233,11 +353,20 @@ proc ffiThreadBody[T](ctx: ptr FFIContext[T]) {.thread.} =
       error "failed to fire threadExitSignal on FFI thread exit", err = fireRes.error
 
   let ffiRun = proc(ctx: ptr FFIContext[T]) {.async.} =
-    var ffiReqHandler: T
-      ## Holds the main library object, i.e., in charge of handling the ffi requests.
-      ## e.g., Waku, LibP2P, SDS, etc.
+    ## Handler Futures live here on the FFI thread's heap, NOT on FFIContext
+    ## (shared pool memory, must stay GC-free); holding them lets destroy await
+    ## and cancel them.
+    var pending: seq[Future[void]]
 
     while ctx.running.load():
+      ## Recycle requested: claim it (RecyclePending -> Recycling, one-shot) and run
+      ## the recycle on this owning thread, then keep looping so the worker stays
+      ## alive for the slot's next reuse.
+      var expected = CtxLifecycle.RecyclePending
+      if ctx.lifecycle.compareExchange(expected, CtxLifecycle.Recycling):
+        await recycleContext(ctx, addr pending)
+        continue
+
       let gotSignal = await ctx.reqSignal.wait().withTimeout(100.milliseconds)
       if not gotSignal:
         continue
@@ -247,11 +376,10 @@ proc ffiThreadBody[T](ctx: ptr FFIContext[T]) {.thread.} =
       if not ctx.reqChannel.tryRecv(request):
         continue
 
-      if ctx.myLib.isNil():
-        ctx.myLib = addr ffiReqHandler
-
-      ## Handle the request
-      asyncSpawn processRequest(request, ctx)
+      ## Dispatch and remember the handler's Future (pruning finished ones) so a
+      ## later recycle can await or cancel it.
+      pending.keepItIf(not it.finished())
+      pending.add(processRequest(request, ctx))
 
       let fireRes = ctx.reqReceivedSignal.fireSync()
       if fireRes.isErr():
@@ -323,6 +451,7 @@ proc initContextResources*[T](ctx: ptr FFIContext[T]): Result[void, string] =
 
   ctx.registeredRequests = addr ffi_types.registeredRequests
 
+  ctx.lifecycle.store(CtxLifecycle.Active)
   ctx.running.store(true)
 
   try:
@@ -385,3 +514,45 @@ proc stopAndJoinThreads*[T](ctx: ptr FFIContext[T]): Result[void, string] =
   joinThread(ctx.ffiThread)
   joinThread(ctx.watchdogThread)
   return ok()
+
+proc requestRecycle*[T](
+    ctx: ptr FFIContext[T], callback: FFICallBack, userData: pointer
+): Result[void, string] =
+  ## Asks the FFI thread to recycle the context and fire `callback` with the
+  ## outcome (RET_OK drained, RET_ERR stuck). NON-BLOCKING.
+  ##
+  ## Order matters: set the callback before flipping to RecyclePending (the flip is
+  ## the trigger), under `lock` to serialise the gate with sendRequestToFFIThread.
+  ctx.recycleCallback = callback
+  ctx.recycleUserData = userData
+
+  ctx.lock.acquire()
+  ctx.lifecycle.store(CtxLifecycle.RecyclePending)
+  ctx.lock.release()
+
+  let fired = ctx.reqSignal.fireSync().valueOr:
+    return err("requestRecycle: failed to signal the FFI thread: " & $error)
+  if not fired:
+    return err("requestRecycle: failed to signal the FFI thread in time")
+  return ok()
+
+proc markReacquired*[T](ctx: ptr FFIContext[T]) =
+  ## Re-arms a recycled context when its slot is reacquired by createFFIContext:
+  ## moves Recycling -> Active (re-opening the gate). The FFI thread's `pending`
+  ## seq was already drained and myLib freed by the recycle handler.
+  ctx.lifecycle.store(CtxLifecycle.Active)
+
+proc tryClaim*[T](ctx: ptr FFIContext[T]): bool =
+  ## Atomically claim this slot (false -> true). Returns true if we won it, false
+  ## if it was already claimed. Used by createFFIContext to hand out a free slot.
+  var expected = false
+  ctx.inUse.compareExchange(expected, true)
+
+proc unclaim*[T](ctx: ptr FFIContext[T]) =
+  ## Mark the slot free for reuse. Called by the recycle handler on the FFI thread
+  ## once teardown is done, and on creation failure / full teardown.
+  ctx.inUse.store(false)
+
+proc isClaimed*[T](ctx: ptr FFIContext[T]): bool =
+  ## Whether the slot is currently claimed by a consumer.
+  ctx.inUse.load()

--- a/ffi/ffi_context.nim
+++ b/ffi/ffi_context.nim
@@ -471,10 +471,14 @@ proc requestRecycle*[T](
   ##
   ## During recycling, the FFI thread drains the handlers, frees the lib and releases
   ## the context, then fires `callback` (RET_OK drained, RET_ERR stuck).
-  ctx.recycleCallback = callback
-  ctx.recycleUserData = userData
 
   ctx.lock.acquire()
+  if ctx.lifecycle.load() != CtxLifecycle.Active:
+    ctx.lock.release()
+    return err("requestRecycle: context is not Active (already recycling)")
+
+  ctx.recycleCallback = callback
+  ctx.recycleUserData = userData
   ctx.lifecycle.store(CtxLifecycle.RecyclePending)
   ctx.lock.release()
 

--- a/ffi/ffi_context.nim
+++ b/ffi/ffi_context.nim
@@ -13,24 +13,14 @@ type FFICallbackState* = object
   userData*: pointer
 
 type CtxLifecycle {.pure.} = enum
-  ## Request-acceptance + recycle handshake for a pooled context, held as an
-  ## Atomic on FFIContext. ("Recycle" = drain the context and return its context to
-  ## the pool for reuse, keeping the worker alive — unlike destroyFFIContext, which
-  ## fully tears the threads down.) Invariants:
-  ##   * Requests are accepted ONLY in `Active`; the gate in sendRequestToFFIThread
-  ##     and the watchdog ping both test `== Active`.
-  ##   * Legal transitions, and who performs them:
-  ##       Active         -> RecyclePending   requestRecycle (caller, under `lock`)
-  ##       RecyclePending -> Recycling        the FFI loop   (one-shot compareExchange)
-  ##       Recycling      -> Active           markReacquired (caller, on reuse)
-  ##     (initContextResources starts a context in `Active`.)
-  ##   * The gate stays closed across BOTH RecyclePending and Recycling, so no
-  ##     request can dispatch onto a context being recycled or about to be reused.
-  ##   * Only the FFI loop makes the RecyclePending -> Recycling move, so the
-  ##     recycle runs exactly once per request.
-  Active            ## serving requests
-  RecyclePending    ## recycle requested; FFI loop hasn't claimed it yet
-  Recycling         ## FFI loop claimed it: draining handlers, then freeing
+  ## State machine guarding a pooled FFI context, held as an Atomic on FFIContext.
+  ## Transitions:
+  ##   Active         -> RecyclePending   when ffiDtor is invoked
+  ##   RecyclePending -> Recycling        The process completed the in-flight processes and is ready for lib cleanup and release
+  ##   Recycling      -> Active           When the FFI thread is ready again to attend to requests
+  Active ## accepting and serving requests
+  RecyclePending ## recycle requested; FFI thread loop hasn't claimed it yet
+  Recycling ## FFI loop draining handlers, then frees lib + returns to pool
 
 type FFIContext*[T] = object
   myLib*: ptr T
@@ -54,8 +44,6 @@ type FFIContext*[T] = object
   callbackState*: FFICallbackState
   running: Atomic[bool] # To control when the threads are running
   lifecycle: Atomic[CtxLifecycle]
-    # Request gate + recycle handshake in one. See CtxLifecycle for the states,
-    # transitions and invariants.
   recycleCallback: FFICallBack
     # The destructor's callback, fired by the recycle handler with the outcome:
     # RET_OK once drained, RET_ERR if it timed out. Set by requestRecycle.
@@ -121,20 +109,14 @@ proc sendRequestToFFIThread*(
     ctx: ptr FFIContext, ffiRequest: ptr FFIThreadRequest, timeout = InfiniteDuration
 ): Result[void, string] =
   ctx.lock.acquire()
-  # This lock is only necessary while we use a SP Channel and while the signalling
-  # between threads assumes that there aren't concurrent requests.
-  # Rearchitecting the signaling + migrating to a MP Channel will allow us to receive
-  # requests concurrently and spare us the need of locks
   defer:
     ctx.lock.release()
 
-  ## A recycle closes this gate (under the same lock), so a queued or late sender
-  ## bails here instead of dispatching onto a context about to be reused.
   if ctx.lifecycle.load() != CtxLifecycle.Active:
     deleteRequest(ffiRequest)
     return err("FFI context is not accepting requests (being recycled)")
 
-  ## Sending the request
+  ## Sending the request to the FFI thread
   let sentOk = ctx.reqChannel.trySend(ffiRequest)
   if not sentOk:
     deleteRequest(ffiRequest)
@@ -152,12 +134,8 @@ proc sendRequestToFFIThread*(
   ## wait until the FFI working thread properly received the request
   let res = ctx.reqReceivedSignal.waitSync(timeout)
   if res.isErr():
-    ## Do not free ffiRequest here: the FFI thread was already signaled and
-    ## will process (and free) it.
     return err("Couldn't receive reqReceivedSignal signal")
 
-  ## Notice that in case of "ok", the deallocShared(req) is performed by the FFI Thread in the
-  ## process proc.
   return ok()
 
 type Foo = object
@@ -200,8 +178,6 @@ proc watchdogThreadBody(ctx: ptr FFIContext) {.thread.} =
         break
 
       if ctx.lifecycle.load() != CtxLifecycle.Active:
-        ## Gate closed (being recycled, not yet reused): a ping would just fail
-        ## and spuriously trip onNotResponding. Skip until reused.
         continue
 
       let callback = proc(
@@ -228,17 +204,14 @@ proc processRequest[T](
     request: ptr FFIThreadRequest, ctx: ptr FFIContext[T]
 ) {.async.} =
   ## Invoked within the FFI thread to process a request coming from the FFI API consumer thread.
-  ## ffiThreadBody keeps this proc's Future in the run loop's `pending` seq so a
-  ## destroy can await (or cancel) it before freeing myLib.
 
   let reqId = $request[].reqId
     ## The reqId determines which proc will handle the request.
     ## The registeredRequests represents a table defined at compile time.
     ## Then, registeredRequests == Table[reqId, proc-handling-the-request-asynchronously]
 
-  ## Explicit conversion keeps `reqId` alive as the backing string,
-  ## avoiding the implicit string→cstring warning that will become an error.
   let reqIdCs = reqId.cstring
+    # keep `reqId` alive and avoid the implicit string→cstring warning.
 
   let retFut =
     if not ctx[].registeredRequests[].contains(reqIdCs):
@@ -251,35 +224,26 @@ proc processRequest[T](
     try:
       await retFut
     except CancelledError as exc:
-      ## Destroy timed out and cancelled us: turn it into an error so handleRes
-      ## still fires the callback and frees the request.
       Result[string, string].err("Request cancelled during destroy: " & exc.msg)
     except AsyncError as exc:
       Result[string, string].err(
         "Async error in processRequest for " & reqId & ": " & exc.msg
       )
 
-  ## handleRes may raise (OOM, GC setup) even though it is rare. Catching here
-  ## keeps the async proc raises:[] compatible. The defer inside handleRes
-  ## guarantees request is freed before the exception propagates.
+  ## handleRes may raise (OOM, GC setup) even though it is rare.
   try:
     handleRes(res, request)
   except Exception as exc:
     error "Unexpected exception in handleRes", error = exc.msg
 
 proc freeLib[T](ctx: ptr FFIContext[T]) {.gcsafe.} =
-  ## Frees the createShared'd library object in ctx.myLib. Runs on the FFI
-  ## thread, which is what makes destroying its GC fields safe.
   if ctx.myLib.isNil():
     return
+
   when not defined(gcRefc):
-    ## orc: shared heap, so run the destructor here. The hook isn't inferred
-    ## gcsafe but only touches this (owning-thread) object, so assert it.
     {.cast(gcsafe).}:
       `=destroy`(ctx.myLib[])
   else:
-    ## refc: `=destroy` here hits the unsafe Selector path (see cleanUpResources).
-    ## Reclaim only the wrapper; leak the inner fields, like the signal fds.
     discard
   freeShared(ctx.myLib)
   ctx.myLib = nil
@@ -290,51 +254,44 @@ var RecycleTimeout* = 1500.milliseconds
   ## finish, so this only bounds a *stuck* handler. A `var` so tests can shorten it.
 
 proc recycleContext[T](
-    ctx: ptr FFIContext[T], pending: ptr seq[Future[void]]
+    ctx: ptr FFIContext[T], ongoingProcessReq: ptr seq[Future[void]]
 ) {.async.} =
-  ## Recycle handler, on the FFI thread (requestRecycle already closed the gate):
-  ## drain the in-flight handlers, free the lib object, release the context for reuse,
+  ## Drain the in-flight handlers, free the lib object, release the context for reuse,
   ## and fire the callback with the outcome. Never blocks the caller.
-  ##
-  ## `pending` is the run loop's seq of handler Futures, by ptr (async procs can't
-  ## take `var`); holding the instances lets us await and cancel them.
-  pending[].keepItIf(not it.finished())
+
+  ongoingProcessReq[].keepItIf(not it.finished())
 
   ## 1. Let the in-flight handlers finish on their own, bounded by RecycleTimeout.
-  var naturallyDrained = pending[].len == 0
+  var naturallyDrained = ongoingProcessReq[].len == 0
   if not naturallyDrained:
-    naturallyDrained = await allFutures(pending[]).withTimeout(RecycleTimeout)
+    naturallyDrained = await allFutures(ongoingProcessReq[]).withTimeout(RecycleTimeout)
 
   ## 2. If any are wedged, cancel them and give the cancellations a bounded moment
   ##    to unwind, so the context can be reclaimed rather than leaked.
   var safeToRecycle = naturallyDrained
   if not naturallyDrained:
-    for fut in pending[]:
+    for fut in ongoingProcessReq[]:
       if not fut.finished():
         fut.cancelSoon()
-    safeToRecycle = await allFutures(pending[]).withTimeout(RecycleTimeout)
+    safeToRecycle = await allFutures(ongoingProcessReq[]).withTimeout(RecycleTimeout)
 
   let cb = ctx.recycleCallback
   let ud = ctx.recycleUserData
   ctx.recycleCallback = nil
 
   if safeToRecycle:
-    ## Nothing can touch the context now. Free the lib here, then release the context
-    ## BEFORE the callback (the atomic store publishes these writes to whoever
-    ## reclaims it) so a caller reacquiring on the callback finds it already free.
     freeLib(ctx)
     ctx.callbackState = default(FFICallbackState)
-    pending[].setLen(0)
-    ctx.unclaim()
+    ongoingProcessReq[].setLen(0)
+    ctx.release()
 
   if not cb.isNil():
     foreignThreadGc:
-      ## Never hand the callback nil: empty string on success, reason on timeout.
-      ## An empty string's cstring still points at a '\0', so msg[0] is a safe
-      ## address with len 0.
       let msg =
-        if naturallyDrained: ""
-        else: "recycle: in-flight requests did not finish in time"
+        if naturallyDrained:
+          ""
+        else:
+          "recycle: in-flight requests did not finish in time"
       let cmsg = msg.cstring
       let retCode = if naturallyDrained: RET_OK else: RET_ERR
       cb(retCode, unsafeAddr cmsg[0], cast[csize_t](msg.len), ud)
@@ -346,25 +303,18 @@ proc ffiThreadBody[T](ctx: ptr FFIContext[T]) {.thread.} =
   logging.setupLog(logging.LogLevel.DEBUG, logging.LogFormat.TEXT)
 
   defer:
-    # Signal destroyFFIContext that this thread has exited, so its bounded
-    # wait can unblock and proceed with cleanup.
     let fireRes = ctx.threadExitSignal.fireSync()
     if fireRes.isErr():
       error "failed to fire threadExitSignal on FFI thread exit", err = fireRes.error
 
   let ffiRun = proc(ctx: ptr FFIContext[T]) {.async.} =
-    ## Handler Futures live here on the FFI thread's heap, NOT on FFIContext
-    ## (shared pool memory, must stay GC-free); holding them lets destroy await
-    ## and cancel them.
-    var pending: seq[Future[void]]
+
+    var ongoingProcessReq: seq[Future[void]]
 
     while ctx.running.load():
-      ## Recycle requested: claim it (RecyclePending -> Recycling, one-shot) and run
-      ## the recycle on this owning thread, then keep looping so the worker stays
-      ## alive for the context's next reuse.
       var expected = CtxLifecycle.RecyclePending
       if ctx.lifecycle.compareExchange(expected, CtxLifecycle.Recycling):
-        await recycleContext(ctx, addr pending)
+        await recycleContext(ctx, addr ongoingProcessReq)
         continue
 
       let gotSignal = await ctx.reqSignal.wait().withTimeout(100.milliseconds)
@@ -376,10 +326,8 @@ proc ffiThreadBody[T](ctx: ptr FFIContext[T]) {.thread.} =
       if not ctx.reqChannel.tryRecv(request):
         continue
 
-      ## Dispatch and remember the handler's Future (pruning finished ones) so a
-      ## later recycle can await or cancel it.
-      pending.keepItIf(not it.finished())
-      pending.add(processRequest(request, ctx))
+      ongoingProcessReq.keepItIf(not it.finished())
+      ongoingProcessReq.add(processRequest(request, ctx))
 
       let fireRes = ctx.reqReceivedSignal.fireSync()
       if fireRes.isErr():
@@ -427,7 +375,7 @@ proc cleanUpResources[T](ctx: ptr FFIContext[T]): Result[void, string] =
 proc initContextResources*[T](ctx: ptr FFIContext[T]): Result[void, string] =
   ## Initialises all resources inside an already-allocated FFIContext.
   ## On failure every partially-initialised resource is closed; the caller
-  ## is responsible for releasing the context (freeShared or ctx.unclaim()).
+  ## is responsible for releasing the context.
   ctx.lock.initLock()
 
   var success = false
@@ -536,23 +484,16 @@ proc requestRecycle*[T](
     return err("requestRecycle: failed to signal the FFI thread in time")
   return ok()
 
-proc markReacquired*[T](ctx: ptr FFIContext[T]) =
-  ## Re-arms a recycled context when its context is reacquired by createFFIContext:
-  ## moves Recycling -> Active (re-opening the gate). The FFI thread's `pending`
-  ## seq was already drained and myLib freed by the recycle handler.
+proc markAsActive*[T](ctx: ptr FFIContext[T]) =
   ctx.lifecycle.store(CtxLifecycle.Active)
 
 proc tryClaim*[T](ctx: ptr FFIContext[T]): bool =
-  ## Atomically claim this context (false -> true). Returns true if we won it, false
-  ## if it was already claimed. Used by createFFIContext to hand out a free context.
+  ## Returns true if acquired the contex, false if it was already claimed.
   var expected = false
   ctx.inUse.compareExchange(expected, true)
 
-proc unclaim*[T](ctx: ptr FFIContext[T]) =
-  ## Mark the context free for reuse. Called by the recycle handler on the FFI thread
-  ## once teardown is done, and on creation failure / full teardown.
+proc release*[T](ctx: ptr FFIContext[T]) =
   ctx.inUse.store(false)
 
-proc isClaimed*[T](ctx: ptr FFIContext[T]): bool =
-  ## Whether the context is currently claimed by a consumer.
+proc isInUse*[T](ctx: ptr FFIContext[T]): bool =
   ctx.inUse.load()

--- a/ffi/ffi_context.nim
+++ b/ffi/ffi_context.nim
@@ -518,11 +518,11 @@ proc stopAndJoinThreads*[T](ctx: ptr FFIContext[T]): Result[void, string] =
 proc requestRecycle*[T](
     ctx: ptr FFIContext[T], callback: FFICallBack, userData: pointer
 ): Result[void, string] =
-  ## Asks the FFI thread to recycle the context and fire `callback` with the
-  ## outcome (RET_OK drained, RET_ERR stuck). NON-BLOCKING.
+  ## Starts ctx recycle process without stopping its worker, so the next
+  ## createFFIContext reuses the same threads and fds. 
   ##
-  ## Order matters: set the callback before flipping to RecyclePending (the flip is
-  ## the trigger), under `lock` to serialise the gate with sendRequestToFFIThread.
+  ## During recycling, the FFI thread drains the handlers, frees the lib and releases
+  ## the context, then fires `callback` (RET_OK drained, RET_ERR stuck).
   ctx.recycleCallback = callback
   ctx.recycleUserData = userData
 

--- a/ffi/ffi_context_pool.nim
+++ b/ffi/ffi_context_pool.nim
@@ -45,13 +45,6 @@ proc createFFIContext*[T](
 proc releaseFFIContext*[T](
     ctx: ptr FFIContext[T], callback: FFICallBack, userData: pointer
 ): Result[void, string] =
-  ## Parks a context for reuse without stopping its worker, so the next
-  ## createFFIContext reuses the same threads and fds. Steady-state cleanup path
-  ## for the generated destructor; destroyFFIContext is for failure/non-pool use.
-  ##
-  ## NON-BLOCKING: the FFI thread drains the handlers, frees the lib and releases
-  ## the context, then fires `callback` (RET_OK drained, RET_ERR stuck). The context
-  ## returns to the pool from that thread, so a reused context never carries a straggler.
   return ctx.requestRecycle(callback, userData)
 
 proc destroyFFIContext*[T](

--- a/ffi/ffi_context_pool.nim
+++ b/ffi/ffi_context_pool.nim
@@ -52,11 +52,22 @@ proc releaseFFIContext*[T](
     pool: var FFIContextPool[T], ctx: ptr FFIContext[T]
 ): Result[void, string] =
   ## Parks a context for reuse: returns its slot to the pool WITHOUT stopping the
-  ## worker threads, so the next createFFIContext reuses the same fds. The caller
-  ## MUST have already quiesced its library object (e.g. cancelled the object's
-  ## async tasks) on the FFI thread before calling this — the worker keeps
-  ## running. The stale C event callback is dropped so a watchdog tick on the
-  ## parked slot cannot invoke a callback whose user-data may already be freed.
+  ## worker threads, so the next createFFIContext reuses the same fds. This is the
+  ## steady-state cleanup path, called by the generated destructor (ffiDtor);
+  ## destroyFFIContext is only for creation failure and non-pooling callers.
+  ##
+  ## Runs on the CALLER's thread, not the FFI worker thread, and does NOT itself
+  ## wait for in-flight work to finish. It is safe to park here because the
+  ## framework processes one request at a time (see sendRequestToFFIThread): by
+  ## the time the destructor calls this, the worker has finished the previous
+  ## request and is idle (looping on reqSignal), so there is no handler still
+  ## touching the slot when it is reused.
+  ##
+  ## Clearing callbackState removes the stored C event callback. The
+  ## worker/watchdog threads stay alive after parking, so an event could still
+  ## fire on this slot; with no callback set that event does nothing, instead of
+  ## calling back into a consumer that has already released the context (whose
+  ## user-data pointer may now be freed).
   ctx.callbackState = default(FFICallbackState)
   ctx.myLib = nil
   pool.releaseSlot(ctx)

--- a/ffi/ffi_context_pool.nim
+++ b/ffi/ffi_context_pool.nim
@@ -4,34 +4,34 @@ import ./ffi_context, ./ffi_types
 
 const MaxFFIContexts* = 32
   ## Maximum number of concurrently live FFI contexts when using FFIContextPool.
-  ## Fds and threads are only consumed for slots that are actually acquired,
+  ## Fds and threads are only consumed for contexts that are actually acquired,
   ## so this value only affects the upfront memory of the pool array.
 
 type FFIContextPool*[T] = object
   ## Fixed-size pool of FFI contexts. Avoids dynamic heap allocation per context
   ## and bounds the total number of file descriptors consumed by ThreadSignalPtrs
   ## to at most MaxFFIContexts * 2.
-  slots: array[MaxFFIContexts, FFIContext[T]]
+  contexts: array[MaxFFIContexts, FFIContext[T]]
   initialized: array[MaxFFIContexts, Atomic[bool]]
-    ## Whether a slot's worker (threads, chronos dispatcher and ThreadSignalPtrs)
+    ## Whether a context's worker (threads, chronos dispatcher and ThreadSignalPtrs)
     ## has been built. Set on first acquisition and kept set across park/reuse,
-    ## so a reacquired slot reuses the same fds instead of allocating a fresh set
+    ## so a reacquired context reuses the same fds instead of allocating a fresh set
     ## every create/destroy cycle. Cleared only by full teardown.
 
 proc createFFIContext*[T](
     pool: var FFIContextPool[T]
 ): Result[ptr FFIContext[T], string] =
-  ## Acquires a slot from the fixed pool. The slot's worker is built once on
-  ## first use and REUSED on every later acquisition of the same slot (a slot is
+  ## Acquires a context from the fixed pool. The context's worker is built once on
+  ## first use and REUSED on every later acquisition of the same context (a context is
   ## made reacquirable by releaseFFIContext, which parks it without tearing the
   ## worker down). This is what keeps fd usage bounded: repeated create/destroy
   ## cycles no longer leak a fresh set of ThreadSignalPtr/dispatcher fds.
   for i in 0 ..< MaxFFIContexts:
-    let ctx = pool.slots[i].addr
+    let ctx = pool.contexts[i].addr
     if not ctx.tryClaim():
       continue
     if pool.initialized[i].load():
-      ## Reused slot: a prior destroy drained and released it, worker still alive.
+      ## Reused context: a prior destroy drained and released it, worker still alive.
       ## Re-arm the gate and hand it back.
       ctx.markReacquired()
       return ok(ctx)
@@ -50,35 +50,35 @@ proc releaseFFIContext*[T](
   ## for the generated destructor; destroyFFIContext is for failure/non-pool use.
   ##
   ## NON-BLOCKING: the FFI thread drains the handlers, frees the lib and releases
-  ## the slot, then fires `callback` (RET_OK drained, RET_ERR stuck). The slot
-  ## returns to the pool from that thread, so a reused slot never carries a straggler.
+  ## the context, then fires `callback` (RET_OK drained, RET_ERR stuck). The context
+  ## returns to the pool from that thread, so a reused context never carries a straggler.
   return ctx.requestRecycle(callback, userData)
 
 proc destroyFFIContext*[T](
     pool: var FFIContextPool[T], ctx: ptr FFIContext[T]
 ): Result[void, string] =
-  ## Full teardown: stops/joins the worker threads and returns the slot to the
+  ## Full teardown: stops/joins the worker threads and returns the context to the
   ## pool, marking it uninitialised so a later createFFIContext rebuilds it. Used
   ## on creation failure and by non-pooling callers; steady-state cleanup should
   ## use releaseFFIContext to keep fd usage bounded. If the FFI thread is blocked
-  ## and does not exit in time, the slot is leaked rather than reclaimed —
+  ## and does not exit in time, the context is leaked rather than reclaimed —
   ## closing its resources while the thread is still live would be unsafe.
   ctx.stopAndJoinThreads().isOkOr:
     return err("destroyFFIContext(pool): " & $error)
   for i in 0 ..< MaxFFIContexts:
-    if pool.slots[i].addr == ctx:
+    if pool.contexts[i].addr == ctx:
       pool.initialized[i].store(false)
       break
   ctx.unclaim()
   return ok()
 
 proc isValidCtx*[T](pool: var FFIContextPool[T], ctx: pointer): bool =
-  ## Returns true only if ctx points to one of the pool's slots that is
+  ## Returns true only if ctx points to one of the pool's contexts that is
   ## currently in use. Rejects nil, offset-invalid, and dangling pointers
   ## at the API boundary, preventing use-after-free dereferences.
   if ctx.isNil():
     return false
   for i in 0 ..< MaxFFIContexts:
-    if cast[pointer](pool.slots[i].addr) == ctx:
+    if cast[pointer](pool.contexts[i].addr) == ctx:
       return cast[ptr FFIContext[T]](ctx).isClaimed()
   return false

--- a/ffi/ffi_context_pool.nim
+++ b/ffi/ffi_context_pool.nim
@@ -13,13 +13,11 @@ type FFIContextPool*[T] = object
   ## to at most MaxFFIContexts * 2.
   slots: array[MaxFFIContexts, FFIContext[T]]
   inUse: array[MaxFFIContexts, Atomic[bool]]
-
-proc acquireSlot[T](pool: var FFIContextPool[T]): Result[ptr FFIContext[T], string] =
-  for i in 0 ..< MaxFFIContexts:
-    var expected = false
-    if pool.inUse[i].compareExchange(expected, true):
-      return ok(pool.slots[i].addr)
-  return err("FFI context pool exhausted (max " & $MaxFFIContexts & " contexts)")
+  initialized: array[MaxFFIContexts, Atomic[bool]]
+    ## Whether a slot's worker (threads, chronos dispatcher and ThreadSignalPtrs)
+    ## has been built. Set on first acquisition and kept set across park/reuse,
+    ## so a reacquired slot reuses the same fds instead of allocating a fresh set
+    ## every create/destroy cycle. Cleared only by full teardown.
 
 proc releaseSlot[T](pool: var FFIContextPool[T], ctx: ptr FFIContext[T]) =
   for i in 0 ..< MaxFFIContexts:
@@ -30,24 +28,55 @@ proc releaseSlot[T](pool: var FFIContextPool[T], ctx: ptr FFIContext[T]) =
 proc createFFIContext*[T](
     pool: var FFIContextPool[T]
 ): Result[ptr FFIContext[T], string] =
-  ## Acquires a slot from the fixed pool and initialises it as an FFI context.
-  ## Bounded fd usage: at most MaxFFIContexts * 2 ThreadSignalPtr fds are ever open.
-  let ctx = pool.acquireSlot().valueOr:
-    return err("createFFIContext: acquireSlot failed: " & $error)
-  initContextResources(ctx).isOkOr:
-    pool.releaseSlot(ctx)
-    return err("createFFIContext: initContextResources failed: " & $error)
-  return ok(ctx)
+  ## Acquires a slot from the fixed pool. The slot's worker is built once on
+  ## first use and REUSED on every later acquisition of the same slot (a slot is
+  ## made reacquirable by releaseFFIContext, which parks it without tearing the
+  ## worker down). This is what keeps fd usage bounded: repeated create/destroy
+  ## cycles no longer leak a fresh set of ThreadSignalPtr/dispatcher fds.
+  for i in 0 ..< MaxFFIContexts:
+    var expected = false
+    if not pool.inUse[i].compareExchange(expected, true):
+      continue
+    let ctx = pool.slots[i].addr
+    if pool.initialized[i].load():
+      ## Reused slot: worker threads, dispatcher and signals are already alive.
+      return ok(ctx)
+    initContextResources(ctx).isOkOr:
+      pool.inUse[i].store(false)
+      return err("createFFIContext: initContextResources failed: " & $error)
+    pool.initialized[i].store(true)
+    return ok(ctx)
+  return err("FFI context pool exhausted (max " & $MaxFFIContexts & " contexts)")
+
+proc releaseFFIContext*[T](
+    pool: var FFIContextPool[T], ctx: ptr FFIContext[T]
+): Result[void, string] =
+  ## Parks a context for reuse: returns its slot to the pool WITHOUT stopping the
+  ## worker threads, so the next createFFIContext reuses the same fds. The caller
+  ## MUST have already quiesced its library object (e.g. cancelled the object's
+  ## async tasks) on the FFI thread before calling this — the worker keeps
+  ## running. The stale C event callback is dropped so a watchdog tick on the
+  ## parked slot cannot invoke a callback whose user-data may already be freed.
+  ctx.callbackState = default(FFICallbackState)
+  ctx.myLib = nil
+  pool.releaseSlot(ctx)
+  return ok()
 
 proc destroyFFIContext*[T](
     pool: var FFIContextPool[T], ctx: ptr FFIContext[T]
 ): Result[void, string] =
-  ## Stops the FFI context and returns its slot to the pool. If the FFI thread
-  ## is blocked and does not exit in time, the slot is leaked rather than
-  ## reclaimed — closing its resources while the thread is still live would be
-  ## unsafe.
+  ## Full teardown: stops/joins the worker threads and returns the slot to the
+  ## pool, marking it uninitialised so a later createFFIContext rebuilds it. Used
+  ## on creation failure and by non-pooling callers; steady-state cleanup should
+  ## use releaseFFIContext to keep fd usage bounded. If the FFI thread is blocked
+  ## and does not exit in time, the slot is leaked rather than reclaimed —
+  ## closing its resources while the thread is still live would be unsafe.
   ctx.stopAndJoinThreads().isOkOr:
     return err("destroyFFIContext(pool): " & $error)
+  for i in 0 ..< MaxFFIContexts:
+    if pool.slots[i].addr == ctx:
+      pool.initialized[i].store(false)
+      break
   pool.releaseSlot(ctx)
   return ok()
 

--- a/ffi/ffi_context_pool.nim
+++ b/ffi/ffi_context_pool.nim
@@ -43,10 +43,7 @@ proc createFFIContext*[T](
   return err("FFI context pool exhausted (max " & $MaxFFIContexts & " contexts)")
 
 proc releaseFFIContext*[T](
-    pool: var FFIContextPool[T],
-    ctx: ptr FFIContext[T],
-    callback: FFICallBack,
-    userData: pointer,
+    ctx: ptr FFIContext[T], callback: FFICallBack, userData: pointer
 ): Result[void, string] =
   ## Parks a context for reuse without stopping its worker, so the next
   ## createFFIContext reuses the same threads and fds. Steady-state cleanup path

--- a/ffi/ffi_context_pool.nim
+++ b/ffi/ffi_context_pool.nim
@@ -1,6 +1,6 @@
 import std/atomics
 import results
-import ./ffi_context
+import ./ffi_context, ./ffi_types
 
 const MaxFFIContexts* = 32
   ## Maximum number of concurrently live FFI contexts when using FFIContextPool.
@@ -12,18 +12,11 @@ type FFIContextPool*[T] = object
   ## and bounds the total number of file descriptors consumed by ThreadSignalPtrs
   ## to at most MaxFFIContexts * 2.
   slots: array[MaxFFIContexts, FFIContext[T]]
-  inUse: array[MaxFFIContexts, Atomic[bool]]
   initialized: array[MaxFFIContexts, Atomic[bool]]
     ## Whether a slot's worker (threads, chronos dispatcher and ThreadSignalPtrs)
     ## has been built. Set on first acquisition and kept set across park/reuse,
     ## so a reacquired slot reuses the same fds instead of allocating a fresh set
     ## every create/destroy cycle. Cleared only by full teardown.
-
-proc releaseSlot[T](pool: var FFIContextPool[T], ctx: ptr FFIContext[T]) =
-  for i in 0 ..< MaxFFIContexts:
-    if pool.slots[i].addr == ctx:
-      pool.inUse[i].store(false)
-      return
 
 proc createFFIContext*[T](
     pool: var FFIContextPool[T]
@@ -34,44 +27,35 @@ proc createFFIContext*[T](
   ## worker down). This is what keeps fd usage bounded: repeated create/destroy
   ## cycles no longer leak a fresh set of ThreadSignalPtr/dispatcher fds.
   for i in 0 ..< MaxFFIContexts:
-    var expected = false
-    if not pool.inUse[i].compareExchange(expected, true):
-      continue
     let ctx = pool.slots[i].addr
+    if not ctx.tryClaim():
+      continue
     if pool.initialized[i].load():
-      ## Reused slot: worker threads, dispatcher and signals are already alive.
+      ## Reused slot: a prior destroy drained and released it, worker still alive.
+      ## Re-arm the gate and hand it back.
+      ctx.markReacquired()
       return ok(ctx)
     initContextResources(ctx).isOkOr:
-      pool.inUse[i].store(false)
+      ctx.unclaim()
       return err("createFFIContext: initContextResources failed: " & $error)
     pool.initialized[i].store(true)
     return ok(ctx)
   return err("FFI context pool exhausted (max " & $MaxFFIContexts & " contexts)")
 
 proc releaseFFIContext*[T](
-    pool: var FFIContextPool[T], ctx: ptr FFIContext[T]
+    pool: var FFIContextPool[T],
+    ctx: ptr FFIContext[T],
+    callback: FFICallBack,
+    userData: pointer,
 ): Result[void, string] =
-  ## Parks a context for reuse: returns its slot to the pool WITHOUT stopping the
-  ## worker threads, so the next createFFIContext reuses the same fds. This is the
-  ## steady-state cleanup path, called by the generated destructor (ffiDtor);
-  ## destroyFFIContext is only for creation failure and non-pooling callers.
+  ## Parks a context for reuse without stopping its worker, so the next
+  ## createFFIContext reuses the same threads and fds. Steady-state cleanup path
+  ## for the generated destructor; destroyFFIContext is for failure/non-pool use.
   ##
-  ## Runs on the CALLER's thread, not the FFI worker thread, and does NOT itself
-  ## wait for in-flight work to finish. It is safe to park here because the
-  ## framework processes one request at a time (see sendRequestToFFIThread): by
-  ## the time the destructor calls this, the worker has finished the previous
-  ## request and is idle (looping on reqSignal), so there is no handler still
-  ## touching the slot when it is reused.
-  ##
-  ## Clearing callbackState removes the stored C event callback. The
-  ## worker/watchdog threads stay alive after parking, so an event could still
-  ## fire on this slot; with no callback set that event does nothing, instead of
-  ## calling back into a consumer that has already released the context (whose
-  ## user-data pointer may now be freed).
-  ctx.callbackState = default(FFICallbackState)
-  ctx.myLib = nil
-  pool.releaseSlot(ctx)
-  return ok()
+  ## NON-BLOCKING: the FFI thread drains the handlers, frees the lib and releases
+  ## the slot, then fires `callback` (RET_OK drained, RET_ERR stuck). The slot
+  ## returns to the pool from that thread, so a reused slot never carries a straggler.
+  return ctx.requestRecycle(callback, userData)
 
 proc destroyFFIContext*[T](
     pool: var FFIContextPool[T], ctx: ptr FFIContext[T]
@@ -88,7 +72,7 @@ proc destroyFFIContext*[T](
     if pool.slots[i].addr == ctx:
       pool.initialized[i].store(false)
       break
-  pool.releaseSlot(ctx)
+  ctx.unclaim()
   return ok()
 
 proc isValidCtx*[T](pool: var FFIContextPool[T], ctx: pointer): bool =
@@ -99,5 +83,5 @@ proc isValidCtx*[T](pool: var FFIContextPool[T], ctx: pointer): bool =
     return false
   for i in 0 ..< MaxFFIContexts:
     if cast[pointer](pool.slots[i].addr) == ctx:
-      return pool.inUse[i].load()
+      return cast[ptr FFIContext[T]](ctx).isClaimed()
   return false

--- a/ffi/ffi_context_pool.nim
+++ b/ffi/ffi_context_pool.nim
@@ -4,39 +4,27 @@ import ./ffi_context, ./ffi_types
 
 const MaxFFIContexts* = 32
   ## Maximum number of concurrently live FFI contexts when using FFIContextPool.
-  ## Fds and threads are only consumed for contexts that are actually acquired,
-  ## so this value only affects the upfront memory of the pool array.
 
 type FFIContextPool*[T] = object
-  ## Fixed-size pool of FFI contexts. Avoids dynamic heap allocation per context
-  ## and bounds the total number of file descriptors consumed by ThreadSignalPtrs
-  ## to at most MaxFFIContexts * 2.
   contexts: array[MaxFFIContexts, FFIContext[T]]
   initialized: array[MaxFFIContexts, Atomic[bool]]
-    ## Whether a context's worker (threads, chronos dispatcher and ThreadSignalPtrs)
-    ## has been built. Set on first acquisition and kept set across park/reuse,
-    ## so a reacquired context reuses the same fds instead of allocating a fresh set
-    ## every create/destroy cycle. Cleared only by full teardown.
 
 proc createFFIContext*[T](
     pool: var FFIContextPool[T]
 ): Result[ptr FFIContext[T], string] =
   ## Acquires a context from the fixed pool. The context's worker is built once on
-  ## first use and REUSED on every later acquisition of the same context (a context is
-  ## made reacquirable by releaseFFIContext, which parks it without tearing the
-  ## worker down). This is what keeps fd usage bounded: repeated create/destroy
-  ## cycles no longer leak a fresh set of ThreadSignalPtr/dispatcher fds.
+  ## first use and reused on every later acquisition.
+
   for i in 0 ..< MaxFFIContexts:
     let ctx = pool.contexts[i].addr
     if not ctx.tryClaim():
       continue
     if pool.initialized[i].load():
       ## Reused context: a prior destroy drained and released it, worker still alive.
-      ## Re-arm the gate and hand it back.
-      ctx.markReacquired()
+      ctx.markAsActive()
       return ok(ctx)
     initContextResources(ctx).isOkOr:
-      ctx.unclaim()
+      ctx.release()
       return err("createFFIContext: initContextResources failed: " & $error)
     pool.initialized[i].store(true)
     return ok(ctx)
@@ -51,27 +39,22 @@ proc destroyFFIContext*[T](
     pool: var FFIContextPool[T], ctx: ptr FFIContext[T]
 ): Result[void, string] =
   ## Full teardown: stops/joins the worker threads and returns the context to the
-  ## pool, marking it uninitialised so a later createFFIContext rebuilds it. Used
-  ## on creation failure and by non-pooling callers; steady-state cleanup should
-  ## use releaseFFIContext to keep fd usage bounded. If the FFI thread is blocked
-  ## and does not exit in time, the context is leaked rather than reclaimed —
-  ## closing its resources while the thread is still live would be unsafe.
+  ## pool, marking it uninitialised so a later createFFIContext rebuilds it.
   ctx.stopAndJoinThreads().isOkOr:
     return err("destroyFFIContext(pool): " & $error)
   for i in 0 ..< MaxFFIContexts:
     if pool.contexts[i].addr == ctx:
       pool.initialized[i].store(false)
       break
-  ctx.unclaim()
+  ctx.release()
   return ok()
 
 proc isValidCtx*[T](pool: var FFIContextPool[T], ctx: pointer): bool =
   ## Returns true only if ctx points to one of the pool's contexts that is
-  ## currently in use. Rejects nil, offset-invalid, and dangling pointers
-  ## at the API boundary, preventing use-after-free dereferences.
+  ## currently in use.
   if ctx.isNil():
     return false
   for i in 0 ..< MaxFFIContexts:
     if cast[pointer](pool.contexts[i].addr) == ctx:
-      return cast[ptr FFIContext[T]](ctx).isClaimed()
+      return cast[ptr FFIContext[T]](ctx).isInUse()
   return false

--- a/ffi/internal/ffi_macro.nim
+++ b/ffi/internal/ffi_macro.nim
@@ -1565,24 +1565,19 @@ macro ffiDtor*(prc: untyped): untyped =
     ffiBody.add(bodyNode)
 
   let poolIdent = ident($libTypeName & "FFIPool")
-  # Park the slot (releaseFFIContext) instead of tearing it down
-  # (destroyFFIContext) so the next createFFIContext reuses the same worker and
-  # fds — this is what keeps fd usage bounded across create/destroy cycles.
-  # Safe because the framework processes one request at a time
-  # (see sendRequestToFFIThread): by the time this destructor runs the worker is
-  # idle, not mid-request, so parking cannot race an in-flight handler.
+  # Hand teardown to the FFI thread (releaseFFIContext -> requestRecycle), recycling
+  # the slot for reuse to keep fd usage bounded. NON-BLOCKING: returns RET_OK once
+  # accepted; the real outcome arrives via `callback`, so callers must wait on it,
+  # not the return code.
   ffiBody.add quote do:
-    let `destroyResIdent` =
-      `poolIdent`.releaseFFIContext(cast[ptr FFIContext[`libTypeName`]](ctx))
+    let `destroyResIdent` = `poolIdent`.releaseFFIContext(
+      cast[ptr FFIContext[`libTypeName`]](ctx), callback, userData
+    )
     if `destroyResIdent`.isErr():
       if not callback.isNil:
         let errStr = "destroy failed: " & $`destroyResIdent`.error
         callback(RET_ERR, unsafeAddr errStr[0], cast[csize_t](errStr.len), userData)
       return RET_ERR
-
-  ffiBody.add quote do:
-    if not callback.isNil:
-      callback(RET_OK, nil, 0, userData)
     return RET_OK
 
   let ffiProc = newProc(

--- a/ffi/internal/ffi_macro.nim
+++ b/ffi/internal/ffi_macro.nim
@@ -1517,7 +1517,7 @@ macro ffiDtor*(prc: untyped): untyped =
   ## The generated C-exported proc has the signature:
   ##   cint mylibobj_destroy(void* ctx, FfiCallback callback, void* userData)
   ##
-  ## Recycle the slot for reuse to keep fd usage bounded.
+  ## Recycle the context for reuse to keep fd usage bounded.
   ## NON-BLOCKING: returns RET_OK once accepted;
   ## the real outcome arrives via `callback`.
 

--- a/ffi/internal/ffi_macro.nim
+++ b/ffi/internal/ffi_macro.nim
@@ -1567,7 +1567,7 @@ macro ffiDtor*(prc: untyped): untyped =
 
   let poolIdent = ident($libTypeName & "FFIPool")
   ffiBody.add quote do:
-    let `destroyResIdent` = `poolIdent`.releaseFFIContext(
+    let `destroyResIdent` = releaseFFIContext(
       cast[ptr FFIContext[`libTypeName`]](ctx), callback, userData
     )
     if `destroyResIdent`.isErr():

--- a/ffi/internal/ffi_macro.nim
+++ b/ffi/internal/ffi_macro.nim
@@ -1511,14 +1511,15 @@ macro ffiDtor*(prc: untyped): untyped =
   ## The body contains any library-level cleanup to run before context teardown.
   ##
   ## Example:
-  ##   proc waku_destroy*(w: Waku) {.ffiDtor.} =
-  ##     w.cleanup()
+  ##   proc mylibobj_destroy*(obj: MyLibObj) {.ffiDtor.} =
+  ##     obj.cleanup()
   ##
   ## The generated C-exported proc has the signature:
-  ##   cint waku_destroy(void* ctx, FfiCallback callback, void* userData)
+  ##   cint mylibobj_destroy(void* ctx, FfiCallback callback, void* userData)
   ##
-  ## It extracts the library value from ctx, runs the body, then calls
-  ## destroyFFIContext to tear down the FFI thread and free the context.
+  ## Recycle the slot for reuse to keep fd usage bounded.
+  ## NON-BLOCKING: returns RET_OK once accepted;
+  ## the real outcome arrives via `callback`.
 
   let procName = prc[0]
   let formalParams = prc[3]
@@ -1528,7 +1529,7 @@ macro ffiDtor*(prc: untyped): untyped =
     error("ffiDtor: proc must have exactly one parameter (w: LibType)")
 
   let libParamName = formalParams[1][0] # e.g. w
-  let libTypeName = formalParams[1][1]  # e.g. Waku
+  let libTypeName = formalParams[1][1]  # e.g. MyLibObj
 
   let procNameStr = block:
     let raw = $procName
@@ -1565,10 +1566,6 @@ macro ffiDtor*(prc: untyped): untyped =
     ffiBody.add(bodyNode)
 
   let poolIdent = ident($libTypeName & "FFIPool")
-  # Hand teardown to the FFI thread (releaseFFIContext -> requestRecycle), recycling
-  # the slot for reuse to keep fd usage bounded. NON-BLOCKING: returns RET_OK once
-  # accepted; the real outcome arrives via `callback`, so callers must wait on it,
-  # not the return code.
   ffiBody.add quote do:
     let `destroyResIdent` = `poolIdent`.releaseFFIContext(
       cast[ptr FFIContext[`libTypeName`]](ctx), callback, userData

--- a/ffi/internal/ffi_macro.nim
+++ b/ffi/internal/ffi_macro.nim
@@ -1538,7 +1538,7 @@ macro ffiDtor*(prc: untyped): untyped =
   let exportedProcName =
     if procName.kind == nnkPostfix: procName[1] else: procName
 
-  let destroyResIdent = genSym(nskLet, "destroyRes")
+  let releaseResIdent = genSym(nskLet, "destroyRes")
 
   let ffiBody = newStmtList()
 
@@ -1567,12 +1567,12 @@ macro ffiDtor*(prc: untyped): untyped =
 
   let poolIdent = ident($libTypeName & "FFIPool")
   ffiBody.add quote do:
-    let `destroyResIdent` = releaseFFIContext(
+    let `releaseResIdent` = releaseFFIContext(
       cast[ptr FFIContext[`libTypeName`]](ctx), callback, userData
     )
-    if `destroyResIdent`.isErr():
-      if not callback.isNil:
-        let errStr = "destroy failed: " & $`destroyResIdent`.error
+    if `releaseResIdent`.isErr():
+      if not callback.isNil():
+        let errStr = "release failed: " & $`releaseResIdent`.error
         callback(RET_ERR, unsafeAddr errStr[0], cast[csize_t](errStr.len), userData)
       return RET_ERR
     return RET_OK

--- a/ffi/internal/ffi_macro.nim
+++ b/ffi/internal/ffi_macro.nim
@@ -1565,9 +1565,15 @@ macro ffiDtor*(prc: untyped): untyped =
     ffiBody.add(bodyNode)
 
   let poolIdent = ident($libTypeName & "FFIPool")
+  # Park the slot (releaseFFIContext) instead of tearing it down
+  # (destroyFFIContext) so the next createFFIContext reuses the same worker and
+  # fds — this is what keeps fd usage bounded across create/destroy cycles.
+  # Safe because the framework processes one request at a time
+  # (see sendRequestToFFIThread): by the time this destructor runs the worker is
+  # idle, not mid-request, so parking cannot race an in-flight handler.
   ffiBody.add quote do:
     let `destroyResIdent` =
-      `poolIdent`.destroyFFIContext(cast[ptr FFIContext[`libTypeName`]](ctx))
+      `poolIdent`.releaseFFIContext(cast[ptr FFIContext[`libTypeName`]](ctx))
     if `destroyResIdent`.isErr():
       if not callback.isNil:
         let errStr = "destroy failed: " & $`destroyResIdent`.error

--- a/tests/test_ffi_context.nim
+++ b/tests/test_ffi_context.nim
@@ -129,18 +129,18 @@ suite "FFIContextPool":
       return
     check pool.destroyFFIContext(ctx).isOk()
 
-  test "slot is reused after destroy":
+  test "context is reused after destroy":
     var pool: FFIContextPool[TestLib]
     let ctx1 = pool.createFFIContext().valueOr:
       assert false, "createFFIContext(pool) failed: " & $error
       return
     check pool.destroyFFIContext(ctx1).isOk()
-    # After destroying, the same slot must be available again
+    # After destroying, the same context must be available again
     let ctx2 = pool.createFFIContext().valueOr:
-      assert false, "createFFIContext(pool) failed after slot release: " & $error
+      assert false, "createFFIContext(pool) failed after context release: " & $error
       return
     check pool.destroyFFIContext(ctx2).isOk()
-    check ctx1 == ctx2 # same array slot reused
+    check ctx1 == ctx2 # same context reused
 
   test "pool exhaustion returns error":
     var pool: FFIContextPool[TestLib]
@@ -149,7 +149,7 @@ suite "FFIContextPool":
       ctxs[i] = pool.createFFIContext().valueOr:
         for j in 0 ..< i:
           discard pool.destroyFFIContext(ctxs[j])
-        assert false, "createFFIContext(pool) failed at slot " & $i & ": " & $error
+        assert false, "createFFIContext(pool) failed at context " & $i & ": " & $error
         return
     # Pool is now full — next create must fail
     check pool.createFFIContext().isErr()
@@ -471,7 +471,7 @@ proc createSimpleLib(initialValue: int): ptr FFIContext[SimpleLib] =
   return cast[ptr FFIContext[SimpleLib]](cast[uint](parseBiggestUInt(callbackMsg(d))))
 
 suite "ffiDtor macro (async destroy + reuse)":
-  test "destroy fires RET_OK after teardown, frees myLib, and frees the slot":
+  test "destroy fires RET_OK after teardown, frees myLib, and frees the context":
     let ctx = createSimpleLib(5)
     check not ctx[].myLib.isNil
     check ctx[].myLib[].value == 5
@@ -489,9 +489,9 @@ suite "ffiDtor macro (async destroy + reuse)":
     check gDestroyedValue == 5 # the user cleanup body saw the live lib
     check ctx[].myLib.isNil() # freed on the FFI thread
 
-    # The slot was freed from the FFI thread, so a fresh create reclaims it.
+    # The context was freed from the FFI thread, so a fresh create reclaims it.
     let ctx2 = createSimpleLib(9)
-    check ctx2 == ctx # same slot, reused worker + fds
+    check ctx2 == ctx # same context, reused worker + fds
     check ctx2[].myLib[].value == 9
     check SimpleLibFFIPool.destroyFFIContext(ctx2).isOk()
 
@@ -531,7 +531,7 @@ suite "ffiDtor macro (async destroy + reuse)":
     waitCallback(dD)
     check dD.retCode == RET_OK
 
-    # Gate stays closed until the slot is reacquired: a late request must not
+    # Gate stays closed until the context is reacquired: a late request must not
     # dispatch onto a context about to be (or already) reused.
     var d: CallbackData
     initCallbackData(d)
@@ -568,8 +568,8 @@ suite "ffiDtor macro (async destroy + reuse)":
     waitCallback(dD)
     check dD.retCode == RET_ERR # drain timed out -> ctx reported stuck
 
-    # The stuck slot is leaked (not reused); the handler still finishes on its
-    # own. Wait for it, then fully tear the leaked slot down.
+    # The stuck context is leaked (not reused); the handler still finishes on its
+    # own. Wait for it, then fully tear the leaked context down.
     waitCallback(slow)
     check SimpleLibFFIPool.destroyFFIContext(ctx).isOk()
 
@@ -798,7 +798,7 @@ proc countOpenFds(): int =
 proc releaseAndWait[T](ctx: ptr FFIContext[T]): cint =
   ## Test helper mirroring how a C consumer destroys a context: kick off the
   ## (non-blocking) teardown and block on the callback, returning its retCode.
-  ## RET_OK means the lib's in-flight tasks finished and the slot was parked.
+  ## RET_OK means the lib's in-flight tasks finished and the context was parked.
   var d: CallbackData
   initCallbackData(d)
   defer:
@@ -809,14 +809,14 @@ proc releaseAndWait[T](ctx: ptr FFIContext[T]): cint =
   return d.retCode
 
 suite "releaseFFIContext (park & reuse)":
-  test "park returns the slot and reuses the same live worker":
+  test "park returns the context and reuses the same live worker":
     var pool: FFIContextPool[TestLib]
     let ctx1 = pool.createFFIContext().valueOr:
       check false
       return
     check ctx1.releaseAndWait() == RET_OK
 
-    # Reacquire: must be the same array slot, with its worker still running.
+    # Reacquire: must be the same context, with its worker still running.
     let ctx2 = pool.createFFIContext().valueOr:
       check false
       return
@@ -856,7 +856,7 @@ suite "releaseFFIContext (park & reuse)":
     else:
       var pool: FFIContextPool[TestLib]
 
-      # Warm up: the first create builds the slot's worker (its fds are allocated
+      # Warm up: the first create builds the context's worker (its fds are allocated
       # once here); parking keeps them open for reuse.
       block:
         let ctx = pool.createFFIContext().valueOr:
@@ -885,7 +885,7 @@ suite "releaseFFIContext (park & reuse)":
       # only tolerates unrelated runtime fd noise, not a per-cycle leak.
       check afterCycles <= baseline + 5
 
-      # Tear the (still parked) slot's worker down so the test leaves no threads.
+      # Tear the (still parked) context's worker down so the test leaves no threads.
       let last = pool.createFFIContext().valueOr:
         check false
         return

--- a/tests/test_ffi_context.nim
+++ b/tests/test_ffi_context.nim
@@ -421,6 +421,12 @@ proc testlib_create*(
 ): Future[Result[SimpleLib, string]] {.ffiCtor.} =
   return ok(SimpleLib(value: config.initialValue))
 
+# Records the value of the library object the destructor body saw, so a test can
+# confirm the user cleanup body ran with the right lib state before teardown.
+var gDestroyedValue {.threadvar.}: int
+proc testlib_destroy*(lib: SimpleLib) {.ffiDtor.} =
+  gDestroyedValue = lib.value
+
 suite "ffiCtor macro":
   test "creates context and returns pointer via callback":
     var d: CallbackData
@@ -448,6 +454,123 @@ suite "ffiCtor macro":
     check not ctx[].myLib.isNil
     check ctx[].myLib[].value == 42
 
+    check SimpleLibFFIPool.destroyFFIContext(ctx).isOk()
+
+proc createSimpleLib(initialValue: int): ptr FFIContext[SimpleLib] =
+  ## Helper: run the generated async ctor and return the live ctx.
+  var d: CallbackData
+  initCallbackData(d)
+  defer:
+    deinitCallbackData(d)
+  let ret =
+    testlib_create(ffiSerialize(SimpleConfig(initialValue: initialValue)).cstring,
+      testCallback, addr d)
+  doAssert not ret.isNil()
+  waitCallback(d)
+  doAssert d.retCode == RET_OK
+  return cast[ptr FFIContext[SimpleLib]](cast[uint](parseBiggestUInt(callbackMsg(d))))
+
+suite "ffiDtor macro (async destroy + reuse)":
+  test "destroy fires RET_OK after teardown, frees myLib, and frees the slot":
+    let ctx = createSimpleLib(5)
+    check not ctx[].myLib.isNil
+    check ctx[].myLib[].value == 5
+
+    var dD: CallbackData
+    initCallbackData(dD)
+    defer:
+      deinitCallbackData(dD)
+
+    # Async destroy: the C return is just "accepted"; the real outcome arrives
+    # via the callback once the FFI thread has finished tearing the lib down.
+    check testlib_destroy(cast[pointer](ctx), testCallback, addr dD) == RET_OK
+    waitCallback(dD)
+    check dD.retCode == RET_OK
+    check gDestroyedValue == 5 # the user cleanup body saw the live lib
+    check ctx[].myLib.isNil() # freed on the FFI thread
+
+    # The slot was freed from the FFI thread, so a fresh create reclaims it.
+    let ctx2 = createSimpleLib(9)
+    check ctx2 == ctx # same slot, reused worker + fds
+    check ctx2[].myLib[].value == 9
+    check SimpleLibFFIPool.destroyFFIContext(ctx2).isOk()
+
+  test "destroy waits for an in-flight request before reporting RET_OK":
+    let ctx = createSimpleLib(1)
+
+    # Dispatch a 500 ms handler and do NOT wait — it is in flight at destroy time.
+    var slow: CallbackData
+    initCallbackData(slow)
+    defer:
+      deinitCallbackData(slow)
+    check sendRequestToFFIThread(ctx, SlowRequest.ffiNewReq(testCallback, addr slow)).isOk()
+
+    var dD: CallbackData
+    initCallbackData(dD)
+    defer:
+      deinitCallbackData(dD)
+    check testlib_destroy(cast[pointer](ctx), testCallback, addr dD) == RET_OK
+    waitCallback(dD)
+    check dD.retCode == RET_OK
+    # Drained: the in-flight handler ran to completion before destroy reported OK.
+    check slow.called
+    check callbackMsg(slow) == "slow-done"
+
+    let ctx2 = createSimpleLib(2)
+    check ctx2 == ctx
+    check SimpleLibFFIPool.destroyFFIContext(ctx2).isOk()
+
+  test "requests are rejected once a destroy closes the gate":
+    let ctx = createSimpleLib(3)
+
+    var dD: CallbackData
+    initCallbackData(dD)
+    defer:
+      deinitCallbackData(dD)
+    check testlib_destroy(cast[pointer](ctx), testCallback, addr dD) == RET_OK
+    waitCallback(dD)
+    check dD.retCode == RET_OK
+
+    # Gate stays closed until the slot is reacquired: a late request must not
+    # dispatch onto a context about to be (or already) reused.
+    var d: CallbackData
+    initCallbackData(d)
+    defer:
+      deinitCallbackData(d)
+    check sendRequestToFFIThread(
+      ctx, SlowRequest.ffiNewReq(testCallback, addr d)
+    ).isErr()
+
+    let ctx2 = createSimpleLib(4)
+    check ctx2 == ctx
+    check SimpleLibFFIPool.destroyFFIContext(ctx2).isOk()
+
+  test "a stuck context is reported as RET_ERR rather than hanging":
+    let ctx = createSimpleLib(8)
+
+    let savedTimeout = RecycleTimeout
+    RecycleTimeout = 150.milliseconds
+    defer:
+      RecycleTimeout = savedTimeout
+
+    # In-flight handler outlasts the (shortened) drain timeout.
+    var slow: CallbackData
+    initCallbackData(slow)
+    defer:
+      deinitCallbackData(slow)
+    check sendRequestToFFIThread(ctx, SlowRequest.ffiNewReq(testCallback, addr slow)).isOk()
+
+    var dD: CallbackData
+    initCallbackData(dD)
+    defer:
+      deinitCallbackData(dD)
+    check testlib_destroy(cast[pointer](ctx), testCallback, addr dD) == RET_OK
+    waitCallback(dD)
+    check dD.retCode == RET_ERR # drain timed out -> ctx reported stuck
+
+    # The stuck slot is leaked (not reused); the handler still finishes on its
+    # own. Wait for it, then fully tear the leaked slot down.
+    waitCallback(slow)
     check SimpleLibFFIPool.destroyFFIContext(ctx).isOk()
 
 # ---------------------------------------------------------------------------
@@ -672,13 +795,26 @@ proc countOpenFds(): int =
     except CatchableError:
       return -1
 
+proc releaseAndWait[T](pool: var FFIContextPool[T], ctx: ptr FFIContext[T]): cint =
+  ## Test helper mirroring how a C consumer destroys a context: kick off the
+  ## (non-blocking) teardown and block on the callback, returning its retCode.
+  ## RET_OK means the lib's in-flight tasks finished and the slot was parked.
+  var d: CallbackData
+  initCallbackData(d)
+  defer:
+    deinitCallbackData(d)
+  if pool.releaseFFIContext(ctx, testCallback, addr d).isErr():
+    return RET_ERR
+  waitCallback(d)
+  return d.retCode
+
 suite "releaseFFIContext (park & reuse)":
   test "park returns the slot and reuses the same live worker":
     var pool: FFIContextPool[TestLib]
     let ctx1 = pool.createFFIContext().valueOr:
       check false
       return
-    check pool.releaseFFIContext(ctx1).isOk()
+    check pool.releaseAndWait(ctx1) == RET_OK
 
     # Reacquire: must be the same array slot, with its worker still running.
     let ctx2 = pool.createFFIContext().valueOr:
@@ -707,7 +843,7 @@ suite "releaseFFIContext (park & reuse)":
     ctx.callbackState.callback = cast[pointer](testCallback)
     ctx.callbackState.userData = cast[pointer](0xDEAD)
 
-    check pool.releaseFFIContext(ctx).isOk()
+    check pool.releaseAndWait(ctx) == RET_OK
     check ctx.callbackState.callback.isNil() # a watchdog tick can't call a freed cb
     check ctx.callbackState.userData.isNil()
     check ctx.myLib.isNil()
@@ -726,7 +862,7 @@ suite "releaseFFIContext (park & reuse)":
         let ctx = pool.createFFIContext().valueOr:
           check false
           return
-        check pool.releaseFFIContext(ctx).isOk()
+        check pool.releaseAndWait(ctx) == RET_OK
 
       let baseline = countOpenFds()
 
@@ -741,7 +877,7 @@ suite "releaseFFIContext (park & reuse)":
         ).isOk()
         waitCallback(d)
         deinitCallbackData(d)
-        check pool.releaseFFIContext(ctx).isOk()
+        check pool.releaseAndWait(ctx) == RET_OK
 
       let afterCycles = countOpenFds()
       # Reuse must not grow fds. Before the fix each cycle leaked ~10 fds (4

--- a/tests/test_ffi_context.nim
+++ b/tests/test_ffi_context.nim
@@ -1,4 +1,4 @@
-import std/[locks, strutils, os]
+import std/[locks, strutils, os, osproc, sequtils]
 import unittest2
 import results
 import ../ffi
@@ -648,3 +648,109 @@ suite "ptr return type in .ffi.":
 
     waitCallback(freeD)
     check freeD.retCode == RET_OK
+
+# ---------------------------------------------------------------------------
+# releaseFFIContext: park & reuse (fd-leak regression)
+# ---------------------------------------------------------------------------
+
+proc countOpenFds(): int =
+  ## Number of open fds for this process, or -1 if not determinable on this
+  ## platform. On Linux we count /proc/self/fd; elsewhere we shell out to lsof
+  ## (skipped if lsof is unavailable, e.g. Windows).
+  when defined(linux):
+    var n = 0
+    for _ in walkDir("/proc/self/fd"):
+      inc n
+    return n
+  else:
+    if findExe("lsof").len == 0:
+      return -1
+    try:
+      let output =
+        execProcess("lsof", args = ["-p", $getCurrentProcessId()], options = {poUsePath})
+      return output.splitLines().countIt(it.len > 0)
+    except CatchableError:
+      return -1
+
+suite "releaseFFIContext (park & reuse)":
+  test "park returns the slot and reuses the same live worker":
+    var pool: FFIContextPool[TestLib]
+    let ctx1 = pool.createFFIContext().valueOr:
+      check false
+      return
+    check pool.releaseFFIContext(ctx1).isOk()
+
+    # Reacquire: must be the same array slot, with its worker still running.
+    let ctx2 = pool.createFFIContext().valueOr:
+      check false
+      return
+    check ctx1 == ctx2
+
+    var d: CallbackData
+    initCallbackData(d)
+    defer:
+      deinitCallbackData(d)
+    check sendRequestToFFIThread(
+      ctx2, PingRequest.ffiNewReq(testCallback, addr d, "reuse".cstring)
+    ).isOk()
+    waitCallback(d)
+    check d.retCode == RET_OK
+    check callbackMsg(d) == "pong:reuse" # reused worker still processes requests
+
+    check pool.destroyFFIContext(ctx2).isOk()
+
+  test "park drops the stale event callback and library pointer":
+    var pool: FFIContextPool[TestLib]
+    let ctx = pool.createFFIContext().valueOr:
+      check false
+      return
+    ctx.callbackState.callback = cast[pointer](testCallback)
+    ctx.callbackState.userData = cast[pointer](0xDEAD)
+
+    check pool.releaseFFIContext(ctx).isOk()
+    check ctx.callbackState.callback.isNil() # a watchdog tick can't call a freed cb
+    check ctx.callbackState.userData.isNil()
+    check ctx.myLib.isNil()
+
+    check pool.destroyFFIContext(ctx).isOk()
+
+  test "fd usage stays bounded across many park/reuse cycles":
+    if countOpenFds() < 0:
+      skip() # no fd-counting facility on this platform
+    else:
+      var pool: FFIContextPool[TestLib]
+
+      # Warm up: the first create builds the slot's worker (its fds are allocated
+      # once here); parking keeps them open for reuse.
+      block:
+        let ctx = pool.createFFIContext().valueOr:
+          check false
+          return
+        check pool.releaseFFIContext(ctx).isOk()
+
+      let baseline = countOpenFds()
+
+      for _ in 0 ..< 20:
+        let ctx = pool.createFFIContext().valueOr:
+          check false
+          return
+        var d: CallbackData
+        initCallbackData(d)
+        check sendRequestToFFIThread(
+          ctx, PingRequest.ffiNewReq(testCallback, addr d, "x".cstring)
+        ).isOk()
+        waitCallback(d)
+        deinitCallbackData(d)
+        check pool.releaseFFIContext(ctx).isOk()
+
+      let afterCycles = countOpenFds()
+      # Reuse must not grow fds. Before the fix each cycle leaked ~10 fds (4
+      # ThreadSignalPtr socketpairs + 2 dispatcher kqueues); the small slack
+      # only tolerates unrelated runtime fd noise, not a per-cycle leak.
+      check afterCycles <= baseline + 5
+
+      # Tear the (still parked) slot's worker down so the test leaves no threads.
+      let last = pool.createFFIContext().valueOr:
+        check false
+        return
+      check pool.destroyFFIContext(last).isOk()

--- a/tests/test_ffi_context.nim
+++ b/tests/test_ffi_context.nim
@@ -795,7 +795,7 @@ proc countOpenFds(): int =
     except CatchableError:
       return -1
 
-proc releaseAndWait[T](pool: var FFIContextPool[T], ctx: ptr FFIContext[T]): cint =
+proc releaseAndWait[T](ctx: ptr FFIContext[T]): cint =
   ## Test helper mirroring how a C consumer destroys a context: kick off the
   ## (non-blocking) teardown and block on the callback, returning its retCode.
   ## RET_OK means the lib's in-flight tasks finished and the slot was parked.
@@ -803,7 +803,7 @@ proc releaseAndWait[T](pool: var FFIContextPool[T], ctx: ptr FFIContext[T]): cin
   initCallbackData(d)
   defer:
     deinitCallbackData(d)
-  if pool.releaseFFIContext(ctx, testCallback, addr d).isErr():
+  if ctx.releaseFFIContext(testCallback, addr d).isErr():
     return RET_ERR
   waitCallback(d)
   return d.retCode
@@ -814,7 +814,7 @@ suite "releaseFFIContext (park & reuse)":
     let ctx1 = pool.createFFIContext().valueOr:
       check false
       return
-    check pool.releaseAndWait(ctx1) == RET_OK
+    check ctx1.releaseAndWait() == RET_OK
 
     # Reacquire: must be the same array slot, with its worker still running.
     let ctx2 = pool.createFFIContext().valueOr:
@@ -843,7 +843,7 @@ suite "releaseFFIContext (park & reuse)":
     ctx.callbackState.callback = cast[pointer](testCallback)
     ctx.callbackState.userData = cast[pointer](0xDEAD)
 
-    check pool.releaseAndWait(ctx) == RET_OK
+    check ctx.releaseAndWait() == RET_OK
     check ctx.callbackState.callback.isNil() # a watchdog tick can't call a freed cb
     check ctx.callbackState.userData.isNil()
     check ctx.myLib.isNil()
@@ -862,7 +862,7 @@ suite "releaseFFIContext (park & reuse)":
         let ctx = pool.createFFIContext().valueOr:
           check false
           return
-        check pool.releaseAndWait(ctx) == RET_OK
+        check ctx.releaseAndWait() == RET_OK
 
       let baseline = countOpenFds()
 
@@ -877,7 +877,7 @@ suite "releaseFFIContext (park & reuse)":
         ).isOk()
         waitCallback(d)
         deinitCallbackData(d)
-        check pool.releaseAndWait(ctx) == RET_OK
+        check ctx.releaseAndWait() == RET_OK
 
       let afterCycles = countOpenFds()
       # Reuse must not grow fds. Before the fix each cycle leaked ~10 fds (4


### PR DESCRIPTION
destroyFFIContext stopped and joined the worker threads on every release, and createFFIContext rebuilt them on the next acquire. Each cycle therefore allocated a fresh worker — 4 ThreadSignalPtr socketpairs + the ffi/watchdog thread chronos dispatcher kqueues — and never reclaimed the old ones (the pool deliberately skips closing them, relying on slot reuse that never actually reused the resources). A consumer that creates and destroys contexts repeatedly (e.g. nim-sds ReliabilityManager) leaked ~10 fds per cycle, unbounded.

Make the pool genuinely reuse a slot's worker:

- Track per-slot `initialized`; createFFIContext builds the worker once and reuses it on every later acquisition of the same slot.
- Add releaseFFIContext: parks a context (returns its slot) WITHOUT stopping the threads, so the next acquire reuses the same fds. It also drops the stale C event callback so a watchdog tick on a parked slot cannot invoke a callback whose user-data the consumer may already have freed. The caller is responsible for quiescing its library object (on the FFI thread) first.
- destroyFFIContext keeps full-teardown semantics for error/non-pooling paths and now marks the slot uninitialised so a later acquire rebuilds it.

Tests: add a park & reuse suite (same-slot live-worker reuse, callback/lib pointer dropped on park, and fd usage bounded across 20 park/reuse cycles). The fd test fails by ~10 fds/cycle against the pre-fix behaviour. Green under both --mm:refc and --mm:orc.