### PR TITLE
feat(ffi): sharded MPSC request ingress (alternative to lock-free #98)

### DIFF
--- a/examples/timer/rust_bindings/src/api.rs
+++ b/examples/timer/rust_bindings/src/api.rs
@@ -129,12 +129,13 @@ pub struct MyTimerCtx {
 
 // SAFETY: The `ptr` field points to an FFIContext owned by the Nim runtime.
 // Every call through the generated FFI proc goes through
-// `sendRequestToFFIThread` on the Nim side, which serialises every request
-// behind `ctx.lock` and dispatches handlers on a single FFI thread, so the
-// pointer is never accessed concurrently from Rust. The Nim-side reentrancy
-// guard (`onFFIThread` threadvar) prevents handlers from re-entering the
-// dispatcher and self-deadlocking. These invariants make it sound to mark
-// the wrapper as Send + Sync.
+// `sendRequestToFFIThread` on the Nim side, which only enqueues the request
+// onto a mutex-guarded MPSC queue (sound from any number of threads) and
+// wakes the single FFI thread that dispatches every handler. The context is
+// thus never mutated non-atomically from the caller's thread. The Nim-side
+// reentrancy guard (`onFFIThread` threadvar) prevents handlers from
+// re-entering the dispatcher. These invariants make it sound to mark the
+// wrapper as Send + Sync.
 unsafe impl Send for MyTimerCtx {}
 unsafe impl Sync for MyTimerCtx {}
 

--- a/ffi/codegen/rust.nim
+++ b/ffi/codegen/rust.nim
@@ -505,19 +505,18 @@ proc generateApiRs*(
   )
   lines.add("// Every call through the generated FFI proc goes through")
   lines.add(
-    "// `sendRequestToFFIThread` on the Nim side, which serialises every request"
+    "// `sendRequestToFFIThread` on the Nim side, which only enqueues the request"
+  )
+  lines.add("// onto a mutex-guarded MPSC queue (sound from any number of threads) and")
+  lines.add(
+    "// wakes the single FFI thread that dispatches every handler. The context is"
   )
   lines.add(
-    "// behind `ctx.lock` and dispatches handlers on a single FFI thread, so the"
+    "// thus never mutated non-atomically from the caller's thread. The Nim-side"
   )
-  lines.add(
-    "// pointer is never accessed concurrently from Rust. The Nim-side reentrancy"
-  )
-  lines.add("// guard (`onFFIThread` threadvar) prevents handlers from re-entering the")
-  lines.add(
-    "// dispatcher and self-deadlocking. These invariants make it sound to mark"
-  )
-  lines.add("// the wrapper as Send + Sync.")
+  lines.add("// reentrancy guard (`onFFIThread` threadvar) prevents handlers from")
+  lines.add("// re-entering the dispatcher. These invariants make it sound to mark the")
+  lines.add("// wrapper as Send + Sync.")
   lines.add("unsafe impl Send for $1 {}" % [ctxTypeName])
   lines.add("unsafe impl Sync for $1 {}" % [ctxTypeName])
   lines.add("")

--- a/ffi/ffi_context.nim
+++ b/ffi/ffi_context.nim
@@ -23,7 +23,7 @@ type FFIContext*[T] = object
   myLib*: ptr T # main library object (Waku, LibP2P, SDS, …)
   ffiThread: Thread[(ptr FFIContext[T])]
   eventThread: Thread[(ptr FFIContext[T])]
-  reqQueue: FFIRequestQueue # mutex-guarded MPSC ingress from foreign threads
+  reqQueueBank: RequestQueueBank # mutex-guarded MPSC ingress from foreign threads
   reqSignal: ThreadSignalPtr # wakes the FFI thread on enqueue
   stopSignal: ThreadSignalPtr
   threadExitSignal: ThreadSignalPtr
@@ -62,7 +62,7 @@ proc deinitContextResources*[T](ctx: ptr FFIContext[T]): Result[void, string] =
   ## Mirror of `initContextResources`. Threads MUST be joined first (FFI thread
   ## drained); fields are nil'd after close so re-init on the same slot is safe.
   ## `deinitRequestQueue` frees any request raced in after the final drain.
-  deinitRequestQueue(ctx[].reqQueue)
+  deinitRequestQueue(ctx[].reqQueueBank)
   deinitEventRegistry(ctx[].eventRegistry)
   deinitHandleRegistry(ctx[].handles)
   deinitEventQueue(ctx[].eventQueue)
@@ -99,7 +99,7 @@ proc initContextResources*[T](ctx: ptr FFIContext[T]): Result[void, string] =
   ctx.threadExitSignal = nil
   ctx.eventQueueSignal = nil
   ctx.eventThreadExitSignal = nil
-  initRequestQueue(ctx[].reqQueue)
+  initRequestQueue(ctx[].reqQueueBank)
   initEventRegistry(ctx[].eventRegistry)
   initHandleRegistry(ctx[].handles)
   initEventQueue(ctx[].eventQueue)

--- a/ffi/ffi_context.nim
+++ b/ffi/ffi_context.nim
@@ -59,10 +59,9 @@ template closeAndNil(field: untyped) =
     field = nil
 
 proc deinitContextResources*[T](ctx: ptr FFIContext[T]): Result[void, string] =
-  ## Mirror of `initContextResources`. Threads MUST be joined first (so the FFI
-  ## thread has drained the queue); fields are nil'd after close so re-init on
-  ## the same slot is safe. `deinitRequestQueue` frees any request a producer
-  ## raced in after the final drain, so teardown leaks nothing.
+  ## Mirror of `initContextResources`. Threads MUST be joined first (FFI thread
+  ## drained); fields are nil'd after close so re-init on the same slot is safe.
+  ## `deinitRequestQueue` frees any request raced in after the final drain.
   deinitRequestQueue(ctx[].reqQueue)
   deinitEventRegistry(ctx[].eventRegistry)
   deinitHandleRegistry(ctx[].handles)

--- a/ffi/ffi_context.nim
+++ b/ffi/ffi_context.nim
@@ -7,12 +7,13 @@
 {.passc: "-fPIC".}
 
 import std/[atomics, locks, options, tables]
-import chronicles, chronos, chronos/threadsync, taskpools/channels_spsc_single, results
+import chronicles, chronos, chronos/threadsync, results
 import
   ./ffi_types,
   ./ffi_events,
   ./ffi_handles,
   ./ffi_thread_request,
+  ./ffi_request_queue,
   ./logging,
   ./cbor_serial
 
@@ -22,10 +23,8 @@ type FFIContext*[T] = object
   myLib*: ptr T # main library object (Waku, LibP2P, SDS, …)
   ffiThread: Thread[(ptr FFIContext[T])]
   eventThread: Thread[(ptr FFIContext[T])]
-  lock: Lock
-  reqChannel: ChannelSPSCSingle[ptr FFIThreadRequest]
-  reqSignal: ThreadSignalPtr
-  reqReceivedSignal: ThreadSignalPtr
+  reqQueue: FFIRequestQueue # mutex-guarded MPSC ingress from foreign threads
+  reqSignal: ThreadSignalPtr # wakes the FFI thread on enqueue
   stopSignal: ThreadSignalPtr
   threadExitSignal: ThreadSignalPtr
     # bounds destroyFFIContext's wait so a blocked loop cannot hang the caller
@@ -60,9 +59,11 @@ template closeAndNil(field: untyped) =
     field = nil
 
 proc deinitContextResources*[T](ctx: ptr FFIContext[T]): Result[void, string] =
-  ## Mirror of `initContextResources`. Threads MUST be joined first;
-  ## fields are nil'd after close so re-init on the same slot is safe.
-  ctx.lock.deinitLock()
+  ## Mirror of `initContextResources`. Threads MUST be joined first (so the FFI
+  ## thread has drained the queue); fields are nil'd after close so re-init on
+  ## the same slot is safe. `deinitRequestQueue` frees any request a producer
+  ## raced in after the final drain, so teardown leaks nothing.
+  deinitRequestQueue(ctx[].reqQueue)
   deinitEventRegistry(ctx[].eventRegistry)
   deinitHandleRegistry(ctx[].handles)
   deinitEventQueue(ctx[].eventQueue)
@@ -74,7 +75,6 @@ proc deinitContextResources*[T](ctx: ptr FFIContext[T]): Result[void, string] =
     discard
   else:
     closeAndNil(ctx.reqSignal)
-    closeAndNil(ctx.reqReceivedSignal)
     closeAndNil(ctx.stopSignal)
     closeAndNil(ctx.threadExitSignal)
     closeAndNil(ctx.eventQueueSignal)
@@ -96,12 +96,11 @@ proc initContextResources*[T](ctx: ptr FFIContext[T]): Result[void, string] =
   ## the slot (freeShared or pool.releaseSlot).
   # Nil first so deferred cleanup can't double-close a reused pool slot.
   ctx.reqSignal = nil
-  ctx.reqReceivedSignal = nil
   ctx.stopSignal = nil
   ctx.threadExitSignal = nil
   ctx.eventQueueSignal = nil
   ctx.eventThreadExitSignal = nil
-  ctx.lock.initLock()
+  initRequestQueue(ctx[].reqQueue)
   initEventRegistry(ctx[].eventRegistry)
   initHandleRegistry(ctx[].handles)
   initEventQueue(ctx[].eventQueue)
@@ -116,7 +115,6 @@ proc initContextResources*[T](ctx: ptr FFIContext[T]): Result[void, string] =
           error = error
 
   newSignalOrErr(ctx.reqSignal, "reqSignal")
-  newSignalOrErr(ctx.reqReceivedSignal, "reqReceivedSignal")
   newSignalOrErr(ctx.stopSignal, "stopSignal")
   newSignalOrErr(ctx.threadExitSignal, "threadExitSignal")
   newSignalOrErr(ctx.eventQueueSignal, "eventQueueSignal")

--- a/ffi/ffi_request_queue.nim
+++ b/ffi/ffi_request_queue.nim
@@ -41,7 +41,7 @@ static:
     "RequestQueueCount must be a power of two"
 
 type
-  RequestShard = object
+  RequestQueue = object
     lock: Lock
     head: ptr FFIThreadRequest ## consumer pops here (oldest)
     tail: ptr FFIThreadRequest ## producers on this queue append here (newest)
@@ -49,7 +49,7 @@ type
     pad: array[QueuePadBytes, byte]
 
   FFIRequestQueue* = object
-    queues: array[RequestQueueCount, RequestShard]
+    queues: array[RequestQueueCount, RequestQueue]
 
 var gRequestQueue {.threadvar.}: int
 var gRequestQueueAssigned {.threadvar.}: bool
@@ -64,26 +64,26 @@ proc myQueueIndex(): int {.raises: [].} =
   return gRequestQueue and (RequestQueueCount - 1) # RequestQueueCount is a power of two
 
 proc initRequestQueue*(q: var FFIRequestQueue) {.raises: [].} =
-  for i in 0 ..< RequestQueueCount:
-    q.queues[i].lock.initLock()
-    q.queues[i].head = nil
-    q.queues[i].tail = nil
-    q.queues[i].count = 0
+  for queue in q.queues.mitems:
+    queue.lock.initLock()
+    queue.head = nil
+    queue.tail = nil
+    queue.count = 0
 
 proc deinitRequestQueue*(q: var FFIRequestQueue) {.raises: [].} =
   ## Both producers and the consumer must have stopped. Frees any request still
   ## queued on any queue — e.g. one a producer raced in after the FFI thread's
   ## final drain — so a teardown race leaks nothing instead of dangling them.
-  for i in 0 ..< RequestQueueCount:
-    var node = q.queues[i].head
+  for queue in q.queues.mitems:
+    var node = queue.head
     while not node.isNil:
       let nxt = node[].next
       deleteRequest(node)
       node = nxt
-    q.queues[i].head = nil
-    q.queues[i].tail = nil
-    q.queues[i].count = 0
-    q.queues[i].lock.deinitLock()
+    queue.head = nil
+    queue.tail = nil
+    queue.count = 0
+    queue.lock.deinitLock()
 
 proc pushRequest*(
     q: var FFIRequestQueue, node: ptr FFIThreadRequest
@@ -113,23 +113,23 @@ proc detachAllRequests*(q: var FFIRequestQueue): ptr FFIThreadRequest {.raises: 
   ## (dispatch frees the node).
   var head: ptr FFIThreadRequest = nil
   var tail: ptr FFIThreadRequest = nil
-  for i in 0 ..< RequestQueueCount:
-    withLock q.queues[i].lock:
-      let h = q.queues[i].head
+  for queue in q.queues.mitems:
+    withLock queue.lock:
+      let h = queue.head
       if not h.isNil:
         if head.isNil:
           head = h
         else:
           tail[].next = h
-        tail = q.queues[i].tail
-        q.queues[i].head = nil
-        q.queues[i].tail = nil
-        q.queues[i].count = 0
+        tail = queue.tail
+        queue.head = nil
+        queue.tail = nil
+        queue.count = 0
   return head
 
 proc requestQueueLen*(q: var FFIRequestQueue): int {.raises: [].} =
   var n = 0
-  for i in 0 ..< RequestQueueCount:
-    withLock q.queues[i].lock:
-      n += q.queues[i].count
+  for queue in q.queues.mitems:
+    withLock queue.lock:
+      n += queue.count
   return n

--- a/ffi/ffi_request_queue.nim
+++ b/ffi/ffi_request_queue.nim
@@ -45,7 +45,6 @@ type
     lock: Lock
     head: ptr FFIThreadRequest ## consumer pops here (oldest)
     tail: ptr FFIThreadRequest ## producers on this queue append here (newest)
-    count: int ## queue depth, for metrics only
     pad: array[QueuePadBytes, byte]
 
   FFIRequestQueue* = object
@@ -68,7 +67,6 @@ proc initRequestQueue*(q: var FFIRequestQueue) {.raises: [].} =
     queue.lock.initLock()
     queue.head = nil
     queue.tail = nil
-    queue.count = 0
 
 proc deinitRequestQueue*(q: var FFIRequestQueue) {.raises: [].} =
   ## Both producers and the consumer must have stopped. Frees any request still
@@ -82,7 +80,6 @@ proc deinitRequestQueue*(q: var FFIRequestQueue) {.raises: [].} =
       request = nextRequest
     queue.head = nil
     queue.tail = nil
-    queue.count = 0
     queue.lock.deinitLock()
 
 proc pushRequest*(
@@ -103,7 +100,6 @@ proc pushRequest*(
     else:
       q.queues[idx].tail[].next = request
     q.queues[idx].tail = request
-    q.queues[idx].count.inc()
     return wasEmpty
 
 proc mergeQueues*(q: var FFIRequestQueue): ptr FFIThreadRequest {.raises: [].} =
@@ -125,12 +121,4 @@ proc mergeQueues*(q: var FFIRequestQueue): ptr FFIThreadRequest {.raises: [].} =
         tail = queue.tail
         queue.head = nil
         queue.tail = nil
-        queue.count = 0
   return head
-
-proc requestQueueLen*(q: var FFIRequestQueue): int {.raises: [].} =
-  var n = 0
-  for queue in q.queues.mitems:
-    withLock queue.lock:
-      n += queue.count
-  return n

--- a/ffi/ffi_request_queue.nim
+++ b/ffi/ffi_request_queue.nim
@@ -106,12 +106,12 @@ proc pushRequest*(
     q.queues[idx].count.inc()
     return wasEmpty
 
-proc detachAllRequests*(q: var FFIRequestQueue): ptr FFIThreadRequest {.raises: [].} =
-  ## Single-consumer: splice every queue's queued chain (each queue FIFO, linked
-  ## by `next`) into one chain and reset the queues to empty, taking each queue's
-  ## lock once. Returns nil when all queues are empty; the caller then owns every
-  ## request in the chain and must read each node's `next` before dispatching it
-  ## (dispatch frees the node).
+proc mergeQueues*(q: var FFIRequestQueue): ptr FFIThreadRequest {.raises: [].} =
+  ## Single-consumer: splice every queue into one chain and reset the queues to empty.
+  ## Returns nil when all queues are empty;
+  ## the caller then owns every request in the chain
+  ## and must read each request's `next` before dispatching it.
+
   var head: ptr FFIThreadRequest = nil
   var tail: ptr FFIThreadRequest = nil
   for queue in q.queues.mitems:

--- a/ffi/ffi_request_queue.nim
+++ b/ffi/ffi_request_queue.nim
@@ -92,9 +92,7 @@ proc pushRequest*(
   ## The queue takes ownership. Returns true iff that lane was empty before the
   ## push — i.e. the caller should wake the consumer. When the lane was
   ## non-empty the consumer is already draining (or has a wake pending), so
-  ## firing again is a wasted syscall; coalescing the wake is what lets
-  ## concurrent submits scale. A skipped edge is bounded by the consumer's 100ms
-  ## poll, so it can never strand a request.
+  ## firing again is a wasted syscall.
   node[].next = nil
   let idx = myLaneIndex()
   withLock q.lanes[idx].lock:

--- a/ffi/ffi_request_queue.nim
+++ b/ffi/ffi_request_queue.nim
@@ -7,15 +7,15 @@
 ## funnels every producer through one shared cache line (the lock, or the
 ## lock-free head). On a multicore host that one hotspot caps aggregate submit
 ## throughput, so it cannot scale past a single thread. Splitting the ingress
-## into `RequestLaneCount` independent lanes, each picked per producer thread,
+## into `RequestQueueCount` independent queues, each picked per producer thread,
 ## removes the shared write point: producers contend only when two land on the
-## same lane. Each lane is a plain intrusive FIFO under its own `Lock`, so the
+## same queue. Each queue is a plain intrusive FIFO under its own `Lock`, so the
 ## structure stays trivially data-race-free under TSAN with no memory-ordering
 ## reasoning, and the request *is* its own queue node (intrusive `next`), so
 ## enqueue allocates nothing and never touches a Nim GC heap (the cross-thread
 ## `MemRegion` hazard documented in `ffi_thread_request.nim`).
 ##
-## Ordering: FIFO is preserved per lane, not globally. Concurrent foreign
+## Ordering: FIFO is preserved per queue, not globally. Concurrent foreign
 ## callers already race with no cross-thread ordering guarantee, so this is the
 ## same contract the single-slot channel offered in practice.
 ##
@@ -26,110 +26,110 @@ import std/[atomics, locks]
 import ./ffi_thread_request
 
 const
-  RequestLaneCount* = 16
-    ## Independent ingress lanes. ≥ the expected concurrent producer count keeps
-    ## lane collisions (hence lock contention) near zero.
-  LanePadBytes = 192
-    ## Pads each lane well past a cache line (128B on Apple silicon) so adjacent
-    ## lanes' hot fields never false-share — false sharing would re-serialise
+  RequestQueueCount* = 16
+    ## Independent ingress queues. ≥ the expected concurrent producer count keeps
+    ## queue collisions (hence lock contention) near zero.
+  QueuePadBytes = 192
+    ## Pads each queue well past a cache line (128B on Apple silicon) so adjacent
+    ## queues' hot fields never false-share — false sharing would re-serialise
     ## exactly what the sharding is meant to spread out.
 
 static:
-  # `myLaneIndex` maps threads to lanes with an `and` mask, so the count must be
-  # a power of two — otherwise the distribution silently skews onto a subset.
-  doAssert (RequestLaneCount and (RequestLaneCount - 1)) == 0,
-    "RequestLaneCount must be a power of two"
+  # `myQueueIndex` maps threads to queues with an `and` mask, so the count must
+  # be a power of two — otherwise the distribution silently skews onto a subset.
+  doAssert (RequestQueueCount and (RequestQueueCount - 1)) == 0,
+    "RequestQueueCount must be a power of two"
 
 type
-  RequestLane = object
+  RequestShard = object
     lock: Lock
     head: ptr FFIThreadRequest ## consumer pops here (oldest)
-    tail: ptr FFIThreadRequest ## producers on this lane append here (newest)
-    count: int ## lane depth, for metrics only
-    pad: array[LanePadBytes, byte]
+    tail: ptr FFIThreadRequest ## producers on this queue append here (newest)
+    count: int ## queue depth, for metrics only
+    pad: array[QueuePadBytes, byte]
 
   FFIRequestQueue* = object
-    lanes: array[RequestLaneCount, RequestLane]
+    queues: array[RequestQueueCount, RequestShard]
 
-var gRequestLane {.threadvar.}: int
-var gRequestLaneAssigned {.threadvar.}: bool
-var gRequestLaneCounter: Atomic[int]
-  ## Hands each producer thread a distinct lane round-robin on first use, so
-  ## lanes fill evenly regardless of OS thread-id distribution.
+var gRequestQueue {.threadvar.}: int
+var gRequestQueueAssigned {.threadvar.}: bool
+var gRequestQueueCounter: Atomic[int]
+  ## Hands each producer thread a distinct queue round-robin on first use, so
+  ## queues fill evenly regardless of OS thread-id distribution.
 
-proc myLaneIndex(): int {.raises: [].} =
-  if not gRequestLaneAssigned:
-    gRequestLane = gRequestLaneCounter.fetchAdd(1)
-    gRequestLaneAssigned = true
-  return gRequestLane and (RequestLaneCount - 1) # RequestLaneCount is a power of two
+proc myQueueIndex(): int {.raises: [].} =
+  if not gRequestQueueAssigned:
+    gRequestQueue = gRequestQueueCounter.fetchAdd(1)
+    gRequestQueueAssigned = true
+  return gRequestQueue and (RequestQueueCount - 1) # RequestQueueCount is a power of two
 
 proc initRequestQueue*(q: var FFIRequestQueue) {.raises: [].} =
-  for i in 0 ..< RequestLaneCount:
-    q.lanes[i].lock.initLock()
-    q.lanes[i].head = nil
-    q.lanes[i].tail = nil
-    q.lanes[i].count = 0
+  for i in 0 ..< RequestQueueCount:
+    q.queues[i].lock.initLock()
+    q.queues[i].head = nil
+    q.queues[i].tail = nil
+    q.queues[i].count = 0
 
 proc deinitRequestQueue*(q: var FFIRequestQueue) {.raises: [].} =
   ## Both producers and the consumer must have stopped. Frees any request still
-  ## queued on any lane — e.g. one a producer raced in after the FFI thread's
+  ## queued on any queue — e.g. one a producer raced in after the FFI thread's
   ## final drain — so a teardown race leaks nothing instead of dangling them.
-  for i in 0 ..< RequestLaneCount:
-    var node = q.lanes[i].head
+  for i in 0 ..< RequestQueueCount:
+    var node = q.queues[i].head
     while not node.isNil:
       let nxt = node[].next
       deleteRequest(node)
       node = nxt
-    q.lanes[i].head = nil
-    q.lanes[i].tail = nil
-    q.lanes[i].count = 0
-    q.lanes[i].lock.deinitLock()
+    q.queues[i].head = nil
+    q.queues[i].tail = nil
+    q.queues[i].count = 0
+    q.queues[i].lock.deinitLock()
 
 proc pushRequest*(
     q: var FFIRequestQueue, node: ptr FFIThreadRequest
 ): bool {.raises: [].} =
-  ## Append `node` to this producer thread's lane (one O(1) critical section).
-  ## The queue takes ownership. Returns true iff that lane was empty before the
-  ## push — i.e. the caller should wake the consumer. When the lane was
+  ## Append `node` to this producer thread's queue (one O(1) critical section).
+  ## The queue takes ownership. Returns true iff that queue was empty before the
+  ## push — i.e. the caller should wake the consumer. When the queue was
   ## non-empty the consumer is already draining (or has a wake pending), so
   ## firing again is a wasted syscall.
   node[].next = nil
-  let idx = myLaneIndex()
-  withLock q.lanes[idx].lock:
-    let wasEmpty = q.lanes[idx].tail.isNil
-    if q.lanes[idx].tail.isNil:
-      q.lanes[idx].head = node
+  let idx = myQueueIndex()
+  withLock q.queues[idx].lock:
+    let wasEmpty = q.queues[idx].tail.isNil
+    if q.queues[idx].tail.isNil:
+      q.queues[idx].head = node
     else:
-      q.lanes[idx].tail[].next = node
-    q.lanes[idx].tail = node
-    q.lanes[idx].count.inc()
+      q.queues[idx].tail[].next = node
+    q.queues[idx].tail = node
+    q.queues[idx].count.inc()
     return wasEmpty
 
 proc detachAllRequests*(q: var FFIRequestQueue): ptr FFIThreadRequest {.raises: [].} =
-  ## Single-consumer: splice every lane's queued chain (each lane FIFO, linked
-  ## by `next`) into one chain and reset the lanes to empty, taking each lane's
-  ## lock once. Returns nil when all lanes are empty; the caller then owns every
+  ## Single-consumer: splice every queue's queued chain (each queue FIFO, linked
+  ## by `next`) into one chain and reset the queues to empty, taking each queue's
+  ## lock once. Returns nil when all queues are empty; the caller then owns every
   ## request in the chain and must read each node's `next` before dispatching it
   ## (dispatch frees the node).
   var head: ptr FFIThreadRequest = nil
   var tail: ptr FFIThreadRequest = nil
-  for i in 0 ..< RequestLaneCount:
-    withLock q.lanes[i].lock:
-      let h = q.lanes[i].head
+  for i in 0 ..< RequestQueueCount:
+    withLock q.queues[i].lock:
+      let h = q.queues[i].head
       if not h.isNil:
         if head.isNil:
           head = h
         else:
           tail[].next = h
-        tail = q.lanes[i].tail
-        q.lanes[i].head = nil
-        q.lanes[i].tail = nil
-        q.lanes[i].count = 0
+        tail = q.queues[i].tail
+        q.queues[i].head = nil
+        q.queues[i].tail = nil
+        q.queues[i].count = 0
   return head
 
 proc requestQueueLen*(q: var FFIRequestQueue): int {.raises: [].} =
   var n = 0
-  for i in 0 ..< RequestLaneCount:
-    withLock q.lanes[i].lock:
-      n += q.lanes[i].count
+  for i in 0 ..< RequestQueueCount:
+    withLock q.queues[i].lock:
+      n += q.queues[i].count
   return n

--- a/ffi/ffi_request_queue.nim
+++ b/ffi/ffi_request_queue.nim
@@ -37,7 +37,7 @@ type
     tail: ptr FFIThreadRequest ## producers on this queue append here (newest)
     pad: array[QueuePadBytes, byte]
 
-  FFIRequestQueue* = object
+  RequestQueueBank* = object
     queues: array[RequestQueueCount, RequestQueue]
 
 var gRequestQueue {.threadvar.}: int
@@ -52,17 +52,17 @@ proc myQueueIndex(): int {.raises: [].} =
     gRequestQueueAssigned = true
   return gRequestQueue and (RequestQueueCount - 1) # RequestQueueCount is a power of two
 
-proc initRequestQueue*(q: var FFIRequestQueue) {.raises: [].} =
-  for queue in q.queues.mitems:
+proc initRequestQueue*(bank: var RequestQueueBank) {.raises: [].} =
+  for queue in bank.queues.mitems:
     queue.lock.initLock()
     queue.head = nil
     queue.tail = nil
 
-proc deinitRequestQueue*(q: var FFIRequestQueue) {.raises: [].} =
+proc deinitRequestQueue*(bank: var RequestQueueBank) {.raises: [].} =
   ## Both producers and the consumer must have stopped. Frees any request still
   ## queued on any queue — e.g. one a producer raced in after the FFI thread's
   ## final drain — so a teardown race leaks nothing instead of dangling them.
-  for queue in q.queues.mitems:
+  for queue in bank.queues.mitems:
     var request = queue.head
     while not request.isNil():
       let nextRequest = request[].next
@@ -73,29 +73,29 @@ proc deinitRequestQueue*(q: var FFIRequestQueue) {.raises: [].} =
     queue.lock.deinitLock()
 
 proc pushRequest*(
-    q: var FFIRequestQueue, request: ptr FFIThreadRequest
+    bank: var RequestQueueBank, request: ptr FFIThreadRequest
 ): bool {.raises: [].} =
   ## Append `request` to this producer thread's queue (takes ownership). Returns
   ## true only when the queue was empty: the consumer sleeps on an empty queue, so
   ## that's the one push that must wake it; a missed wake just waits the 100ms poll.
   request[].next = nil
   let idx = myQueueIndex()
-  withLock q.queues[idx].lock:
-    let wasEmpty = q.queues[idx].tail.isNil()
-    if q.queues[idx].tail.isNil():
-      q.queues[idx].head = request
+  withLock bank.queues[idx].lock:
+    let wasEmpty = bank.queues[idx].tail.isNil()
+    if bank.queues[idx].tail.isNil():
+      bank.queues[idx].head = request
     else:
-      q.queues[idx].tail[].next = request
-    q.queues[idx].tail = request
+      bank.queues[idx].tail[].next = request
+    bank.queues[idx].tail = request
     return wasEmpty
 
-proc mergeQueues*(q: var FFIRequestQueue): ptr FFIThreadRequest {.raises: [].} =
+proc mergeQueues*(bank: var RequestQueueBank): ptr FFIThreadRequest {.raises: [].} =
   ## Single-consumer: splice every queue into one chain, resetting them to empty.
   ## Returns nil when all are empty; the caller then owns the chain and must read
   ## each request's `next` before dispatching (dispatch frees the request).
   var head: ptr FFIThreadRequest = nil
   var tail: ptr FFIThreadRequest = nil
-  for queue in q.queues.mitems:
+  for queue in bank.queues.mitems:
     withLock queue.lock:
       let h = queue.head
       if not h.isNil():

--- a/ffi/ffi_request_queue.nim
+++ b/ffi/ffi_request_queue.nim
@@ -1,26 +1,16 @@
-## Sharded, mutex-guarded multi-producer / single-consumer ingress for
-## `ptr FFIThreadRequest`. Replaces the single-slot SPSC channel plus the
-## blocking accept handshake (`reqReceivedSignal.waitSync`) that made every
-## foreign-thread submit serialise.
+## Sharded, mutex-guarded MPSC ingress for `ptr FFIThreadRequest`: foreign
+## threads enqueue without serialising against each other.
 ##
-## Why sharded: a *single* queue — whether mutex-guarded or lock-free (Vyukov) —
-## funnels every producer through one shared cache line (the lock, or the
-## lock-free head). On a multicore host that one hotspot caps aggregate submit
-## throughput, so it cannot scale past a single thread. Splitting the ingress
-## into `RequestQueueCount` independent queues, each picked per producer thread,
-## removes the shared write point: producers contend only when two land on the
-## same queue. Each queue is a plain intrusive FIFO under its own `Lock`, so the
-## structure stays trivially data-race-free under TSAN with no memory-ordering
-## reasoning, and the request *is* its own queue node (intrusive `next`), so
-## enqueue allocates nothing and never touches a Nim GC heap (the cross-thread
-## `MemRegion` hazard documented in `ffi_thread_request.nim`).
+## Why sharded: one shared queue funnels all producers through a single cache
+## line, capping submit throughput. N independent queues (one per producer)
+## remove that hotspot — producers contend only when two pick the same queue.
 ##
-## Ordering: FIFO is preserved per queue, not globally. Concurrent foreign
-## callers already race with no cross-thread ordering guarantee, so this is the
-## same contract the single-slot channel offered in practice.
+## Each queue is an intrusive FIFO under its own `Lock`: race-free under TSAN, and
+## the request is its own node (intrusive `next`), so enqueue never allocates nor
+## touches a Nim GC heap (the cross-thread `MemRegion` hazard).
 ##
-## Unbounded by design: the submit path must never reject or block a caller —
-## completion is reported asynchronously through each request's own callback.
+## FIFO holds per queue, not globally. Unbounded by design: submit never blocks
+## or rejects; completion comes via each request's callback.
 
 import std/[atomics, locks]
 import ./ffi_thread_request
@@ -85,12 +75,9 @@ proc deinitRequestQueue*(q: var FFIRequestQueue) {.raises: [].} =
 proc pushRequest*(
     q: var FFIRequestQueue, request: ptr FFIThreadRequest
 ): bool {.raises: [].} =
-  ## Append `request` to this producer thread's queue; the queue takes ownership.
-  ## Returns true only when the queue was empty before the push. The consumer
-  ## sleeps while its queue is empty, so the caller wakes it (a syscall) only on
-  ## this empty→non-empty push; a push onto an already-non-empty queue needs no
-  ## wake, as the consumer is still draining it. A missed wake can't strand the
-  ## request: the consumer re-polls every 100ms.
+  ## Append `request` to this producer thread's queue (takes ownership). Returns
+  ## true only when the queue was empty: the consumer sleeps on an empty queue, so
+  ## that's the one push that must wake it; a missed wake just waits the 100ms poll.
   request[].next = nil
   let idx = myQueueIndex()
   withLock q.queues[idx].lock:
@@ -103,11 +90,9 @@ proc pushRequest*(
     return wasEmpty
 
 proc mergeQueues*(q: var FFIRequestQueue): ptr FFIThreadRequest {.raises: [].} =
-  ## Single-consumer: splice every queue into one chain and reset the queues to empty.
-  ## Returns nil when all queues are empty;
-  ## the caller then owns every request in the chain
-  ## and must read each request's `next` before dispatching it.
-
+  ## Single-consumer: splice every queue into one chain, resetting them to empty.
+  ## Returns nil when all are empty; the caller then owns the chain and must read
+  ## each request's `next` before dispatching (dispatch frees the request).
   var head: ptr FFIThreadRequest = nil
   var tail: ptr FFIThreadRequest = nil
   for queue in q.queues.mitems:

--- a/ffi/ffi_request_queue.nim
+++ b/ffi/ffi_request_queue.nim
@@ -1,0 +1,137 @@
+## Sharded, mutex-guarded multi-producer / single-consumer ingress for
+## `ptr FFIThreadRequest`. Replaces the single-slot SPSC channel plus the
+## blocking accept handshake (`reqReceivedSignal.waitSync`) that made every
+## foreign-thread submit serialise.
+##
+## Why sharded: a *single* queue — whether mutex-guarded or lock-free (Vyukov) —
+## funnels every producer through one shared cache line (the lock, or the
+## lock-free head). On a multicore host that one hotspot caps aggregate submit
+## throughput, so it cannot scale past a single thread. Splitting the ingress
+## into `RequestLaneCount` independent lanes, each picked per producer thread,
+## removes the shared write point: producers contend only when two land on the
+## same lane. Each lane is a plain intrusive FIFO under its own `Lock`, so the
+## structure stays trivially data-race-free under TSAN with no memory-ordering
+## reasoning, and the request *is* its own queue node (intrusive `next`), so
+## enqueue allocates nothing and never touches a Nim GC heap (the cross-thread
+## `MemRegion` hazard documented in `ffi_thread_request.nim`).
+##
+## Ordering: FIFO is preserved per lane, not globally. Concurrent foreign
+## callers already race with no cross-thread ordering guarantee, so this is the
+## same contract the single-slot channel offered in practice.
+##
+## Unbounded by design: the submit path must never reject or block a caller —
+## completion is reported asynchronously through each request's own callback.
+
+import std/[atomics, locks]
+import ./ffi_thread_request
+
+const
+  RequestLaneCount* = 16
+    ## Independent ingress lanes. ≥ the expected concurrent producer count keeps
+    ## lane collisions (hence lock contention) near zero.
+  LanePadBytes = 192
+    ## Pads each lane well past a cache line (128B on Apple silicon) so adjacent
+    ## lanes' hot fields never false-share — false sharing would re-serialise
+    ## exactly what the sharding is meant to spread out.
+
+static:
+  # `myLaneIndex` maps threads to lanes with an `and` mask, so the count must be
+  # a power of two — otherwise the distribution silently skews onto a subset.
+  doAssert (RequestLaneCount and (RequestLaneCount - 1)) == 0,
+    "RequestLaneCount must be a power of two"
+
+type
+  RequestLane = object
+    lock: Lock
+    head: ptr FFIThreadRequest ## consumer pops here (oldest)
+    tail: ptr FFIThreadRequest ## producers on this lane append here (newest)
+    count: int ## lane depth, for metrics only
+    pad: array[LanePadBytes, byte]
+
+  FFIRequestQueue* = object
+    lanes: array[RequestLaneCount, RequestLane]
+
+var gRequestLane {.threadvar.}: int
+var gRequestLaneAssigned {.threadvar.}: bool
+var gRequestLaneCounter: Atomic[int]
+  ## Hands each producer thread a distinct lane round-robin on first use, so
+  ## lanes fill evenly regardless of OS thread-id distribution.
+
+proc myLaneIndex(): int {.raises: [].} =
+  if not gRequestLaneAssigned:
+    gRequestLane = gRequestLaneCounter.fetchAdd(1)
+    gRequestLaneAssigned = true
+  return gRequestLane and (RequestLaneCount - 1) # RequestLaneCount is a power of two
+
+proc initRequestQueue*(q: var FFIRequestQueue) {.raises: [].} =
+  for i in 0 ..< RequestLaneCount:
+    q.lanes[i].lock.initLock()
+    q.lanes[i].head = nil
+    q.lanes[i].tail = nil
+    q.lanes[i].count = 0
+
+proc deinitRequestQueue*(q: var FFIRequestQueue) {.raises: [].} =
+  ## Both producers and the consumer must have stopped. Frees any request still
+  ## queued on any lane — e.g. one a producer raced in after the FFI thread's
+  ## final drain — so a teardown race leaks nothing instead of dangling them.
+  for i in 0 ..< RequestLaneCount:
+    var node = q.lanes[i].head
+    while not node.isNil:
+      let nxt = node[].next
+      deleteRequest(node)
+      node = nxt
+    q.lanes[i].head = nil
+    q.lanes[i].tail = nil
+    q.lanes[i].count = 0
+    q.lanes[i].lock.deinitLock()
+
+proc pushRequest*(
+    q: var FFIRequestQueue, node: ptr FFIThreadRequest
+): bool {.raises: [].} =
+  ## Append `node` to this producer thread's lane (one O(1) critical section).
+  ## The queue takes ownership. Returns true iff that lane was empty before the
+  ## push — i.e. the caller should wake the consumer. When the lane was
+  ## non-empty the consumer is already draining (or has a wake pending), so
+  ## firing again is a wasted syscall; coalescing the wake is what lets
+  ## concurrent submits scale. A skipped edge is bounded by the consumer's 100ms
+  ## poll, so it can never strand a request.
+  node[].next = nil
+  let idx = myLaneIndex()
+  withLock q.lanes[idx].lock:
+    let wasEmpty = q.lanes[idx].tail.isNil
+    if q.lanes[idx].tail.isNil:
+      q.lanes[idx].head = node
+    else:
+      q.lanes[idx].tail[].next = node
+    q.lanes[idx].tail = node
+    q.lanes[idx].count.inc()
+    return wasEmpty
+
+proc detachAllRequests*(q: var FFIRequestQueue): ptr FFIThreadRequest {.raises: [].} =
+  ## Single-consumer: splice every lane's queued chain (each lane FIFO, linked
+  ## by `next`) into one chain and reset the lanes to empty, taking each lane's
+  ## lock once. Returns nil when all lanes are empty; the caller then owns every
+  ## request in the chain and must read each node's `next` before dispatching it
+  ## (dispatch frees the node).
+  var head: ptr FFIThreadRequest = nil
+  var tail: ptr FFIThreadRequest = nil
+  for i in 0 ..< RequestLaneCount:
+    withLock q.lanes[i].lock:
+      let h = q.lanes[i].head
+      if not h.isNil:
+        if head.isNil:
+          head = h
+        else:
+          tail[].next = h
+        tail = q.lanes[i].tail
+        q.lanes[i].head = nil
+        q.lanes[i].tail = nil
+        q.lanes[i].count = 0
+  return head
+
+proc requestQueueLen*(q: var FFIRequestQueue): int {.raises: [].} =
+  var n = 0
+  for i in 0 ..< RequestLaneCount:
+    withLock q.lanes[i].lock:
+      n += q.lanes[i].count
+  return n

--- a/ffi/ffi_request_queue.nim
+++ b/ffi/ffi_request_queue.nim
@@ -75,33 +75,34 @@ proc deinitRequestQueue*(q: var FFIRequestQueue) {.raises: [].} =
   ## queued on any queue — e.g. one a producer raced in after the FFI thread's
   ## final drain — so a teardown race leaks nothing instead of dangling them.
   for queue in q.queues.mitems:
-    var node = queue.head
-    while not node.isNil:
-      let nxt = node[].next
-      deleteRequest(node)
-      node = nxt
+    var request = queue.head
+    while not request.isNil():
+      let nextRequest = request[].next
+      deleteRequest(request)
+      request = nextRequest
     queue.head = nil
     queue.tail = nil
     queue.count = 0
     queue.lock.deinitLock()
 
 proc pushRequest*(
-    q: var FFIRequestQueue, node: ptr FFIThreadRequest
+    q: var FFIRequestQueue, request: ptr FFIThreadRequest
 ): bool {.raises: [].} =
-  ## Append `node` to this producer thread's queue (one O(1) critical section).
-  ## The queue takes ownership. Returns true iff that queue was empty before the
-  ## push — i.e. the caller should wake the consumer. When the queue was
-  ## non-empty the consumer is already draining (or has a wake pending), so
-  ## firing again is a wasted syscall.
-  node[].next = nil
+  ## Append `request` to this producer thread's queue; the queue takes ownership.
+  ## Returns true only when the queue was empty before the push. The consumer
+  ## sleeps while its queue is empty, so the caller wakes it (a syscall) only on
+  ## this empty→non-empty push; a push onto an already-non-empty queue needs no
+  ## wake, as the consumer is still draining it. A missed wake can't strand the
+  ## request: the consumer re-polls every 100ms.
+  request[].next = nil
   let idx = myQueueIndex()
   withLock q.queues[idx].lock:
-    let wasEmpty = q.queues[idx].tail.isNil
-    if q.queues[idx].tail.isNil:
-      q.queues[idx].head = node
+    let wasEmpty = q.queues[idx].tail.isNil()
+    if q.queues[idx].tail.isNil():
+      q.queues[idx].head = request
     else:
-      q.queues[idx].tail[].next = node
-    q.queues[idx].tail = node
+      q.queues[idx].tail[].next = request
+    q.queues[idx].tail = request
     q.queues[idx].count.inc()
     return wasEmpty
 
@@ -116,8 +117,8 @@ proc detachAllRequests*(q: var FFIRequestQueue): ptr FFIThreadRequest {.raises: 
   for queue in q.queues.mitems:
     withLock queue.lock:
       let h = queue.head
-      if not h.isNil:
-        if head.isNil:
+      if not h.isNil():
+        if head.isNil():
           head = h
         else:
           tail[].next = h

--- a/ffi/ffi_thread.nim
+++ b/ffi/ffi_thread.nim
@@ -115,7 +115,6 @@ proc ffiThreadBody[T](ctx: ptr FFIContext[T]) {.thread.} =
 
   let ffiRun = proc(ctx: ptr FFIContext[T]) {.async.} =
     var ffiReqHandler: T # main library object (Waku, LibP2P, SDS, …)
-    ctx.myLib = addr ffiReqHandler
 
     # Tracked so shutdown can drain them; abandoning a mid-await future leaks the request.
     var pending: seq[Future[void]] = @[]
@@ -143,6 +142,11 @@ proc ffiThreadBody[T](ctx: ptr FFIContext[T]) {.thread.} =
           # Tick per dispatch so a large backlog can't flatline the heartbeat
           # and trip the event thread's wedged-FFI-thread detection mid-drain.
           ctx.proveAlive()
+          if ctx.myLib.isNil():
+            # Keep this reference to `ffiReqHandler` inside the closure is what keeps
+            # the variable in the async env, so `myLib` stays valid across awaits.
+            ctx.myLib = addr ffiReqHandler
+
           pending.add processRequest(request, ctx)
           request = nextRequest
 

--- a/ffi/ffi_thread.nim
+++ b/ffi/ffi_thread.nim
@@ -4,7 +4,7 @@
 ## and the `onFFIThread` threadvar. Companion to `event_thread.nim`.
 ##
 ## Responsibilities:
-## - Receive `FFIThreadRequest`s from foreign threads via `reqQueue` (a
+## - Receive `FFIThreadRequest`s from foreign threads via `reqQueueBank` (a
 ##   mutex-guarded MPSC queue) and dispatch them through the user-registered
 ##   handler table.
 ## - Advance `ctx.ffiHeartbeat` each loop iteration so the event thread can
@@ -32,7 +32,7 @@ proc sendRequestToFFIThread*(
   # Wake only when the push found the queue empty: while the consumer drains, a
   # fireSync() syscall per submit (contended across producers) is what destroys
   # scaling. A skipped wake can't strand the request — the consumer re-polls 100ms.
-  let shouldWake = ctx.reqQueue.pushRequest(ffiRequest)
+  let shouldWake = ctx.reqQueueBank.pushRequest(ffiRequest)
 
   # A failed wake is non-fatal: the request is queued and the poll-drain
   # dispatches it within a tick anyway. Returning err would double-fire the
@@ -127,7 +127,7 @@ proc ffiThreadBody[T](ctx: ptr FFIContext[T]) {.thread.} =
       ## stand for many submits, so we drain fully rather than once per wake —
       ## otherwise queued requests would sit until the next wake.
       while true:
-        var request = ctx.reqQueue.mergeQueues()
+        var request = ctx.reqQueueBank.mergeQueues()
         if request.isNil():
           break
         while not request.isNil():

--- a/ffi/ffi_thread.nim
+++ b/ffi/ffi_thread.nim
@@ -4,50 +4,49 @@
 ## and the `onFFIThread` threadvar. Companion to `event_thread.nim`.
 ##
 ## Responsibilities:
-## - Receive `FFIThreadRequest`s from foreign threads via `reqChannel` and
-##   dispatch them through the user-registered handler table.
+## - Receive `FFIThreadRequest`s from foreign threads via `reqQueue` (a
+##   mutex-guarded MPSC queue) and dispatch them through the user-registered
+##   handler table.
 ## - Advance `ctx.ffiHeartbeat` each loop iteration so the event thread can
 ##   detect a wedged FFI thread.
 
 proc sendRequestToFFIThread*(
-    ctx: ptr FFIContext, ffiRequest: ptr FFIThreadRequest, timeout = InfiniteDuration
+    ctx: ptr FFIContext, ffiRequest: ptr FFIThreadRequest
 ): Result[void, string] =
   if ctx.eventQueueStuck.load():
     deleteRequest(ffiRequest)
     return err("event queue stuck - library cannot accept new requests")
 
   if onFFIThread:
-    # Re-entrant dispatch from a handler would self-deadlock on `reqReceivedSignal`.
+    # A handler re-dispatching onto its own FFI thread would enqueue work the
+    # blocked dispatcher can never drain; reject instead of dead-locking.
     deleteRequest(ffiRequest)
     return err(
       "reentrant ffi call: a handler invoked sendRequestToFFIThread on its own context"
     )
 
-  # Serialise the trySend + fireSync + waitSync — reqChannel is SP and reqReceivedSignal is shared.
-  ctx.lock.acquire()
-  defer:
-    ctx.lock.release()
+  # Mutex-guarded hand-off: the lock inside pushRequest covers only the O(1)
+  # enqueue; the request malloc (already done) and the wake below stay outside
+  # it, so concurrent producers don't serialise. The queue is unbounded, so
+  # enqueue can't fail, and completion is reported through the request's own
+  # callback — there is no accept-ack to wait on.
+  #
+  # Only wake the FFI thread when this push found the queue empty. While the
+  # consumer is draining (queue non-empty) the wake is redundant — and a
+  # fireSync() syscall per submit, contended across producers, is precisely
+  # what destroys submit scaling. A skipped edge can't strand the request: the
+  # consumer drains to empty and re-polls every 100ms regardless.
+  let shouldWake = ctx.reqQueue.pushRequest(ffiRequest)
 
-  let sentOk = ctx.reqChannel.trySend(ffiRequest)
-  if not sentOk:
-    deleteRequest(ffiRequest)
-    return err("Couldn't send a request to the ffi thread")
+  # A failed wake is non-fatal: the request is queued and the FFI thread's
+  # poll-drain dispatches it within one tick regardless of the signal. Returning
+  # err here would double-fire the caller's callback for a request that still
+  # completes normally.
+  if shouldWake:
+    ctx.reqSignal.fireSync().isOkOr:
+      error "failed to wake FFI thread after enqueue (request still queued)",
+        error = error
 
-  let fireSyncRes = ctx.reqSignal.fireSync()
-  if fireSyncRes.isErr():
-    deleteRequest(ffiRequest)
-    return err("failed fireSync: " & $fireSyncRes.error)
-
-  if fireSyncRes.get() == false:
-    deleteRequest(ffiRequest)
-    return err("Couldn't fireSync in time")
-
-  let res = ctx.reqReceivedSignal.waitSync(timeout)
-  if res.isErr():
-    # FFI thread was signaled and owns the request; don't double-free.
-    return err("Couldn't receive reqReceivedSignal signal")
-
-  # On ok the FFI thread's processRequest deallocShared(req)'s.
   ok()
 
 proc processRequest[T](
@@ -122,30 +121,40 @@ proc ffiThreadBody[T](ctx: ptr FFIContext[T]) {.thread.} =
           continue
         pending.del(i)
 
+    proc drainQueue() =
+      ## Dispatch every request producers have enqueued. fireSync coalesces, so
+      ## one wake can stand for many submits — drain to empty, not one per wake,
+      ## or queued requests would strand until the next signal. Each detach
+      ## takes the whole chain in one lock, so the consumer barely contends with
+      ## the producers.
+      while true:
+        var node = ctx.reqQueue.detachAllRequests()
+        if node.isNil:
+          break
+        while not node.isNil:
+          let nxt = node[].next # read before processRequest frees the node
+          # Tick per dispatch so a large backlog can't flatline the heartbeat
+          # and trip the event thread's wedged-FFI-thread detection mid-drain.
+          discard ctx.ffiHeartbeat.fetchAdd(1)
+          if ctx.myLib.isNil():
+            ctx.myLib = addr ffiReqHandler
+          pending.add processRequest(node, ctx)
+          node = nxt
+
     while ctx.running.load():
       # Freezes if a sync handler blocks the dispatcher; event thread reads to detect wedged FFI thread.
       discard ctx.ffiHeartbeat.fetchAdd(1)
 
       reapCompleted()
 
-      let gotSignal = await ctx.reqSignal.wait().withTimeout(chronos.milliseconds(100))
-      if not gotSignal:
-        continue
+      # Drain regardless of the wait outcome: a missed/coalesced signal must not
+      # leave requests stranded, and the 100ms timeout bounds shutdown latency.
+      discard await ctx.reqSignal.wait().withTimeout(chronos.milliseconds(100))
+      drainQueue()
 
-      var request: ptr FFIThreadRequest
-      if not ctx.reqChannel.tryRecv(request):
-        continue
-
-      if ctx.myLib.isNil():
-        ctx.myLib = addr ffiReqHandler
-
-      pending.add processRequest(request, ctx)
-
-      let fireRes = ctx.reqReceivedSignal.fireSync()
-      if fireRes.isErr():
-        error "could not fireSync back to requester thread", error = fireRes.error
-
-    # Drain so each pending handler's deleteRequest defer runs before exit.
+    # Drain once more so requests enqueued just before `running` flipped still
+    # dispatch and each pending handler's deleteRequest defer runs before exit.
+    drainQueue()
     reapCompleted()
     if pending.len > 0:
       try:

--- a/ffi/ffi_thread.nim
+++ b/ffi/ffi_thread.nim
@@ -128,7 +128,7 @@ proc ffiThreadBody[T](ctx: ptr FFIContext[T]) {.thread.} =
       ## takes the whole chain in one lock, so the consumer barely contends with
       ## the producers.
       while true:
-        var node = ctx.reqQueue.detachAllRequests()
+        var node = ctx.reqQueue.mergeQueues()
         if node.isNil:
           break
         while not node.isNil:

--- a/ffi/ffi_thread.nim
+++ b/ffi/ffi_thread.nim
@@ -119,7 +119,7 @@ proc ffiThreadBody[T](ctx: ptr FFIContext[T]) {.thread.} =
     # Tracked so shutdown can drain them; abandoning a mid-await future leaks the request.
     var pending: seq[Future[void]] = @[]
 
-    proc reapCompleted() =
+    proc cleanFinishedRequests() =
       var i = 0
       while i < pending.len:
         if not pending[i].finished():
@@ -127,12 +127,10 @@ proc ffiThreadBody[T](ctx: ptr FFIContext[T]) {.thread.} =
           continue
         pending.del(i)
 
-    proc drainQueue() =
-      ## Dispatch every request producers have enqueued. fireSync coalesces, so
-      ## one wake can stand for many submits — drain to empty, not one per wake,
-      ## or queued requests would strand until the next signal. Each detach
-      ## takes the whole chain in one lock, so the consumer barely contends with
-      ## the producers.
+    proc processQueue() =
+      ## Process enqueued requests until the queue is empty. A single wake can
+      ## stand for many submits, so we drain fully rather than once per wake —
+      ## otherwise queued requests would sit until the next wake.
       while true:
         var request = ctx.reqQueue.mergeQueues()
         if request.isNil():
@@ -154,17 +152,16 @@ proc ffiThreadBody[T](ctx: ptr FFIContext[T]) {.thread.} =
       # Freezes if a sync handler blocks the dispatcher; event thread reads to detect wedged FFI thread.
       ctx.proveAlive()
 
-      reapCompleted()
+      cleanFinishedRequests()
 
-      # Drain regardless of the wait outcome: a missed/coalesced signal must not
-      # leave requests stranded, and the 100ms timeout bounds shutdown latency.
+      # Block until a submit signals us, or for at most 100ms if none does.
       discard await ctx.reqSignal.wait().withTimeout(chronos.milliseconds(100))
-      drainQueue()
+      processQueue()
 
     # Drain once more so requests enqueued just before `running` flipped still
     # dispatch and each pending handler's deleteRequest defer runs before exit.
-    drainQueue()
-    reapCompleted()
+    processQueue()
+    cleanFinishedRequests()
     if pending.len > 0:
       try:
         await allFutures(pending)

--- a/ffi/ffi_thread.nim
+++ b/ffi/ffi_thread.nim
@@ -25,23 +25,18 @@ proc sendRequestToFFIThread*(
       "reentrant ffi call: a handler invoked sendRequestToFFIThread on its own context"
     )
 
-  # Mutex-guarded hand-off: the lock inside pushRequest covers only the O(1)
-  # enqueue; the request malloc (already done) and the wake below stay outside
-  # it, so concurrent producers don't serialise. The queue is unbounded, so
-  # enqueue can't fail, and completion is reported through the request's own
-  # callback — there is no accept-ack to wait on.
+  # The lock inside pushRequest covers only the O(1) enqueue; the wake stays
+  # outside it, so concurrent producers don't serialise. Unbounded, so enqueue
+  # can't fail — completion comes via the request's own callback, no accept-ack.
   #
-  # Only wake the FFI thread when this push found the queue empty. While the
-  # consumer is draining (queue non-empty) the wake is redundant — and a
-  # fireSync() syscall per submit, contended across producers, is precisely
-  # what destroys submit scaling. A skipped edge can't strand the request: the
-  # consumer drains to empty and re-polls every 100ms regardless.
+  # Wake only when the push found the queue empty: while the consumer drains, a
+  # fireSync() syscall per submit (contended across producers) is what destroys
+  # scaling. A skipped wake can't strand the request — the consumer re-polls 100ms.
   let shouldWake = ctx.reqQueue.pushRequest(ffiRequest)
 
-  # A failed wake is non-fatal: the request is queued and the FFI thread's
-  # poll-drain dispatches it within one tick regardless of the signal. Returning
-  # err here would double-fire the caller's callback for a request that still
-  # completes normally.
+  # A failed wake is non-fatal: the request is queued and the poll-drain
+  # dispatches it within a tick anyway. Returning err would double-fire the
+  # caller's callback for a request that still completes.
   if shouldWake:
     ctx.reqSignal.fireSync().isOkOr:
       error "failed to wake FFI thread after enqueue (request still queued)",
@@ -141,8 +136,8 @@ proc ffiThreadBody[T](ctx: ptr FFIContext[T]) {.thread.} =
           # and trip the event thread's wedged-FFI-thread detection mid-drain.
           ctx.proveAlive()
           if ctx.myLib.isNil():
-            # Keep this reference to `ffiReqHandler` inside the closure is what keeps
-            # the variable in the async env, so `myLib` stays valid across awaits.
+            # This reference must stay inside the closure: it's what keeps
+            # `ffiReqHandler` in the async env, so `myLib` survives across awaits.
             ctx.myLib = addr ffiReqHandler
 
           pending.add processRequest(request, ctx)

--- a/ffi/ffi_thread.nim
+++ b/ffi/ffi_thread.nim
@@ -87,6 +87,12 @@ proc ffiNotifyEventEnqueuedHook() {.gcsafe, raises: [].} =
     if res.isErr():
       error "failed to fire eventQueueSignal after enqueue", err = res.error
 
+proc proveAlive(ctx: ptr FFIContext) =
+  ## Advance the heartbeat the event thread polls to spot a wedged FFI thread.
+  ## Only that the counter keeps moving matters, never its value — so a plain
+  ## atomic increment, no read-back.
+  ctx.ffiHeartbeat.atomicInc()
+
 proc ffiThreadBody[T](ctx: ptr FFIContext[T]) {.thread.} =
   ## FFI thread body that attends library user API requests
   ffiCurrentEventRegistry = addr ctx[].eventRegistry
@@ -129,20 +135,20 @@ proc ffiThreadBody[T](ctx: ptr FFIContext[T]) {.thread.} =
       ## takes the whole chain in one lock, so the consumer barely contends with
       ## the producers.
       while true:
-        var node = ctx.reqQueue.mergeQueues()
-        if node.isNil:
+        var request = ctx.reqQueue.mergeQueues()
+        if request.isNil():
           break
-        while not node.isNil:
-          let nxt = node[].next # read before processRequest frees the node
+        while not request.isNil():
+          let nextRequest = request[].next # read before processRequest frees it
           # Tick per dispatch so a large backlog can't flatline the heartbeat
           # and trip the event thread's wedged-FFI-thread detection mid-drain.
-          discard ctx.ffiHeartbeat.fetchAdd(1)
-          pending.add processRequest(node, ctx)
-          node = nxt
+          ctx.proveAlive()
+          pending.add processRequest(request, ctx)
+          request = nextRequest
 
     while ctx.running.load():
       # Freezes if a sync handler blocks the dispatcher; event thread reads to detect wedged FFI thread.
-      discard ctx.ffiHeartbeat.fetchAdd(1)
+      ctx.proveAlive()
 
       reapCompleted()
 

--- a/ffi/ffi_thread.nim
+++ b/ffi/ffi_thread.nim
@@ -109,6 +109,7 @@ proc ffiThreadBody[T](ctx: ptr FFIContext[T]) {.thread.} =
 
   let ffiRun = proc(ctx: ptr FFIContext[T]) {.async.} =
     var ffiReqHandler: T # main library object (Waku, LibP2P, SDS, …)
+    ctx.myLib = addr ffiReqHandler
 
     # Tracked so shutdown can drain them; abandoning a mid-await future leaks the request.
     var pending: seq[Future[void]] = @[]
@@ -136,8 +137,6 @@ proc ffiThreadBody[T](ctx: ptr FFIContext[T]) {.thread.} =
           # Tick per dispatch so a large backlog can't flatline the heartbeat
           # and trip the event thread's wedged-FFI-thread detection mid-drain.
           discard ctx.ffiHeartbeat.fetchAdd(1)
-          if ctx.myLib.isNil():
-            ctx.myLib = addr ffiReqHandler
           pending.add processRequest(node, ctx)
           node = nxt
 

--- a/ffi/ffi_thread_request.nim
+++ b/ffi/ffi_thread_request.nim
@@ -26,6 +26,10 @@ type FFIThreadRequest* = object
   reqId*: cstring ## Per-proc Req type name used to look up the handler.
   data*: ptr UncheckedArray[byte] ## Owned CBOR-encoded request payload.
   dataLen*: int
+  next*: ptr FFIThreadRequest
+    ## Intrusive ingress-queue link (see `ffi_request_queue.nim`). Touched only
+    ## under the queue's lock; the request doubles as its own node, so no
+    ## separate node alloc lands on the per-thread ORC MemRegion.
 
 proc allocBaseRequest(
     callback: FFICallBack, userData: pointer, reqId: cstring
@@ -39,6 +43,7 @@ proc allocBaseRequest(
   ret[].reqId = reqId.alloc()
   ret[].data = nil
   ret[].dataLen = 0
+  ret[].next = nil
   return ret
 
 proc copySharedPayload(req: ptr FFIThreadRequest, data: ptr byte, dataLen: int) =

--- a/ffi/internal/ffi_macro.nim
+++ b/ffi/internal/ffi_macro.nim
@@ -857,12 +857,9 @@ macro ffi*(args: varargs[untyped]): untyped =
     )
 
   proc asyncPath(): NimNode =
-    ## Emits the C-exported wrapper and registers the request handler.
-    ## All `.ffi.` procs dispatch through the FFI thread channel and reply
-    ## through the callback when the future resolves — the previous "sync
-    ## fast-path" that ran inline on the foreign caller thread was removed
-    ## (PR #23 review, items 1–5) because it bypassed `foreignThreadGc`, the
-    ## MPSC ingress hand-off, and chronos's single-thread invariant.
+    ## Emits the C-exported wrapper and registers the handler. Every `.ffi.` proc
+    ## dispatches through the FFI thread and replies via its callback, honouring
+    ## `foreignThreadGc`, the MPSC ingress hand-off, and chronos's invariant.
     let helperProc = buildAsyncHelperProc()
 
     # registerReqFFI lambda: typed params, returns user's typed Result.

--- a/ffi/internal/ffi_macro.nim
+++ b/ffi/internal/ffi_macro.nim
@@ -861,8 +861,8 @@ macro ffi*(args: varargs[untyped]): untyped =
     ## All `.ffi.` procs dispatch through the FFI thread channel and reply
     ## through the callback when the future resolves — the previous "sync
     ## fast-path" that ran inline on the foreign caller thread was removed
-    ## (PR #23 review, items 1–5) because it bypassed `foreignThreadGc`,
-    ## `ctx.lock`, and chronos's single-thread invariant.
+    ## (PR #23 review, items 1–5) because it bypassed `foreignThreadGc`, the
+    ## MPSC ingress hand-off, and chronos's single-thread invariant.
     let helperProc = buildAsyncHelperProc()
 
     # registerReqFFI lambda: typed params, returns user's typed Result.

--- a/tests/bench/README.md
+++ b/tests/bench/README.md
@@ -9,7 +9,13 @@ This directory holds Nim micro/stress benchmarks. Neither is part of `nimble tes
 
 `bench_ffi_submit.nim` motivates [issue #90](https://github.com/logos-messaging/nim-ffi/issues/90): every foreign-thread call serialises the whole `trySend + reqSignal.fireSync + reqReceivedSignal.waitSync` cycle under a single `ctx.lock`. The lock is load-bearing because `reqChannel` is single-slot and the accept handshake waits on a *shared* `reqReceivedSignal`, so producers cannot overlap.
 
-The bench fans **K producer threads (1 → 8)** at one context, each firing the same per-thread volume of no-op requests. It times the **submit phase only** — from the start gate until every producer returns from its last `sendRequestToFFIThread` — because that is the path the fix parallelises; completion is bounded by the single FFI thread and deliberately excluded. Each thread count runs `FFI_SUBMIT_ITERS` times (default 5) and the **median** submit/sec is reported, so run-to-run noise can't move the verdict.
+The bench fans **K producer threads** at one context (default sweep `1,2,4,8`), each firing the same per-thread volume of no-op requests. It times the **submit phase only** — from the start gate until every producer returns from its last `sendRequestToFFIThread` — because that is the path the fix parallelises; completion is bounded by the single FFI thread and deliberately excluded. Each thread count runs `FFI_SUBMIT_ITERS` times (default 5) and the **median** submit/sec is reported, so run-to-run noise can't move the verdict.
+
+The high-contention curve (up to 100 producers) is **opt-in for local runs**, not CI: under a sanitizer on a slow runner, 100 threads can't settle their callbacks within the bench's timeout and would fail on time, not on a bug. Run it on demand with `FFI_SUBMIT_THREADS`:
+
+```sh
+FFI_SUBMIT_THREADS="1,8,16,32,64,100" nimble bench_ffi_submit
+```
 
 It is also a correctness stress test: the aggregate callback count must match the submit count **exactly** (no drops or double-fires), with zero submit errors and (under asan/lsan/tsan) zero leaks or races.
 
@@ -21,13 +27,26 @@ FFI_SUBMIT_PER_THREAD=2000 FFI_SUBMIT_ITERS=1 FFI_SCALING_GATE=0 nimble bench_ff
 NIM_FFI_SAN=tsan FFI_SUBMIT_PER_THREAD=2000 FFI_SCALING_GATE=0 nimble bench_ffi_submit
 ```
 
-Env knobs: `FFI_SUBMIT_PER_THREAD` (volume per producer, default 20000), `FFI_SUBMIT_ITERS` (median sample count, default 5), `FFI_SCALING_GATE` (default `1`; set `0` to report numbers without failing).
+Env knobs: `FFI_SUBMIT_PER_THREAD` (volume per producer, default 20000), `FFI_SUBMIT_ITERS` (median sample count, default 5), `FFI_SUBMIT_THREADS` (comma-separated producer counts, default `1,2,4,8`), `FFI_SCALING_GATE` (default `1`; set `0` to report numbers without failing).
 
-### Scaling gate — red until the lock is replaced
+### Scaling gate — guards the sharded ingress against regression
 
-By default the bench **fails** (non-zero exit) unless submit throughput at 8 threads is at least `1.5x` the 1-thread rate. This is a forcing function: it cannot pass while `sendRequestToFFIThread` holds `ctx.lock` across the synchronous `reqReceivedSignal` accept, because that serialises every submit no matter how many producers run.
+By default the bench **fails** (non-zero exit) unless submit throughput at the top thread count is at least `1.5x` the 1-thread rate. This was a forcing function while `sendRequestToFFIThread` still held `ctx.lock` across the synchronous `reqReceivedSignal` accept (which serialised every submit); it is now a regression guard for the sharded ingress that replaced it.
 
-Baseline measured 2026-06-24 (16-core Linux, orc, `-d:danger`, median of 5): submit scaling held at **0.98–1.16x** across threads — flat, as the lock dictates. `1.5x` sits above that noise ceiling (so the lock-bound code fails reliably) and well below the `>=2x` that parallel lock-free MPSC ingress yields on any multicore host (so the fix clears it with margin). Once it lands and this turns green, keep the gate as a regression guard.
+The original lock-bound code measured 2026-06-24 (16-core Linux, orc, `-d:danger`, median of 5): submit scaling held flat at **0.98–1.16x** — adding producers bought nothing. `1.5x` sits above that noise ceiling so the old code fails reliably, and well below what the sharded ingress delivers, so the fix clears it with wide margin.
+
+The fix replaces the single-slot channel + accept handshake with a **sharded, mutex-guarded MPSC ingress** (`ffi/ffi_request_queue.nim`): independent per-producer lanes remove the single shared hotspot, and the wake fires only on a lane's empty→non-empty edge so submits don't each pay a syscall. Measured 2026-06-25 (Apple M5, 10 cores, orc, `-d:danger`, median of 5), submit/sec and scaling vs 1 thread:
+
+| threads | sharded ingress | vs 1T | lock-free MPSC (Vyukov) | vs 1T |
+| ---: | ---: | :---: | ---: | :---: |
+| 1   | 2.14M | 1.00x | 1.18M | 1.00x |
+| 8   | 17.6M | 8.22x | 0.23M | 0.20x |
+| 16  | 20.3M | 9.52x | 0.13M | 0.11x |
+| 32  | 23.4M | 10.96x | 0.115M | 0.10x |
+| 64  | 24.5M | 11.44x | 0.113M | 0.10x |
+| 100 | 23.8M | **11.13x** | 0.113M | **0.10x** |
+
+The sharded ingress tracks the hardware ceiling (~24M/s plateau, saturating the cores) and degrades gracefully past it; the single-hotspot lock-free queue collapses to a contention floor and gets *worse* with more threads. Both are correct at every level (callback count matches submits exactly, no drops/dupes).
 
 The gate runs in the non-sanitized **Submit Scaling Gate** CI job (`.github/workflows/ci.yml`); the sanitized jobs run the same bench with `FFI_SCALING_GATE=0` for leak/race coverage only, since sanitizer instrumentation makes throughput scaling meaningless.
 

--- a/tests/bench/README.md
+++ b/tests/bench/README.md
@@ -35,7 +35,7 @@ By default the bench **fails** (non-zero exit) unless submit throughput at the t
 
 The original lock-bound code measured 2026-06-24 (16-core Linux, orc, `-d:danger`, median of 5): submit scaling held flat at **0.98–1.16x** — adding producers bought nothing. `1.5x` sits above that noise ceiling so the old code fails reliably, and well below what the sharded ingress delivers, so the fix clears it with wide margin.
 
-The fix replaces the single-slot channel + accept handshake with a **sharded, mutex-guarded MPSC ingress** (`ffi/ffi_request_queue.nim`): independent per-producer lanes remove the single shared hotspot, and the wake fires only on a lane's empty→non-empty edge so submits don't each pay a syscall. Measured 2026-06-25 (Apple M5, 10 cores, orc, `-d:danger`, median of 5), submit/sec and scaling vs 1 thread:
+The fix replaces the single-slot channel + accept handshake with a **sharded, mutex-guarded MPSC ingress** (`ffi/ffi_request_queue.nim`): independent per-producer queues remove the single shared hotspot, and the wake fires only on a queue's empty→non-empty edge so submits don't each pay a syscall. Measured 2026-06-25 (Apple M5, 10 cores, orc, `-d:danger`, median of 5), submit/sec and scaling vs 1 thread:
 
 | threads | sharded ingress | vs 1T | lock-free MPSC (Vyukov) | vs 1T |
 | ---: | ---: | :---: | ---: | :---: |

--- a/tests/bench/bench_ffi_submit.nim
+++ b/tests/bench/bench_ffi_submit.nim
@@ -119,11 +119,9 @@ proc main() =
   let gateOn = getEnv("FFI_SCALING_GATE", "1") != "0"
   if perThread < 1 or iters < 1:
     quit("FFI_SUBMIT_PER_THREAD and FFI_SUBMIT_ITERS must be >= 1")
-  # CI default is a light sweep so the gate and the (far slower) asan/tsan jobs
-  # stay fast; the high-contention curve (e.g. up to 100 threads) is opt-in for
-  # local on-demand runs via FFI_SUBMIT_THREADS. A heavy sweep under a sanitizer
-  # on a slow runner can't settle its callbacks within `settleTimeout` and would
-  # fail on a timeout, not a real bug — so it is kept out of CI deliberately.
+  # Default sweep is light so CI (and the slower asan/tsan jobs) stays fast. Set
+  # FFI_SUBMIT_THREADS for the high-contention curve locally — under a sanitizer
+  # it can outrun `settleTimeout` and fail on timing, not a real bug.
   #   FFI_SUBMIT_THREADS="1,8,16,32,64,100" nimble bench_ffi_submit
   let threadCounts = block:
     var cs: seq[int]

--- a/tests/bench/bench_ffi_submit.nim
+++ b/tests/bench/bench_ffi_submit.nim
@@ -119,7 +119,21 @@ proc main() =
   let gateOn = getEnv("FFI_SCALING_GATE", "1") != "0"
   if perThread < 1 or iters < 1:
     quit("FFI_SUBMIT_PER_THREAD and FFI_SUBMIT_ITERS must be >= 1")
-  let threadCounts = [1, 2, 4, 8]
+  # CI default is a light sweep so the gate and the (far slower) asan/tsan jobs
+  # stay fast; the high-contention curve (e.g. up to 100 threads) is opt-in for
+  # local on-demand runs via FFI_SUBMIT_THREADS. A heavy sweep under a sanitizer
+  # on a slow runner can't settle its callbacks within `settleTimeout` and would
+  # fail on a timeout, not a real bug — so it is kept out of CI deliberately.
+  #   FFI_SUBMIT_THREADS="1,8,16,32,64,100" nimble bench_ffi_submit
+  let threadCounts = block:
+    var cs: seq[int]
+    for part in getEnv("FFI_SUBMIT_THREADS", "1,2,4,8").split(','):
+      let p = part.strip()
+      if p.len > 0:
+        cs.add(parseInt(p))
+    if cs.len < 2:
+      quit("FFI_SUBMIT_THREADS needs >= 2 counts (first = baseline, last = peak)")
+    cs
 
   echo "── sendRequestToFFIThread submit throughput (median of ",
     iters, ") ──────"

--- a/tests/unit/test_ffi_context.nim
+++ b/tests/unit/test_ffi_context.nim
@@ -487,12 +487,9 @@ suite "Nim-native .ffi. / .ffiCtor. API":
     check ctorRes.isOk
     check ctorRes.value.value == 21
 
-# Regression for PR #23 review items 1–5: a `.ffi.` body without `await`
-# used to be emitted as an inline-on-foreign-thread fast path, which bypassed
-# `foreignThreadGc`, the MPSC ingress hand-off, and chronos's single-thread invariant. The
-# sync fast-path was deleted; this test records `getThreadId()` inside a
-# sync body and asserts the handler runs on the FFI thread, not on the
-# caller's thread.
+# A sync `.ffi.` body (no `await`) must run on the FFI thread, not the caller's,
+# so it goes through `foreignThreadGc`, the MPSC ingress hand-off, and chronos's
+# single-thread invariant. Records `getThreadId()` in a sync body and asserts it.
 
 var gRecordedHandlerTid: Atomic[int]
 
@@ -551,10 +548,9 @@ suite "sync-body .ffi. runs on FFI thread (PR #23 regression)":
     # And the callback payload (the recorded tid) matches what the handler stored.
     check cborDecode(callbackBytes(d), int).value == handlerTid
 
-# Regression for PR #23 review item 6: reentrancy guard on
-# sendRequestToFFIThread. A handler running on the FFI thread that re-dispatches
-# through sendRequestToFFIThread would enqueue work onto the very queue its
-# blocked dispatcher can never drain. The guard returns an Err immediately.
+# Reentrancy guard on sendRequestToFFIThread: a handler running on the FFI thread
+# that re-dispatches through it would enqueue work onto the very queue its blocked
+# dispatcher can never drain, so the guard returns an Err immediately.
 
 var gReentrantNestedRes: Channel[string]
 gReentrantNestedRes.open()

--- a/tests/unit/test_ffi_context.nim
+++ b/tests/unit/test_ffi_context.nim
@@ -489,7 +489,7 @@ suite "Nim-native .ffi. / .ffiCtor. API":
 
 # Regression for PR #23 review items 1–5: a `.ffi.` body without `await`
 # used to be emitted as an inline-on-foreign-thread fast path, which bypassed
-# `foreignThreadGc`, `ctx.lock`, and chronos's single-thread invariant. The
+# `foreignThreadGc`, the MPSC ingress hand-off, and chronos's single-thread invariant. The
 # sync fast-path was deleted; this test records `getThreadId()` inside a
 # sync body and asserts the handler runs on the FFI thread, not on the
 # caller's thread.
@@ -552,10 +552,9 @@ suite "sync-body .ffi. runs on FFI thread (PR #23 regression)":
     check cborDecode(callbackBytes(d), int).value == handlerTid
 
 # Regression for PR #23 review item 6: reentrancy guard on
-# sendRequestToFFIThread. A handler running on the FFI thread that tries to
-# dispatch back through sendRequestToFFIThread used to self-deadlock waiting
-# on `reqReceivedSignal` (which only the FFI thread can fire). The guard now
-# returns an Err immediately.
+# sendRequestToFFIThread. A handler running on the FFI thread that re-dispatches
+# through sendRequestToFFIThread would enqueue work onto the very queue its
+# blocked dispatcher can never drain. The guard returns an Err immediately.
 
 var gReentrantNestedRes: Channel[string]
 gReentrantNestedRes.open()


### PR DESCRIPTION
## Summary

A simpler, faster alternative to the lock-free (Vyukov) request transport in #98, proposed so the two can be compared head-to-head against the #97 submit-scaling gate. Replaces the single-slot SPSC channel + global submit lock with a **sharded, mutex-guarded MPSC ingress**.

> Note: this branch builds on #97, so the diff vs `master` also carries #97's submit benchmark (`tests/bench/bench_ffi_submit.nim`, the `Submit Scaling Gate` CI job, and the nimble task). That is intentional — it makes the comparison runnable standalone.

## The problem (issue #90 / #97)

`sendRequestToFFIThread` held `ctx.lock` while **blocking** on `reqReceivedSignal` waiting for the FFI thread to ack each request, so concurrent producers could never overlap — the #97 gate stays red until that serialisation is removed.

## Why sharding, not lock-free

A **single** queue — lock-free or not — funnels every producer through **one shared cache line** (the lock, or the lock-free head), plus #98 keeps a `fireSync()` **syscall on every submit**. That hotspot caps aggregate throughput, so it can't scale past one thread. Measured on this hardware the lock-free single queue actually *anti-scales*.

This PR instead:
- **Shards the ingress into 16 independent per-producer lanes** (`ffi/ffi_request_queue.nim`) — removes the shared write point; producers contend only when two land on the same lane.
- **Coalesces the wake** — fires only on a lane's empty→non-empty edge, so submits don't each pay a syscall (the consumer drains to empty and re-polls every 100 ms, so a skipped edge can't strand a request).
- Keeps each lane a **plain intrusive FIFO under its own `Lock`**: trivially data-race-free under TSAN, no memory-ordering reasoning, no transient-nil/shutdown-race. The request doubles as its own queue node (intrusive `next`), so enqueue allocates nothing and never touches a Nim GC heap (the cross-thread `MemRegion` hazard in `ffi_thread_request.nim`).

## Benchmark comparison

Apple M5 (10 cores), orc, `-d:danger`, median of 5 — submit/sec and scaling vs 1 thread:

| threads | **sharded (this PR)** | vs 1T | lock-free MPSC (#98) | vs 1T |
| ---: | ---: | :---: | ---: | :---: |
| 1   | 2.14M | 1.00x | 1.18M | 1.00x |
| 8   | 17.6M | 8.22x | 0.23M | 0.20x |
| 16  | 20.3M | 9.52x | 0.13M | 0.11x |
| 32  | 23.4M | 10.96x | 0.115M | 0.10x |
| 64  | 24.5M | 11.44x | 0.113M | 0.10x |
| 100 | 23.8M | **11.13x** | 0.113M | **0.10x** |

The sharded ingress tracks the hardware ceiling (~24M/s plateau) and degrades gracefully past it; the single-hotspot lock-free queue collapses to a contention floor and gets *worse* with more threads (~211x slower at 100 threads). Both are correct at every level (callback count matches submits exactly, no drops/dupes).

This matters for the real workload: a foreign Go app can drive ~75 concurrent threads at the library — squarely in the regime where the single-hotspot design collapses and sharding holds.

## Trade-offs (drawbacks of sharding)

- **Per-lane FIFO, not global** — concurrent foreign callers already raced with no cross-thread ordering guarantee, so this matches the existing contract; a single thread's own order is preserved (it maps to one lane).
- **Lane count (16) is a fixed constant** — the knob that bounds how far it scales. ≥ expected concurrent producers keeps lane collisions near zero (75 Go threads → ~5/lane, still scales as the 100-thread row shows). On a much larger host it may warrant bumping; candidate follow-up: make it a `declareLibrary` setting.
- **Consumer takes O(lanes) locks per drain pass** (16 here) even when most lanes are empty — trivial at 16, grows if lanes are raised.
- Helps **many** producers, not one hot producer (single-lane-bound).
- Padding (~280 B/lane) assumes a 128-byte cache line.

## Compatibility

- **FFI context pool unchanged and functional** — `ffi_context_pool.nim` only drives the lifecycle procs; the benchmark exercises it (create/destroy per iteration) at up to 100 threads.
- Rust codegen + the generated `api.rs` SAFETY comment updated to describe the mutex-guarded enqueue.

## Test plan

- Unit suites pass under **orc + refc**: `test_ffi_context` (19), `test_event_thread`, `test_event_dispatch`, `test_gc_compat`.
- Library builds `--app:lib`.
- Submit gate passes with wide margin (11x) across 1→100 threads; exactly-once correctness holds.
- TODO before merge: confirm on the Linux CI host (should win there too — it removes contention regardless of OS), and run under asan/tsan via the sanitized job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
