### PR TITLE
fix(test): rebuild CBOR libecho in cpp e2e to avoid ABI mismatch

### DIFF
--- a/ffi.nimble
+++ b/ffi.nimble
@@ -88,10 +88,11 @@ proc removeStaleEchoLib() =
   ## The CBOR and `abi = c` echo e2e suites both compile examples/echo/echo.nim
   ## to the same repo-root `libecho.so`, differing only by `-d:ffiEchoAbiC`.
   ## CMake keys the dylib rebuild on echo.nim's mtime, not the ABI flag, so a
-  ## `libecho.so` left by an earlier CBOR e2e step is silently reused by the
-  ## abi=c build — the flat-struct C caller then reaches the CBOR entry points
-  ## (wrong arity/ABI) and segfaults. Delete it first to force a fresh rebuild
-  ## with the right ABI.
+  ## `libecho.so` left by an earlier run is silently reused when the ABI flips —
+  ## in *either* direction. The caller then reaches entry points of the wrong
+  ## ABI (CBOR bytes decoded as a flat struct, or vice versa) and segfaults.
+  ## Every echo-building e2e task must delete it first to force a fresh rebuild
+  ## with the ABI its bindings expect.
   for name in ["libecho.so", "libecho.dylib", "echo.dll"]:
     let path = thisDir() / name
     if fileExists(path):
@@ -137,6 +138,9 @@ task test_cpp_e2e, "Build and run the C++ end-to-end tests for the timer example
   # Regenerate the C++ bindings so the suite always runs against fresh codegen.
   runOrQuit "nimble genbindings_cpp"
   runOrQuit "nimble genbindings_cpp_echo"
+  # Force a fresh CBOR libecho: a prior abi=c run leaves a same-named dylib that
+  # cmake would otherwise reuse, mismatching the CBOR bindings (segfault).
+  removeStaleEchoLib()
   runOrQuit "cmake -S tests/e2e/cpp -B tests/e2e/cpp/build"
   runOrQuit "cmake --build tests/e2e/cpp/build --config Debug"
   # `-C Debug` is required on Windows multi-config generators because
@@ -175,6 +179,9 @@ task test_cpp_e2e_sanitized,
   let san = getEnv("NIM_FFI_SAN", "none")
   runOrQuit "nimble genbindings_cpp"
   runOrQuit "nimble genbindings_cpp_echo"
+  # See test_cpp_e2e: force a fresh CBOR libecho so a prior abi=c dylib can't be
+  # reused against the CBOR bindings.
+  removeStaleEchoLib()
   runOrQuit "cmake -S tests/e2e/cpp -B tests/e2e/cpp/build" & " -DNIM_FFI_MM=" & mm &
     " -DNIM_FFI_SANITIZER=" & san
   runOrQuit "cmake --build tests/e2e/cpp/build --config Debug -j"


### PR DESCRIPTION
## Problem

`TimerE2E.CrossLibrary` (the only e2e that loads two nim-ffi dylibs in one process) **segfaults** when the C++ CBOR suite runs after the `abi=c` suite in the same workspace.

Backtrace: `libecho.dylib`echo_create → cwireUnpack → cstrToNimstr → strlen` on a garbage `char*` (the faulting address literally contains the ASCII bytes of "config").

## Root cause — build hygiene, not a runtime bug

The CBOR and `abi=c` echo suites compile `examples/echo/echo.nim` to the **same** `${REPO_ROOT}/libecho.dylib` (the name derives only from the lib name, not the ABI). CMake keys the rebuild on `echo.nim`'s mtime, which does **not** change when only the `-d:ffiEchoAbiC` flag flips. So flipping the ABI silently reuses the previously built dylib.

`removeStaleEchoLib()` guarded only the `abi=c` tasks. Running an `abi=c` suite first left the flat-struct dylib in place; the CBOR `CrossLibrary` test then reached `echo_create`'s `cwireUnpack`, decoded CBOR bytes as a flat struct, and crashed. (`removeStaleEchoLib`'s own comment described only the reverse direction.)

## Fix

Call `removeStaleEchoLib()` in the CBOR cpp e2e tasks too (`test_cpp_e2e`, `test_cpp_e2e_sanitized`), and update the helper's doc to note the hazard is bidirectional.

## Verification

Repro'd the exact bad sequence, then confirmed the fix:

```
nimble test_c_abi_e2e   # writes abi=c libecho.dylib
nimble test_cpp_e2e     # before: CrossLibrary SEGFAULT; after: 20/20 pass
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)