### PR TITLE
fix(codegen): propagate the destructor status code out of <lib>_ctx_destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project are documented in this file.
 ## [Unreleased]
 
 ### Changed
+- The generated C `<lib>_ctx_destroy()` now returns `int` instead of `void`,
+  propagating the exported `<lib>_destroy()` status code (`NIMFFI_RET_OK` on
+  success, `RET_ERR` on a null/invalid context or a failed context teardown)
+  instead of discarding it, so a host can observe a failed teardown. Existing
+  callers that invoke it as a statement are unaffected
+  ([#133](https://github.com/logos-messaging/nim-ffi/issues/133)).
+- A failed `<lib>_ctx_destroy()` no longer frees the event-listener boxes. A
+  non-`NIMFFI_RET_OK` teardown leaves the worker threads live, and they still
+  hold each box as callback `user_data`; the boxes are now leaked rather than
+  freed out from under a running event thread. The context struct and the
+  listener array are still freed unconditionally.
 - User event callbacks now run on a dedicated event thread fed by a
   bounded SPSC queue (default capacity 1024), so a slow listener can no
   longer block the FFI thread or concurrent `add_event_listener` /

--- a/examples/echo/c_abi_bindings/echo.h
+++ b/examples/echo/c_abi_bindings/echo.h
@@ -118,10 +118,12 @@ static inline int echo_ctx_create(const EchoConfig* config, EchoCreateFn on_crea
     return 0;
 }
 
-static inline void echo_ctx_destroy(EchoCtx* ctx) {
-    if (!ctx) return;
-    if (ctx->ptr) { echo_destroy(ctx->ptr); ctx->ptr = NULL; }
+static inline int echo_ctx_destroy(EchoCtx* ctx) {
+    if (!ctx) return NIMFFI_RET_OK;
+    int rc = NIMFFI_RET_OK;
+    if (ctx->ptr) { rc = echo_destroy(ctx->ptr); ctx->ptr = NULL; }
     free(ctx);
+    return rc;
 }
 
 static inline int echo_ctx_shout(const EchoCtx* ctx, const ShoutRequest* req, EchoShoutReplyFn on_reply, void* user_data) {

--- a/examples/echo/c_bindings/echo.h
+++ b/examples/echo/c_bindings/echo.h
@@ -289,10 +289,12 @@ static inline int echo_ctx_create(const EchoConfig* config, EchoCreateFn on_crea
     return 0;
 }
 
-static inline void echo_ctx_destroy(EchoCtx* ctx) {
-    if (!ctx) return;
-    if (ctx->ptr) { echo_destroy(ctx->ptr); ctx->ptr = NULL; }
+static inline int echo_ctx_destroy(EchoCtx* ctx) {
+    if (!ctx) return NIMFFI_RET_OK;
+    int rc = NIMFFI_RET_OK;
+    if (ctx->ptr) { rc = echo_destroy(ctx->ptr); ctx->ptr = NULL; }
     free(ctx);
+    return rc;
 }
 
 typedef void (*EchoShoutReplyFn)(int err_code, const ShoutResponse* reply, const char* err_msg, void* user_data);

--- a/examples/timer/c_bindings/my_timer.h
+++ b/examples/timer/c_bindings/my_timer.h
@@ -896,12 +896,16 @@ static inline int my_timer_ctx_create(const TimerConfig* config, MyTimerCreateFn
     return 0;
 }
 
-static inline void my_timer_ctx_destroy(MyTimerCtx* ctx) {
-    if (!ctx) return;
-    if (ctx->ptr) { my_timer_destroy(ctx->ptr); ctx->ptr = NULL; }
-    for (size_t i = 0; i < ctx->listeners_len; i++) free(ctx->listeners[i].box);
+static inline int my_timer_ctx_destroy(MyTimerCtx* ctx) {
+    if (!ctx) return NIMFFI_RET_OK;
+    int rc = NIMFFI_RET_OK;
+    if (ctx->ptr) { rc = my_timer_destroy(ctx->ptr); ctx->ptr = NULL; }
+    if (rc == NIMFFI_RET_OK) {
+        for (size_t i = 0; i < ctx->listeners_len; i++) free(ctx->listeners[i].box);
+    }
     free(ctx->listeners);
     free(ctx);
+    return rc;
 }
 
 static inline uint64_t my_timer_ctx_add_on_echo_fired_listener(MyTimerCtx* ctx, MyTimerOnEchoFiredFn fn, void* user_data) {

--- a/ffi/codegen/c.nim
+++ b/ffi/codegen/c.nim
@@ -528,16 +528,25 @@ proc emitDestructor(
     ctxType, libName, dtorProcName: string,
     events: seq[FFIEventMeta],
 ) =
-  lines.add("static inline void " & libName & "_ctx_destroy(" & ctxType & "* ctx) {")
-  lines.add("    if (!ctx) return;")
+  lines.add("static inline int " & libName & "_ctx_destroy(" & ctxType & "* ctx) {")
+  lines.add("    if (!ctx) return NIMFFI_RET_OK;")
+  lines.add("    int rc = NIMFFI_RET_OK;")
   if dtorProcName.len > 0:
-    lines.add("    if (ctx->ptr) { " & dtorProcName & "(ctx->ptr); ctx->ptr = NULL; }")
-  if events.len > 0:
     lines.add(
-      "    for (size_t i = 0; i < ctx->listeners_len; i++) free(ctx->listeners[i].box);"
+      "    if (ctx->ptr) { rc = " & dtorProcName & "(ctx->ptr); ctx->ptr = NULL; }"
     )
+  if events.len > 0:
+    # A failed teardown leaves the worker threads live (ffi_context.nim:
+    # stopAndJoinThreads), and they still hold each box as callback user_data.
+    # Leaking a box beats handing a running event thread a dangling pointer.
+    lines.add("    if (rc == NIMFFI_RET_OK) {")
+    lines.add(
+      "        for (size_t i = 0; i < ctx->listeners_len; i++) free(ctx->listeners[i].box);"
+    )
+    lines.add("    }")
     lines.add("    free(ctx->listeners);")
   lines.add("    free(ctx);")
+  lines.add("    return rc;")
   lines.add("}")
   lines.add("")
 
@@ -1194,15 +1203,6 @@ proc emitAbiCtxAndCtor(
     lines.add("}")
     lines.add("")
 
-proc emitAbiDestructor(lines: var seq[string], ctxType, libName, dtorProcName: string) =
-  lines.add("static inline void " & libName & "_ctx_destroy(" & ctxType & "* ctx) {")
-  lines.add("    if (!ctx) return;")
-  if dtorProcName.len > 0:
-    lines.add("    if (ctx->ptr) { " & dtorProcName & "(ctx->ptr); ctx->ptr = NULL; }")
-  lines.add("    free(ctx);")
-  lines.add("}")
-  lines.add("")
-
 proc emitAbiMethod(
     lines: var seq[string],
     reg: var AbiReg,
@@ -1400,7 +1400,8 @@ proc generateCAbiLibHeader*(
 
   lines.add("/* High-level context wrapper */")
   emitAbiCtxAndCtor(lines, reg, libName, libType, ctxType, classified.ctors)
-  emitAbiDestructor(lines, ctxType, libName, classified.dtorProcName)
+  # abi = c has no events, so the destructor is the CBOR one minus the listener sweep.
+  emitDestructor(lines, ctxType, libName, classified.dtorProcName, @[])
   for m in classified.methods:
     if m.scalarFastPath:
       emitAbiScalarMethod(lines, reg, ctxType, libName, libType, m)

--- a/tests/e2e/c/test_timer_e2e.c
+++ b/tests/e2e/c/test_timer_e2e.c
@@ -257,7 +257,7 @@ int main(void) {
     test_schedule_ok(ctx);
     test_schedule_error(ctx);
     test_event(ctx);
-    my_timer_ctx_destroy(ctx);
+    assert(my_timer_ctx_destroy(ctx) == NIMFFI_RET_OK);
     printf("all C e2e checks passed\n");
     return 0;
 }

--- a/tests/e2e/c_abi/test_echo_c_abi.c
+++ b/tests/e2e/c_abi/test_echo_c_abi.c
@@ -107,7 +107,7 @@ int main(void) {
     EchoCtx* ctx = make_ctx();
     test_shout(ctx);
     test_version(ctx);
-    echo_ctx_destroy(ctx);
+    assert(echo_ctx_destroy(ctx) == NIMFFI_RET_OK);
     printf("all abi=c echo e2e checks passed\n");
     return 0;
 }

--- a/tests/unit/test_c_abi_codegen.nim
+++ b/tests/unit/test_c_abi_codegen.nim
@@ -133,6 +133,19 @@ suite "generateCAbiLibHeader":
     check "timer_ctx_version(" in header
     check "timer_ctx_destroy(" in header
 
+  test "the context destructor propagates the destructor's status code":
+    check(
+      """
+static inline int timer_ctx_destroy(TimerCtx* ctx) {
+    if (!ctx) return NIMFFI_RET_OK;
+    int rc = NIMFFI_RET_OK;
+    if (ctx->ptr) { rc = timer_destroy(ctx->ptr); ctx->ptr = NULL; }
+    free(ctx);
+    return rc;
+}""" in
+        header
+    )
+
   test "scalar-fast-path methods take inline args, not a Req struct":
     check "TimerAddReq" notin header
     check "TimerNameReq" notin header

--- a/tests/unit/test_c_codegen.nim
+++ b/tests/unit/test_c_codegen.nim
@@ -124,6 +124,19 @@ suite "generateCLibHeader: ABI declarations and context API":
     check "timer_ctx_version(" in header
     check "timer_ctx_destroy(" in header
 
+  test "the context destructor propagates the destructor's status code":
+    check(
+      """
+static inline int timer_ctx_destroy(TimerCtx* ctx) {
+    if (!ctx) return NIMFFI_RET_OK;
+    int rc = NIMFFI_RET_OK;
+    if (ctx->ptr) { rc = timer_destroy(ctx->ptr); ctx->ptr = NULL; }
+    free(ctx);
+    return rc;
+}""" in
+        header
+    )
+
   test "the async API is callback-driven, not blocking":
     # methods take a typed reply callback + user_data; no out-param, no char** err
     check "typedef void (*TimerVersionReplyFn)(int err_code, const NimFfiStr* reply, const char* err_msg, void* user_data);" in
@@ -192,6 +205,25 @@ suite "generateCLibHeader: events":
   test "the context tracks listeners only when events exist":
     check "TimerCtxListener* listeners;" in header
 
+  test "a failed teardown leaks the listener boxes instead of dangling them":
+    # A non-OK rc leaves the worker threads live, still holding each box as
+    # callback user_data, so the sweep must sit behind the rc guard.
+    check(
+      """
+static inline int timer_ctx_destroy(TimerCtx* ctx) {
+    if (!ctx) return NIMFFI_RET_OK;
+    int rc = NIMFFI_RET_OK;
+    if (ctx->ptr) { rc = timer_destroy(ctx->ptr); ctx->ptr = NULL; }
+    if (rc == NIMFFI_RET_OK) {
+        for (size_t i = 0; i < ctx->listeners_len; i++) free(ctx->listeners[i].box);
+    }
+    free(ctx->listeners);
+    free(ctx);
+    return rc;
+}""" in
+        header
+    )
+
 suite "generateCLibHeader: no-event libraries stay lean":
   test "a library without events has no listener bookkeeping":
     let procs = @[
@@ -207,6 +239,29 @@ suite "generateCLibHeader: no-event libraries stay lean":
     let header = generateCLibHeader(procs, @[], "timer")
     check "listeners_len" notin header
     check "_add_event_listener" in header # raw ABI symbol is always declared
+
+  test "a library without a dtor still reports success from ctx_destroy":
+    let procs = @[
+      FFIProcMeta(
+        procName: "timer_create",
+        libName: "timer",
+        kind: FFIKind.CTOR,
+        libTypeName: "Timer",
+        extraParams: @[],
+        returnTypeName: "Timer",
+      )
+    ]
+    let header = generateCLibHeader(procs, @[], "timer")
+    check(
+      """
+static inline int timer_ctx_destroy(TimerCtx* ctx) {
+    if (!ctx) return NIMFFI_RET_OK;
+    int rc = NIMFFI_RET_OK;
+    free(ctx);
+    return rc;
+}""" in
+        header
+    )
 
 suite "generateCLibHeader: scalar-fast-path procs are excluded":
   setup:


### PR DESCRIPTION
## Summary

`<lib>_ctx_destroy()` was emitted as `static inline void` and called the exported destructor with its return value dropped, so a host had no way to observe a failed teardown. The exported `int <lib>_destroy(void* ctx)` returns meaningful codes — `NIMFFI_RET_OK` on success, `RET_ERR` on a null/invalid context or when `destroyFFIContext` fails — and the wrapper swallowed all of them. The host in logos-co/logos-libp2p-module#77 simply calls `libp2p_ctx_destroy(ctx)` and cannot tell teardown failed.

The wrapper now returns `int`, propagating that code. Existing callers that invoke it as a statement compile unchanged.

Note the status code belongs to the *generated* destructor wrapper, not to the user's `{.ffiDtor.}` proc — `ffi/internal/ffi_macro.nim:1345` rejects any `{.ffiDtor.}` that returns anything but nothing or `Future[void]`, so a dtor body cannot itself report failure.

## The part worth reviewing: what a failed teardown means

Issue #133 suggests freeing the C-side state unconditionally. Following that literally turns out to be unsafe, so this PR deviates in one specific way and it deserves a second opinion.

A non-zero rc means `destroyFFIContext` failed (`ffi/ffi_context_pool.nim:39`), which happens when `stopAndJoinThreads` fails — documented as *"On timeout, returns err and skips remaining joins (leaves threads live)"* (`ffi/ffi_context.nim:180`). The Nim side deliberately leaks in that case rather than closing resources under a live thread (`ffi_context_pool.nim:38`: *"On thread-exit timeout the slot is leaked; closing live-thread resources is unsafe"*).

The event-listener boxes are handed to Nim as callback `user_data` via `<lib>_add_event_listener(ctx->ptr, "...", tramp, box)`. So `rc != NIMFFI_RET_OK` means a still-running event thread still holds those exact pointers — and freeing them there is a use-after-free waiting for the next event.

So: the boxes are freed only when `rc == NIMFFI_RET_OK`, and leaked otherwise, matching the Nim side's own reasoning. The `ctx` struct and the `listeners` array are still freed unconditionally — the Nim side holds no pointer into either — so the issue's "teardown is unconditional" intent survives for everything it is safe to apply to.

## Affected Areas

- `ffi/codegen/c.nim` — the destructor emitter. The issue points at `c.nim#L558` and `c_abi.nim#L340`, but `c_abi.nim` no longer exists: #130 unified the backends. `emitAbiDestructor` was a byte-for-byte clone of `emitDestructor` minus the listener sweep, so it is deleted and the `abi = c` path now calls `emitDestructor(..., events = @[])`. One emitter, one place to fix the next bug. The regenerated `abi = c` and CBOR headers are unchanged by that dedupe, which is the proof it is output-preserving.
- Regenerated bindings: `examples/timer/c_bindings/my_timer.h` (events path), `examples/echo/c_bindings/echo.h`, `examples/echo/c_abi_bindings/echo.h`.
- Tests: both codegen suites assert the exact emitted destructor block; new coverage for the events path (the rc guard), for a dtor-less library, and both C e2e mains assert `ctx_destroy(ctx) == NIMFFI_RET_OK`.

The C++ backend emits no `ctx_destroy` wrapper; the Rust backend is untouched.

## Impact on Library Users

Source-compatible. `<lib>_ctx_destroy(ctx)` as a bare statement still compiles — `examples/timer/c_bindings/main.c` does exactly that. Callers that care can now check the code. Not ABI-compatible in principle, but the wrapper is `static inline` in a header, so it has no linkage and every caller recompiles against the new header by construction. The change adds a return value, not `warn_unused_result`, so `-Wunused-result` builds are unaffected.

Behavior change worth calling out in review: on a failed teardown the listener boxes now leak instead of being freed. That is a bounded, deliberate leak on a path that previously produced a dangling pointer.

## Risk Assessment

The rc plumbing itself is mechanical. The real judgement calls, both flagged for a reviewer:

1. **Leak-on-failure** (above). Deviates from the issue text; justified by the Nim side's own precedent. Say the word if you would rather match the issue literally.
2. **A `NULL` ctx returns `NIMFFI_RET_OK`**, treating "destroy nothing" as a successful no-op like `free(NULL)`. Note this differs from the raw `<lib>_destroy(NULL)`, which returns `RET_ERR`.

## Validation

- `nimble genbindings_c` / `genbindings_c_echo` / `genbindings_c_abi_echo` regenerated and committed, so `check_bindings_c` / `check_bindings_c_abi` are clean. `nim check` clean; `nph` idempotent.
- Full `nimble test` under `--mm:orc` and `--mm:refc`, plus `test_c_e2e` / `test_c_abi_e2e` and their ASan/UBSan/LSan variants, were green — but note that was against the first commit; the leak-on-failure and dedupe changes need a re-run.

**Known gap:** nothing exercises a non-zero rc at runtime. Every test asserts the success path, which is the path that already worked. Forcing a real failure needs a fault-injection seam — the plausible one is building an example with `-d:ffiThreadExitTimeoutMs=0` (`ffi/ffi_context.nim:176`) to make `stopAndJoinThreads` time out, which would need its own e2e target and CMake wiring. Worth doing before this leaves draft; the codegen tests currently pin the emitted shape only.

## References

Closes #133. Found while reviewing logos-co/logos-libp2p-module#77. Backend unification context: #130.