### PR TITLE
feat(nimble): actionable remediation message on stale-bindings check failure

### DIFF
--- a/ffi.nimble
+++ b/ffi.nimble
@@ -45,6 +45,15 @@ proc runOrQuit(cmd: string) =
     echo "error: ", e.msg
     quit(QuitFailure)
 
+proc checkBindingsDiff(regenCmd: string, paths: openArray[string]) =
+  # On a diff, print a remediation hint instead of a bare diff wall. Re-quitting
+  # non-zero also dodges the nimble ≥2.2.10 exit-0-on-failure footgun (runOrQuit).
+  try:
+    exec "git diff --exit-code -- " & paths.join(" ")
+  except OSError:
+    echo "Checked-in bindings are stale. Run `" & regenCmd & "` and commit the result."
+    quit(QuitFailure)
+
 proc sanFlags(san: string): string =
   # Each --passC / --passL adds one literal flag to the C compiler / linker
   # invocation — avoids any quoting ambiguity that arises from putting
@@ -269,32 +278,52 @@ task genbindings_c_abi_echo, "Generate CBOR-free abi=c C bindings for the echo e
     " -o:/dev/null examples/echo/echo.nim"
 
 task check_bindings_rust, "Verify checked-in Rust bindings match Nim source":
-  exec "nimble genbindings_rust"
-  exec "git diff --exit-code --" & " examples/timer/rust_bindings/Cargo.toml" &
-    " examples/timer/rust_bindings/build.rs" & " examples/timer/rust_bindings/src"
+  runOrQuit "nimble genbindings_rust"
+  checkBindingsDiff(
+    "nimble genbindings_rust",
+    [
+      "examples/timer/rust_bindings/Cargo.toml",
+      "examples/timer/rust_bindings/build.rs", "examples/timer/rust_bindings/src",
+    ],
+  )
 
 task check_bindings_cpp, "Verify checked-in C++ bindings match Nim source":
-  exec "nimble genbindings_cpp"
-  exec "nimble genbindings_cpp_echo"
-  exec "git diff --exit-code --" & " examples/timer/cpp_bindings/my_timer.hpp" &
-    " examples/timer/cpp_bindings/CMakeLists.txt" &
-    " examples/echo/cpp_bindings/echo.hpp" & " examples/echo/cpp_bindings/CMakeLists.txt"
+  runOrQuit "nimble genbindings_cpp"
+  runOrQuit "nimble genbindings_cpp_echo"
+  checkBindingsDiff(
+    "nimble genbindings_cpp && nimble genbindings_cpp_echo",
+    [
+      "examples/timer/cpp_bindings/my_timer.hpp",
+      "examples/timer/cpp_bindings/CMakeLists.txt",
+      "examples/echo/cpp_bindings/echo.hpp", "examples/echo/cpp_bindings/CMakeLists.txt",
+    ],
+  )
 
 task check_bindings_c, "Verify checked-in C bindings match Nim source":
-  exec "nimble genbindings_c"
-  exec "nimble genbindings_c_echo"
-  exec "git diff --exit-code --" & " examples/timer/c_bindings/my_timer.h" &
-    " examples/timer/c_bindings/nim_ffi_prelude.h" &
-    " examples/timer/c_bindings/nim_ffi_cbor.h" &
-    " examples/timer/c_bindings/CMakeLists.txt" & " examples/echo/c_bindings/echo.h" &
-    " examples/echo/c_bindings/nim_ffi_prelude.h" &
-    " examples/echo/c_bindings/nim_ffi_cbor.h" &
-    " examples/echo/c_bindings/CMakeLists.txt"
+  runOrQuit "nimble genbindings_c"
+  runOrQuit "nimble genbindings_c_echo"
+  checkBindingsDiff(
+    "nimble genbindings_c && nimble genbindings_c_echo",
+    [
+      "examples/timer/c_bindings/my_timer.h",
+      "examples/timer/c_bindings/nim_ffi_prelude.h",
+      "examples/timer/c_bindings/nim_ffi_cbor.h",
+      "examples/timer/c_bindings/CMakeLists.txt", "examples/echo/c_bindings/echo.h",
+      "examples/echo/c_bindings/nim_ffi_prelude.h",
+      "examples/echo/c_bindings/nim_ffi_cbor.h",
+      "examples/echo/c_bindings/CMakeLists.txt",
+    ],
+  )
 
 task check_bindings_c_abi, "Verify checked-in abi=c C bindings match Nim source":
-  exec "nimble genbindings_c_abi_echo"
-  exec "git diff --exit-code --" & " examples/echo/c_abi_bindings/echo.h" &
-    " examples/echo/c_abi_bindings/CMakeLists.txt"
+  runOrQuit "nimble genbindings_c_abi_echo"
+  checkBindingsDiff(
+    "nimble genbindings_c_abi_echo",
+    [
+      "examples/echo/c_abi_bindings/echo.h",
+      "examples/echo/c_abi_bindings/CMakeLists.txt",
+    ],
+  )
 
 task check_bindings, "Verify all checked-in example bindings match Nim source":
   exec "nimble check_bindings_rust"


### PR DESCRIPTION
## Summary

`check_bindings_*` verified checked-in example bindings with a bare `git diff --exit-code`. When bindings drifted, a contributor got a wall of diff and zero instruction on how to fix it — and under nimble ≥2.2.10, a failing bare `exec` prints its `OSError` but exits 0, so CI could report green on an actual staleness failure.

This wraps the diff in a `checkBindingsDiff` helper (modeled on the existing `runOrQuit`) that, on any diff, prints `Checked-in bindings are stale. Run \`nimble genbindings_<lang>\` and commit the result.` and quits non-zero. The four check tasks (`rust`, `cpp`, `c`, `c_abi`) route through it.

Two adjacent robustness fixes fold in while touching this code:

- The `nimble genbindings_*` regeneration steps inside each check task were bare `exec` — the same nimble ≥2.2.10 exit-0-on-failure footgun. They now use `runOrQuit`, matching the sibling `test_*_e2e` tasks so a codegen failure fails the task loudly.
- The verified path list moved from hand-glued space-prefixed string concatenation (`"a.h" & " b.h"`, where one missing leading space silently fuses two paths into a non-matching pathspec that `git diff` exits 0 on) to `openArray[string]` joined with `join(" ")`, per the house `openArray` preference.

## Testing

Build-script-only change; no runtime surface. Verified by evaluating `ffi.nimble` as nimscript under Nim 2.2.6 (`nim e`, exits 0) and exercising the helper's failure path directly — a non-zero `git diff` prints the remediation hint and exits 1. Formatted with `nph`.