### PR TITLE
docs: backfill 0.1.5 changelog with noSignalHandler guard and #83

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,15 @@
 
 [Full changelog](https://github.com/logos-messaging/nim-ffi/compare/v0.1.4...v0.1.5)
 
+### Added
+
+- Compile-time guard that requires consumers to build with
+  `-d:noSignalHandler`, failing the build with an actionable message so the
+  Nim runtime never clobbers the foreign host's signal handling.
+
 ### Fixed
 
+- Foreign-host (Go) concurrency crashes (#83).
 - Recycle FFI contexts in the pool instead of tearing them down per cycle,
   stopping a per-cycle file-descriptor leak (#74).
 


### PR DESCRIPTION
## Summary

The `v0.1.5` tag points to HEAD but includes two commits that landed *after* the 0.1.5 changelog entry, so the released changelog under-reported what actually shipped:

- `d4c87c1` — enforce `-d:noSignalHandler` at compile time
- `0a6bf6c` — fix foreign-host (Go) concurrency crashes (#83)

This backfills both under the existing `0.1.5` section so the changelog matches the tagged release.

## Changes

- **Added**: compile-time guard requiring `-d:noSignalHandler`.
- **Fixed**: foreign-host (Go) concurrency crashes (#83).

🤖 Generated with [Claude Code](https://claude.com/claude-code)