### PR TITLE
chore: bump Nim to 2.2.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
       nim-versions:
         required: true
         type: string
-        description: JSON array of Nim versions to run the matrix against, e.g. '["2.2.4","stable"]'.
+        description: JSON array of Nim versions to run the matrix against, e.g. '["2.2.6","stable"]'.
       nimble-version:
         required: true
         type: string

--- a/.github/workflows/tests-sanitized.yml
+++ b/.github/workflows/tests-sanitized.yml
@@ -9,7 +9,7 @@ on:
       nim-versions:
         required: true
         type: string
-        description: JSON array of Nim versions to run the matrix against, e.g. '["2.2.4","stable"]'.
+        description: JSON array of Nim versions to run the matrix against, e.g. '["2.2.6","stable"]'.
       nimble-version:
         required: true
         type: string

--- a/examples/echo/echo.nimble
+++ b/examples/echo/echo.nimble
@@ -5,7 +5,7 @@ description =
   "Second nim-ffi example library, used as the cross-library partner of the timer example in C++ e2e tests"
 license = "MIT or Apache License 2.0"
 
-requires "nim >= 2.2.4"
+requires "nim >= 2.2.6"
 requires "chronos"
 requires "chronicles"
 requires "taskpools"

--- a/examples/timer/timer.nimble
+++ b/examples/timer/timer.nimble
@@ -4,7 +4,7 @@ author = "Institute of Free Technology"
 description = "Example Nim timer library using nim-ffi"
 license = "MIT or Apache License 2.0"
 
-requires "nim >= 2.2.4"
+requires "nim >= 2.2.6"
 requires "chronos"
 requires "chronicles"
 requires "taskpools"

--- a/ffi.nimble
+++ b/ffi.nimble
@@ -7,7 +7,7 @@ license = "MIT or Apache License 2.0"
 
 packageName = "ffi"
 
-requires "nim >= 2.2.4"
+requires "nim >= 2.2.6"
 requires "chronos"
 requires "chronicles"
 requires "taskpools"

--- a/versions.env
+++ b/versions.env
@@ -1,2 +1,2 @@
-NIM_VERSIONS=["2.2.4","stable"]
+NIM_VERSIONS=["2.2.6","stable"]
 NIMBLE_VERSION=0.22.3


### PR DESCRIPTION
## Summary

Bumps the project's Nim from 2.2.4 to 2.2.6 across the CI matrix, the `requires` floors, and the workflow input docs. `stable` is retained as the second matrix entry.

The minimum-supported version is raised deliberately: CI now only exercises 2.2.6 and `stable`, so the `requires` floors are moved to match what is actually tested rather than claiming support for an untested 2.2.4/2.2.5. There is no 2.2.6-specific language feature in play — no `NimMajor`/`NimMinor` guards exist in the tree — this is purely a toolchain refresh.

`v2.2.6` is a real upstream tag, so `jiro4989/setup-nim-action@v2` resolves it; the bump is install-safe.

## Changes

- `versions.env` — `NIM_VERSIONS=["2.2.6","stable"]` (CI matrix source of truth)
- `ffi.nimble`, `examples/timer/timer.nimble`, `examples/echo/echo.nimble` — `requires "nim >= 2.2.6"`
- `.github/workflows/test.yml`, `.github/workflows/tests-sanitized.yml` — `nim-versions` input example text updated to `["2.2.6","stable"]`

`NIMBLE_VERSION` (0.22.3) is unchanged.

## Notes

The existing nimble `exec`-exit-0 workaround (`ffi.nimble`) targets the nimble shipping with Nim 2.2.10+; since 2.2.6 is below that, it remains necessary and its comment is still accurate.