### PR TITLE
fix(ffi): regenerate stale echo C++ bindings and guard them in check_bindings_cpp

### DIFF
--- a/examples/echo/cpp_bindings/echo.hpp
+++ b/examples/echo/cpp_bindings/echo.hpp
@@ -145,17 +145,20 @@ inline CborError encode_cbor(CborEncoder& e, const std::optional<T>& v) {
 
 // ── decode_cbor overloads ───────────────────────────────────────────────
 
-inline CborError decode_cbor(CborValue& it, bool& out) {
-    if (!cbor_value_is_boolean(&it)) return CborErrorImproperValue;
-    CborError err = cbor_value_get_boolean(&it, &out);
+// After reading a leaf value, the parser must advance past it; both steps
+// short-circuit on the same CborError, so they always travel together.
+inline CborError advance_if_ok(CborValue& it, CborError err) {
     if (err) return err;
     return cbor_value_advance(&it);
 }
+
+inline CborError decode_cbor(CborValue& it, bool& out) {
+    if (!cbor_value_is_boolean(&it)) return CborErrorImproperValue;
+    return advance_if_ok(it, cbor_value_get_boolean(&it, &out));
+}
 inline CborError decode_cbor(CborValue& it, int64_t& out) {
     if (!cbor_value_is_integer(&it)) return CborErrorImproperValue;
-    CborError err = cbor_value_get_int64_checked(&it, &out);
-    if (err) return err;
-    return cbor_value_advance(&it);
+    return advance_if_ok(it, cbor_value_get_int64_checked(&it, &out));
 }
 inline CborError decode_cbor(CborValue& it, int32_t& out) {
     int64_t tmp = 0;
@@ -166,15 +169,11 @@ inline CborError decode_cbor(CborValue& it, int32_t& out) {
 }
 inline CborError decode_cbor(CborValue& it, uint64_t& out) {
     if (!cbor_value_is_unsigned_integer(&it)) return CborErrorImproperValue;
-    CborError err = cbor_value_get_uint64(&it, &out);
-    if (err) return err;
-    return cbor_value_advance(&it);
+    return advance_if_ok(it, cbor_value_get_uint64(&it, &out));
 }
 inline CborError decode_cbor(CborValue& it, double& out) {
     if (cbor_value_is_double(&it)) {
-        CborError err = cbor_value_get_double(&it, &out);
-        if (err) return err;
-        return cbor_value_advance(&it);
+        return advance_if_ok(it, cbor_value_get_double(&it, &out));
     }
     if (cbor_value_is_float(&it)) {
         float f = 0.0f;
@@ -191,9 +190,8 @@ inline CborError decode_cbor(CborValue& it, std::string& out) {
     CborError err = cbor_value_get_string_length(&it, &len);
     if (err) return err;
     out.resize(len);
-    err = cbor_value_copy_text_string(&it, out.empty() ? nullptr : &out[0], &len, nullptr);
-    if (err) return err;
-    return cbor_value_advance(&it);
+    return advance_if_ok(
+        it, cbor_value_copy_text_string(&it, out.empty() ? nullptr : &out[0], &len, nullptr));
 }
 
 template<typename T>
@@ -222,10 +220,8 @@ inline CborError decode_cbor(CborValue& it, std::vector<std::uint8_t>& out) {
     CborError err = cbor_value_get_string_length(&it, &len);
     if (err) return err;
     out.resize(len);
-    err = cbor_value_copy_byte_string(
-        &it, out.empty() ? nullptr : out.data(), &len, nullptr);
-    if (err) return err;
-    return cbor_value_advance(&it);
+    return advance_if_ok(
+        it, cbor_value_copy_byte_string(&it, out.empty() ? nullptr : out.data(), &len, nullptr));
 }
 
 template<typename T>

--- a/ffi.nimble
+++ b/ffi.nimble
@@ -201,8 +201,10 @@ task check_bindings_rust, "Verify checked-in Rust bindings match Nim source":
 
 task check_bindings_cpp, "Verify checked-in C++ bindings match Nim source":
   exec "nimble genbindings_cpp"
+  exec "nimble genbindings_cpp_echo"
   exec "git diff --exit-code --" & " examples/timer/cpp_bindings/my_timer.hpp" &
-    " examples/timer/cpp_bindings/CMakeLists.txt"
+    " examples/timer/cpp_bindings/CMakeLists.txt" &
+    " examples/echo/cpp_bindings/echo.hpp" & " examples/echo/cpp_bindings/CMakeLists.txt"
 
 task check_bindings, "Verify all checked-in example bindings match Nim source":
   exec "nimble check_bindings_rust"


### PR DESCRIPTION
## Summary

The checked-in `examples/echo/cpp_bindings/echo.hpp` had drifted out of sync with the C++ codegen and nothing caught it. The current template (`ffi/codegen/templates/cpp/cbor_helpers.hpp.tpl`) factors the repeated "read leaf value, then advance the iterator" pattern into a shared `advance_if_ok` helper, but the checked-in echo header still carried the old inlined form. The timer header (`my_timer.hpp`) had the helper; echo did not.

The drift survived because `check_bindings_cpp` only regenerated and `git diff --exit-code`d the **timer** bindings — the echo header was never verified, so any divergence between `echo.nim` and its checked-in C++ output passed CI silently.

## What changed

- Regenerated `examples/echo/cpp_bindings/echo.hpp` via `nimble genbindings_cpp_echo`. Pure codegen output, no hand edits: the leaf `decode_cbor` overloads (`bool`, `int64_t`, `uint64_t`, `double`, `std::string`, `std::vector<std::uint8_t>`) now route through `advance_if_ok` instead of repeating the `get + advance` dance.
- Extended `check_bindings_cpp` (`ffi.nimble`) to also run `genbindings_cpp_echo` and diff `echo.hpp` + its `CMakeLists.txt`, alongside the existing timer checks. The `genbindings_cpp_echo` task already existed; it just was never wired into the guard.

## Verification

Ran `nimble check_bindings_cpp` after regenerating: clean exit 0 with both the timer and echo diffs empty, confirming the checked-in echo header now matches codegen and that the guard actually covers it. Before the regen, the extended check fails on echo's missing `advance_if_ok` — so the guard bites on real drift rather than being decorative.