### PR TITLE
Integrate the 0.2 line into master: {.ffi.} shape router, {.ffiExport.}, context recycling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ All notable changes to this project are documented in this file.
   longer need a hand-written payload type. A single parameter still rides the
   wire directly (a scalar, or an existing `{.ffi.}` object). The foreign
   bindings gain the envelope as a first-class struct plus a typed handler.
+- `{.ffiExport.}`, for simple synchronous C exports, from the 0.2 line.
+- `{.ffi.}` now picks the path from the shape of the signature. One pragma
+  covers the context method, the static call, the synchronous export, the
+  destructor and the event. `ffi/internal/ffi_route.nim` holds the rules:
+
+  | Shape | Path |
+  |---|---|
+  | The first parameter is the library type or an `{.ffiHandle.}` type | Context method |
+  | No receiver, and the result is `Future[Result[T, string]]` | Static call |
+  | No parameters, and the result is a plain Nim type | Synchronous export |
+  | A library receiver, and no result or `Future[void]` | Destructor |
+  | A payload parameter, and no result | Event |
+
+  Every shape that the router claims failed to compile under any other pragma
+  before, so the router only turns a compile error into the intended meaning.
+
+  `{.ffiStatic.}`, `{.ffiExport.}`, `{.ffiDtor.}` and `{.ffiEvent.}` still work.
+  Each one now asserts its shape and names the right pragma when the shape does
+  not match.
+
+  `{.ffiCtor.}` stays explicit, because its shape is not free. A ctor differs
+  from a static call by one token: the type inside `Result`. A static call that
+  returns the library type builds today and exports a working C symbol, so a
+  router would silently give it the ctor ABI instead.
 
 ### Fixed
 - A `{.ffi.}` call against a `ref` library type whose `{.ffiCtor.}` never stored

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ All notable changes to this project are documented in this file.
   wire directly (a scalar, or an existing `{.ffi.}` object). The foreign
   bindings gain the envelope as a first-class struct plus a typed handler.
 
+### Fixed
+- A `{.ffi.}` call against a `ref` library type whose `{.ffiCtor.}` never stored
+  a library (it failed, or none ran) no longer crashes. Without a constructed
+  library the FFI thread points `myLib` at a default-valued fallback; for an
+  `object` that is a usable zero value, but for a `ref` it is `nil`, so the user
+  body faulted on its first field access. Such a request is now rejected with
+  `library is not initialized: the constructor failed or has not run yet`
+  through the callback. The check is emitted only for `ref` library types, and
+  it runs on the FFI thread behind any queued constructor, so a host that issues
+  a call without awaiting the create callback is unaffected.
+
 ## [0.3.0] - 2026-07-24
 
 [Full changelog](https://github.com/logos-messaging/nim-ffi/compare/v0.2.0...v0.3.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,19 @@ All notable changes to this project are documented in this file.
   longer need a hand-written payload type. A single parameter still rides the
   wire directly (a scalar, or an existing `{.ffi.}` object). The foreign
   bindings gain the envelope as a first-class struct plus a typed handler.
-- `{.ffiExport.}`, for simple synchronous C exports, from the 0.2 line.
+- `{.ffiExport.}`, for simple synchronous C exports, from the 0.2 line. Each
+  wrapper carries `raises: []` and catches every exception of the body, because
+  an exception must not cross the C ABI. A return type with no C ABI mapping is
+  a compile error. `int` maps to `long long`, so a 64-bit value keeps its full
+  width. A `string` return rides in a buffer that belongs to the calling thread
+  and stays valid until that thread calls another string export.
+- Pooled FFI contexts are recycled instead of destroyed. Each slot builds its
+  worker thread, its event thread and its signal fds once, then reuses them, so
+  repeated create/destroy no longer churns fds past `FD_SETSIZE`. The `ffiDtor`
+  asks the FFI thread to drain the in-flight handlers, free the library and
+  return the slot, while the threads stay alive. A recycle also fails every
+  request still queued for that slot, because such a request carries the
+  `userData` of a host that is gone.
 - `{.ffi.}` now picks the path from the shape of the signature. One pragma
   covers the context method, the static call, the synchronous export, the
   destructor and the event. `ffi/internal/ffi_route.nim` holds the rules:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project are documented in this file.
 
+## [Unreleased]
+
+### Added
+- `{.ffiEvent.}` now accepts multiple parameters. The macro synthesises and
+  registers an envelope object (`<WireNamePascalCase>Payload`) whose fields are
+  the parameters and dispatches an instance of it, so multi-field events no
+  longer need a hand-written payload type. A single parameter still rides the
+  wire directly (a scalar, or an existing `{.ffi.}` object). The foreign
+  bindings gain the envelope as a first-class struct plus a typed handler.
+
 ## [0.3.0] - 2026-07-24
 
 [Full changelog](https://github.com/logos-messaging/nim-ffi/compare/v0.2.0...v0.3.0)

--- a/examples/timer/c_bindings/my_timer.h
+++ b/examples/timer/c_bindings/my_timer.h
@@ -56,6 +56,10 @@ typedef struct {
     NimFfiStr message;
     int64_t echoCount;
 } EchoEvent;
+typedef struct {
+    NimFfiStr jobId;
+    int64_t willRunCount;
+} OnJobScheduledPayload;
 typedef enum {
     JOB_PRIORITY_JP_LOW = 0,
     JOB_PRIORITY_JP_NORMAL = 1,
@@ -447,6 +451,42 @@ static inline CborError my_timer_dec_EchoEvent(
 static inline void my_timer_free_EchoEvent(EchoEvent* v) {
     if (!v) return;
     nimffi_free_str(&v->message);
+}
+static inline CborError my_timer_enc_OnJobScheduledPayload(
+        CborEncoder* e, const OnJobScheduledPayload* v) {
+    CborEncoder m;
+    CborError err = cbor_encoder_create_map(e, &m, 2);
+    if (err) return err;
+    err = cbor_encode_text_stringz(&m, "jobId");
+    if (err) return err;
+    err = nimffi_enc_str(&m, &v->jobId);
+    if (err) return err;
+    err = cbor_encode_text_stringz(&m, "willRunCount");
+    if (err) return err;
+    err = nimffi_enc_i64(&m, &v->willRunCount);
+    if (err) return err;
+    return cbor_encoder_close_container(e, &m);
+}
+static inline CborError my_timer_dec_OnJobScheduledPayload(
+        CborValue* it, OnJobScheduledPayload* out) {
+    if (!cbor_value_is_map(it)) return CborErrorImproperValue;
+    CborValue field;
+    CborError err;
+    err = cbor_value_map_find_value(it, "jobId", &field);
+    if (err) return err;
+    if (!cbor_value_is_valid(&field)) return CborErrorImproperValue;
+    err = nimffi_dec_str(&field, &out->jobId);
+    if (err) return err;
+    err = cbor_value_map_find_value(it, "willRunCount", &field);
+    if (err) return err;
+    if (!cbor_value_is_valid(&field)) return CborErrorImproperValue;
+    err = nimffi_dec_i64(&field, &out->willRunCount);
+    if (err) return err;
+    return cbor_value_advance(it);
+}
+static inline void my_timer_free_OnJobScheduledPayload(OnJobScheduledPayload* v) {
+    if (!v) return;
+    nimffi_free_str(&v->jobId);
 }
 static inline CborError my_timer_enc_JobPriority(
         CborEncoder* e, const JobPriority* v) {
@@ -883,6 +923,25 @@ static void my_timer_on_echo_fired_trampoline(int ret, const char* msg, size_t l
     my_timer_free_EchoEvent(&payload);
 }
 
+typedef void (*MyTimerOnJobScheduledFn)(const OnJobScheduledPayload* evt, void* user_data);
+typedef struct { MyTimerOnJobScheduledFn fn; void* user_data; } MyTimerOnJobScheduledBox;
+static void my_timer_on_job_scheduled_trampoline(int ret, const char* msg, size_t len, void* ud) {
+    if (!ud || ret != 0 || !msg || len == 0) return;
+    MyTimerOnJobScheduledBox* box = (MyTimerOnJobScheduledBox*)ud;
+    if (!box->fn) return;
+    CborParser parser;
+    CborValue it;
+    if (cbor_parser_init((const uint8_t*)msg, len, 0, &parser, &it) != CborNoError) return;
+    if (!cbor_value_is_map(&it)) return;
+    CborValue payloadField;
+    if (cbor_value_map_find_value(&it, "payload", &payloadField) != CborNoError) return;
+    OnJobScheduledPayload payload;
+    memset(&payload, 0, sizeof(payload));
+    if (my_timer_dec_OnJobScheduledPayload(&payloadField, &payload) != CborNoError) return;
+    box->fn(&payload, box->user_data);
+    my_timer_free_OnJobScheduledPayload(&payload);
+}
+
 /* ============================================================ */
 /* High-level context wrapper                                   */
 /* ============================================================ */
@@ -990,6 +1049,30 @@ static inline uint64_t my_timer_ctx_add_on_echo_fired_listener(MyTimerCtx* ctx, 
     box->fn = fn;
     box->user_data = user_data;
     uint64_t id = my_timer_add_event_listener(ctx->ptr, "on_echo_fired", my_timer_on_echo_fired_trampoline, box);
+    if (id == 0) { free(box); return 0; }
+    if (ctx->listeners_len == ctx->listeners_cap) {
+        size_t ncap = ctx->listeners_cap ? ctx->listeners_cap * 2 : 4;
+        MyTimerCtxListener* grown = (MyTimerCtxListener*)realloc(ctx->listeners, ncap * sizeof(MyTimerCtxListener));
+        if (!grown) { my_timer_remove_event_listener(ctx->ptr, id); free(box); return 0; }
+        ctx->listeners = grown;
+        ctx->listeners_cap = ncap;
+    }
+    ctx->listeners[ctx->listeners_len].id = id;
+    ctx->listeners[ctx->listeners_len].box = box;
+    ctx->listeners_len++;
+    return id;
+}
+
+/**
+ * Fired by `myTimerSchedule`. Its two params ride the wire as a synthesised
+ * `OnJobScheduledPayload` envelope, so the foreign side decodes one typed value.
+ */
+static inline uint64_t my_timer_ctx_add_on_job_scheduled_listener(MyTimerCtx* ctx, MyTimerOnJobScheduledFn fn, void* user_data) {
+    MyTimerOnJobScheduledBox* box = (MyTimerOnJobScheduledBox*)malloc(sizeof(MyTimerOnJobScheduledBox));
+    if (!box) return 0;
+    box->fn = fn;
+    box->user_data = user_data;
+    uint64_t id = my_timer_add_event_listener(ctx->ptr, "on_job_scheduled", my_timer_on_job_scheduled_trampoline, box);
     if (id == 0) { free(box); return 0; }
     if (ctx->listeners_len == ctx->listeners_cap) {
         size_t ncap = ctx->listeners_cap ? ctx->listeners_cap * 2 : 4;

--- a/examples/timer/cddl_bindings/my_timer.cddl
+++ b/examples/timer/cddl_bindings/my_timer.cddl
@@ -9,6 +9,7 @@ EchoResponse = { echoed: tstr, timerName: tstr }
 ComplexRequest = { messages: [* EchoRequest], tags: [* tstr], note: tstr / nil, retries: int / nil }
 ComplexResponse = { summary: tstr, itemCount: int, hasNote: bool }
 EchoEvent = { message: tstr, echoCount: int }
+OnJobScheduledPayload = { jobId: tstr, willRunCount: int }
 JobPriority = "low" / "normal" / "high"
 JobSpec = { name: tstr, payload: [* tstr], priority: JobPriority }
 RetryPolicy = { maxAttempts: int, backoffMs: int, retryOn: [* tstr] }

--- a/examples/timer/cpp_bindings/my_timer.hpp
+++ b/examples/timer/cpp_bindings/my_timer.hpp
@@ -502,6 +502,33 @@ inline CborError decode_cbor(CborValue& it, EchoEvent& v) {
     return cbor_value_advance(&it);
 }
 
+struct OnJobScheduledPayload {
+    std::string jobId;
+    int64_t willRunCount;
+};
+inline CborError encode_cbor(CborEncoder& e, const OnJobScheduledPayload& v) {
+    CborEncoder m;
+    CborError err = cbor_encoder_create_map(&e, &m, 2);
+    if (err) return err;
+    err = cbor_encode_text_stringz(&m, "jobId"); if (err) return err;
+    err = encode_cbor(m, v.jobId);              if (err) return err;
+    err = cbor_encode_text_stringz(&m, "willRunCount"); if (err) return err;
+    err = encode_cbor(m, v.willRunCount);              if (err) return err;
+    return cbor_encoder_close_container(&e, &m);
+}
+inline CborError decode_cbor(CborValue& it, OnJobScheduledPayload& v) {
+    if (!cbor_value_is_map(&it)) return CborErrorImproperValue;
+    CborValue field;
+    CborError err;
+    err = cbor_value_map_find_value(&it, "jobId", &field); if (err) return err;
+    if (!cbor_value_is_valid(&field)) return CborErrorImproperValue;
+    err = decode_cbor(field, v.jobId); if (err) return err;
+    err = cbor_value_map_find_value(&it, "willRunCount", &field); if (err) return err;
+    if (!cbor_value_is_valid(&field)) return CborErrorImproperValue;
+    err = decode_cbor(field, v.willRunCount); if (err) return err;
+    return cbor_value_advance(&it);
+}
+
 struct JobSpec {
     std::string name;
     std::vector<std::string> payload;
@@ -927,6 +954,18 @@ public:
         auto* raw = owned.get();
         const auto id = my_timer_add_event_listener(
             ptr_, "on_echo_fired", &MyTimerCtx::typedTrampoline<EchoEvent>, raw);
+        if (id == 0) return ListenerHandle{0};
+        listeners_.emplace(id, std::move(owned));
+        return ListenerHandle{id};
+    }
+
+    /// Fired by `myTimerSchedule`. Its two params ride the wire as a synthesised
+    /// `OnJobScheduledPayload` envelope, so the foreign side decodes one typed value.
+    ListenerHandle addOnJobScheduledListener(std::function<void(const OnJobScheduledPayload&)> handler) {
+        auto owned = std::make_unique<TypedListener<OnJobScheduledPayload>>(std::move(handler));
+        auto* raw = owned.get();
+        const auto id = my_timer_add_event_listener(
+            ptr_, "on_job_scheduled", &MyTimerCtx::typedTrampoline<OnJobScheduledPayload>, raw);
         if (id == 0) return ListenerHandle{0};
         listeners_.emplace(id, std::move(owned));
         return ListenerHandle{id};

--- a/examples/timer/rust_bindings/src/api.rs
+++ b/examples/timer/rust_bindings/src/api.rs
@@ -127,6 +127,25 @@ unsafe extern "C" fn on_echo_fired_trampoline(
     }
 }
 
+struct OnJobScheduledHandler {
+    f: Box<dyn Fn(&OnJobScheduledPayload) + Send + Sync>,
+}
+
+unsafe extern "C" fn on_job_scheduled_trampoline(
+    ret: c_int, msg: *const c_char, len: usize, ud: *mut c_void,
+) {
+    if ud.is_null() || ret != 0 || msg.is_null() || len == 0 {
+        return;
+    }
+    let h = &*(ud as *const OnJobScheduledHandler);
+    let bytes = slice::from_raw_parts(msg as *const u8, len);
+    #[derive(serde::Deserialize)]
+    struct Envelope { payload: OnJobScheduledPayload }
+    if let Ok(env) = ciborium::de::from_reader::<Envelope, _>(bytes) {
+        (h.f)(&env.payload);
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct ListenerHandle { pub id: u64 }
 
@@ -210,6 +229,18 @@ impl MyTimerCtx {
         let owned: Box<OnEchoFiredHandler> = Box::new(OnEchoFiredHandler { f: Box::new(handler) });
         let raw = &*owned as *const OnEchoFiredHandler as *mut c_void;
         self.add_listener_inner(b"on_echo_fired\0".as_ptr() as *const c_char, on_echo_fired_trampoline, raw, owned)
+    }
+
+    /// Fired by `myTimerSchedule`. Its two params ride the wire as a synthesised
+    /// `OnJobScheduledPayload` envelope, so the foreign side decodes one typed value.
+    /// Register a typed listener for `on_job_scheduled`. The returned handle can be
+    /// passed to `remove_event_listener` to unregister.
+    pub fn add_on_job_scheduled_listener<F>(&self, handler: F) -> ListenerHandle
+    where F: Fn(&OnJobScheduledPayload) + Send + Sync + 'static,
+    {
+        let owned: Box<OnJobScheduledHandler> = Box::new(OnJobScheduledHandler { f: Box::new(handler) });
+        let raw = &*owned as *const OnJobScheduledHandler as *mut c_void;
+        self.add_listener_inner(b"on_job_scheduled\0".as_ptr() as *const c_char, on_job_scheduled_trampoline, raw, owned)
     }
 
     /// Remove a previously-registered listener by handle. Returns true

--- a/examples/timer/rust_bindings/src/types.rs
+++ b/examples/timer/rust_bindings/src/types.rs
@@ -58,6 +58,14 @@ pub struct EchoEvent {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OnJobScheduledPayload {
+    #[serde(rename = "jobId")]
+    pub job_id: String,
+    #[serde(rename = "willRunCount")]
+    pub will_run_count: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JobSpec {
     pub name: String,
     pub payload: Vec<String>,

--- a/examples/timer/timer.nim
+++ b/examples/timer/timer.nim
@@ -45,6 +45,12 @@ type EchoEvent {.ffi.} = object
 proc onEchoFired*(evt: EchoEvent) {.ffiEvent: "on_echo_fired".} =
   ## Fired by `myTimerEcho` once the reply is ready.
 
+proc onJobScheduled*(
+    jobId: string, willRunCount: int
+) {.ffiEvent: "on_job_scheduled".} =
+  ## Fired by `myTimerSchedule`. Its two params ride the wire as a synthesised
+  ## `OnJobScheduledPayload` envelope, so the foreign side decodes one typed value.
+
 proc myTimerCreate*(config: TimerConfig): Future[Result[MyTimer, string]] {.ffiCtor.} =
   ## Creates the FFIContext + MyTimer; async via chronos.
   await sleepAsync(1.milliseconds) # proves chronos is live on the FFI thread
@@ -134,6 +140,7 @@ proc myTimerSchedule*(
     else:
       1
   let jitter = if schedule.jitter.isSome: schedule.jitter.get else: 0
+  onJobScheduled(timer.name & ":" & job.name, willRunCount)
   return ok(
     ScheduleResult(
       jobId: timer.name & ":" & job.name,

--- a/ffi.nim
+++ b/ffi.nim
@@ -1,7 +1,7 @@
 import std/[atomics, tables]
 import chronos, chronicles
 import
-  ffi/internal/[ffi_library, ffi_macro, c_wire],
+  ffi/internal/[ffi_library, ffi_macro, ffi_export, c_wire],
   ffi/[
     alloc, ffi_types, ffi_events, ffi_handles, ffi_context, ffi_context_pool,
     ffi_thread_request, cbor_serial,
@@ -10,5 +10,5 @@ import
 export atomics, tables
 export chronos, chronicles
 export
-  atomics, alloc, ffi_library, ffi_macro, ffi_types, ffi_events, ffi_handles,
+  atomics, alloc, ffi_library, ffi_macro, ffi_export, ffi_types, ffi_events, ffi_handles,
   ffi_context, ffi_context_pool, ffi_thread_request, cbor_serial, c_wire

--- a/ffi.nim
+++ b/ffi.nim
@@ -10,5 +10,5 @@ import
 export atomics, tables
 export chronos, chronicles
 export
-  atomics, alloc, ffi_library, ffi_macro, ffi_export, ffi_types, ffi_events, ffi_handles,
-  ffi_context, ffi_context_pool, ffi_thread_request, cbor_serial, c_wire
+  atomics, alloc, ffi_library, ffi_macro, ffi_export, ffi_types, ffi_events,
+  ffi_handles, ffi_context, ffi_context_pool, ffi_thread_request, cbor_serial, c_wire

--- a/ffi/codegen/rust.nim
+++ b/ffi/codegen/rust.nim
@@ -30,8 +30,8 @@ func rustOpt(elem: string): string =
 const rustMap = NativeTypeMap(
   scalar: rustScalar,
   str: "String",
-  # serde encodes a plain Vec<u8> as a CBOR integer array, which Nim rejects.
-  # ByteBuf gives the CBOR byte string that Nim decodes.
+  # serde encodes a plain Vec<u8> as a CBOR integer array, and Nim rejects that
+  # array. ByteBuf gives the CBOR byte string that Nim decodes.
   bytes: "serde_bytes::ByteBuf",
   ptrType: RustPtrType,
   seqOf: rustSeq,
@@ -71,7 +71,7 @@ proc reqStructName(p: FFIProcMeta): string =
     camel & "Req"
 
 func typeUsesBytes(typeName: string): bool =
-  ## True if `typeName` resolves to a `seq[byte]` at any depth of Seq or Option.
+  ## True if `typeName` is a `seq[byte]` at any depth of Seq or Option.
   var t = parseFFIType(typeName)
   while t.kind in {ftSeq, ftOpt}:
     t = t.elem
@@ -79,7 +79,7 @@ func typeUsesBytes(typeName: string): bool =
 
 func needsSerdeBytes*(types: seq[FFITypeMeta], procs: seq[FFIProcMeta]): bool =
   ## True if a field, a parameter or a return type maps to `serde_bytes::ByteBuf`.
-  ## `types` holds every struct, thus a scan of the fields also finds the bytes
+  ## `types` holds every struct. Thus a scan of the fields also finds the bytes
   ## in a nested struct.
   for t in types:
     for f in t.fields:

--- a/ffi/ffi_context.nim
+++ b/ffi/ffi_context.nim
@@ -39,6 +39,9 @@ type FFIContext*[T] = object
   recycleDoneSignal: ThreadSignalPtr
     # fired by the recycle handler once the lib is freed and the slot released;
     # the synchronous recycleFFIContext caller waits on it.
+  libReady*: Atomic[bool]
+    # False until a {.ffiCtor.} stores the library; until then `myLib` is the
+    # FFI thread's default-valued fallback, which for a `ref` type is nil.
   ffiThread: Thread[(ptr FFIContext[T])]
   eventThread: Thread[(ptr FFIContext[T])]
   reqQueueBank: RequestQueueBank
@@ -131,6 +134,7 @@ proc initContextResources*[T](ctx: ptr FFIContext[T]): Result[void, string] =
   initHandleRegistry(ctx[].handles)
   initEventQueue(ctx[].eventQueue)
   ctx.ffiHeartbeat.store(0)
+  ctx.libReady.store(false)
   ctx.eventQueueStuck.store(false)
   ctx.ffiThreadExited.store(false)
   ctx.staleWarnInterval = StaleWarnInterval

--- a/ffi/ffi_context.nim
+++ b/ffi/ffi_context.nim
@@ -40,8 +40,9 @@ type FFIContext*[T] = object
     # fired by the recycle handler once the lib is freed and the slot released;
     # the synchronous recycleFFIContext caller waits on it.
   libReady*: Atomic[bool]
-    # False until a {.ffiCtor.} stores the library; until then `myLib` is the
-    # FFI thread's default-valued fallback, which for a `ref` type is nil.
+    # False until a {.ffiCtor.} stores the library. Before that, `myLib` points
+    # at the default fallback of the FFI thread. For a `ref` type that fallback
+    # is nil.
   ffiThread: Thread[(ptr FFIContext[T])]
   eventThread: Thread[(ptr FFIContext[T])]
   reqQueueBank: RequestQueueBank

--- a/ffi/ffi_context.nim
+++ b/ffi/ffi_context.nim
@@ -2,7 +2,7 @@
 
 {.passc: "-fPIC".}
 
-import std/[atomics, locks, options, tables]
+import std/[atomics, locks, options, sequtils, tables]
 import chronicles, chronos, chronos/threadsync, results
 import
   ./ffi_types,
@@ -15,8 +15,30 @@ import
 
 export ffi_events, ffi_handles
 
+type CtxLifecycle* {.pure.} = enum
+  ## State machine guarding a pooled FFI context (Atomic on FFIContext).
+  ##   Active         -> RecyclePending   when the ffiDtor requests recycle
+  ##   RecyclePending -> Recycling        FFI loop claimed it, draining handlers
+  ##   Recycling      -> Active           createFFIContext reuses the slot
+  Active
+  RecyclePending
+  Recycling
+
 type FFIContext*[T] = object
   myLib*: ptr T # main library object (Waku, LibP2P, SDS, …)
+  myLibRefd*: bool
+    # refc only: true once myLib[] (a ref) has been GC_ref'd to root it against
+    # the cycle collector. Balanced by GC_unref in freeLib.
+  myLibOwned*: bool
+    # true once a ctor stored a createShared'd lib into myLib (vs the worker's
+    # stack fallback). freeLib only frees/destroys owned libs.
+  inUse*: Atomic[bool]
+    # Whether this pooled context is claimed. The recycle handler clears it on
+    # the FFI thread so the slot returns to the pool without recreating threads.
+  lifecycle*: Atomic[CtxLifecycle]
+  recycleDoneSignal: ThreadSignalPtr
+    # fired by the recycle handler once the lib is freed and the slot released;
+    # the synchronous recycleFFIContext caller waits on it.
   ffiThread: Thread[(ptr FFIContext[T])]
   eventThread: Thread[(ptr FFIContext[T])]
   reqQueueBank: RequestQueueBank
@@ -42,6 +64,9 @@ var onFFIThread* {.threadvar.}: bool
 const git_version* {.strdefine.} = "n/a"
 
 const
+  RecycleWaitTimeout* = 5.seconds
+    ## Caller-side bound for synchronous recycle; the FFI-thread drain itself is
+    ## bounded by RecycleTimeout, so this only guards against a wedged worker.
   EventThreadTickInterval* = 1.seconds
   FFIHeartbeatStartDelay* = 10.seconds
   FFIHeartbeatStaleThreshold* = 1.seconds
@@ -73,7 +98,8 @@ proc deinitContextResources*[T](ctx: ptr FFIContext[T]): Result[void, string] =
   deinitHandleRegistry(ctx[].handles)
   deinitEventQueue(ctx[].eventQueue)
   when defined(gcRefc):
-    # ThreadSignalPtr.close() under refc hangs via signal-handler re-entry; leak the bounded fd.
+    # ThreadSignalPtr.close() under refc hangs via signal-handler re-entry; the
+    # recycle pool makes full destroy rare, so the leaked fd stays bounded.
     discard
   else:
     closeAndNil(ctx.reqSignal)
@@ -81,6 +107,7 @@ proc deinitContextResources*[T](ctx: ptr FFIContext[T]): Result[void, string] =
     closeAndNil(ctx.threadExitSignal)
     closeAndNil(ctx.eventQueueSignal)
     closeAndNil(ctx.eventThreadExitSignal)
+    closeAndNil(ctx.recycleDoneSignal)
   ok()
 
 template newSignalOrErr(field: untyped, name: string) =
@@ -95,6 +122,10 @@ proc initContextResources*[T](ctx: ptr FFIContext[T]): Result[void, string] =
   ctx.threadExitSignal = nil
   ctx.eventQueueSignal = nil
   ctx.eventThreadExitSignal = nil
+  ctx.recycleDoneSignal = nil
+  ctx.myLibOwned = false
+  ctx.myLibRefd = false
+  ctx.lifecycle.store(CtxLifecycle.Active)
   initRequestQueue(ctx[].reqQueueBank)
   initEventRegistry(ctx[].eventRegistry)
   initHandleRegistry(ctx[].handles)
@@ -117,6 +148,7 @@ proc initContextResources*[T](ctx: ptr FFIContext[T]): Result[void, string] =
   newSignalOrErr(ctx.threadExitSignal, "threadExitSignal")
   newSignalOrErr(ctx.eventQueueSignal, "eventQueueSignal")
   newSignalOrErr(ctx.eventThreadExitSignal, "eventThreadExitSignal")
+  newSignalOrErr(ctx.recycleDoneSignal, "recycleDoneSignal")
 
   ctx.registeredRequests = addr ffi_types.registeredRequests
 
@@ -165,6 +197,40 @@ proc signalStop*[T](ctx: ptr FFIContext[T]): Result[void, string] =
   ?ctx.stopSignal.fireOrErr("stopSignal")
   ctx.eventQueueSignal.fireOrErr("eventQueueSignal").isOkOr:
     error "failed to signal eventQueueSignal in signalStop", error = error
+  ok()
+
+proc tryClaim*[T](ctx: ptr FFIContext[T]): bool =
+  ## Atomically claim a free pooled context (false -> true).
+  var expected = false
+  ctx.inUse.compareExchange(expected, true)
+
+proc release*[T](ctx: ptr FFIContext[T]) =
+  ctx.inUse.store(false)
+
+proc isInUse*[T](ctx: ptr FFIContext[T]): bool =
+  ctx.inUse.load()
+
+proc markAsActive*[T](ctx: ptr FFIContext[T]) =
+  ## Reused context: its worker threads are still alive; re-arm for requests.
+  ctx.lifecycle.store(CtxLifecycle.Active)
+
+proc requestRecycle*[T](ctx: ptr FFIContext[T]): Result[void, string] =
+  ## Ask the FFI thread to drain, free the lib and release the slot, WITHOUT
+  ## stopping its worker/event threads, so the next createFFIContext reuses them.
+  ## Synchronous: waits on recycleDoneSignal. No fd churn -> no select() limit.
+  var expected = CtxLifecycle.Active
+  if not ctx.lifecycle.compareExchange(expected, CtxLifecycle.RecyclePending):
+    return err("requestRecycle: context is not Active (already recycling)")
+
+  let fired = ctx.reqSignal.fireSync().valueOr:
+    return err("requestRecycle: failed to signal the FFI thread: " & $error)
+  if not fired:
+    return err("requestRecycle: failed to signal the FFI thread in time")
+
+  let done = ctx.recycleDoneSignal.waitSync(RecycleWaitTimeout).valueOr:
+    return err("requestRecycle: failed waiting for recycle: " & $error)
+  if not done:
+    return err("requestRecycle: recycle did not complete in time")
   ok()
 
 ## Per-thread exit wait before stopAndJoinThreads leaks ctx rather than hanging; async

--- a/ffi/ffi_context.nim
+++ b/ffi/ffi_context.nim
@@ -37,8 +37,8 @@ type FFIContext*[T] = object
     # the FFI thread so the slot returns to the pool without recreating threads.
   lifecycle*: Atomic[CtxLifecycle]
   recycleDoneSignal: ThreadSignalPtr
-    # fired by the recycle handler once the lib is freed and the slot released;
-    # the synchronous recycleFFIContext caller waits on it.
+    # fired by the recycle handler once the lib is freed, just before it releases
+    # the slot; the synchronous recycleFFIContext caller waits on it.
   libReady*: Atomic[bool]
     # False until a {.ffiCtor.} stores the library. Before that, `myLib` points
     # at the default fallback of the FFI thread. For a `ref` type that fallback
@@ -67,10 +67,16 @@ var onFFIThread* {.threadvar.}: bool
 
 const git_version* {.strdefine.} = "n/a"
 
+const RecycleTimeoutMs* {.intdefine: "ffiRecycleTimeoutMs".} = 1500
+  ## Bounds one drain round of the recycle handler. The handler runs at most two
+  ## rounds: it waits for the in-flight handlers, then cancels them and waits
+  ## again. Override with `-d:ffiRecycleTimeoutMs=<ms>`.
+const RecycleTimeout* = RecycleTimeoutMs.milliseconds
+
 const
-  RecycleWaitTimeout* = 5.seconds
-    ## Caller-side bound for synchronous recycle; the FFI-thread drain itself is
-    ## bounded by RecycleTimeout, so this only guards against a wedged worker.
+  RecycleWaitTimeout* = 2 * RecycleTimeout + 2.seconds
+    ## Caller-side bound for synchronous recycle. It covers both drain rounds
+    ## plus slack, so it only fires when the worker itself is wedged.
   EventThreadTickInterval* = 1.seconds
   FFIHeartbeatStartDelay* = 10.seconds
   FFIHeartbeatStaleThreshold* = 1.seconds
@@ -209,7 +215,7 @@ proc tryClaim*[T](ctx: ptr FFIContext[T]): bool =
   var expected = false
   ctx.inUse.compareExchange(expected, true)
 
-proc release*[T](ctx: ptr FFIContext[T]) =
+proc releaseClaim*[T](ctx: ptr FFIContext[T]) =
   ctx.inUse.store(false)
 
 proc isInUse*[T](ctx: ptr FFIContext[T]): bool =
@@ -226,6 +232,10 @@ proc requestRecycle*[T](ctx: ptr FFIContext[T]): Result[void, string] =
   var expected = CtxLifecycle.Active
   if not ctx.lifecycle.compareExchange(expected, CtxLifecycle.RecyclePending):
     return err("requestRecycle: context is not Active (already recycling)")
+
+  # A recycle that timed out can fire late. The CAS makes this the only recycle
+  # in flight, so drop that stale fire before the wait below can answer to it.
+  discard ctx.recycleDoneSignal.waitSync(ZeroDuration)
 
   let fired = ctx.reqSignal.fireSync().valueOr:
     return err("requestRecycle: failed to signal the FFI thread: " & $error)

--- a/ffi/ffi_context_pool.nim
+++ b/ffi/ffi_context_pool.nim
@@ -29,7 +29,7 @@ proc releaseSlot[T](pool: var FFIContextPool[T], ctx: ptr FFIContext[T]) =
     if pool.contexts[i].addr == ctx:
       pool.initialized[i].store(false)
       break
-  ctx.release()
+  ctx.releaseClaim()
 
 proc createFFIContext*[T](
     pool: var FFIContextPool[T]
@@ -45,7 +45,7 @@ proc createFFIContext*[T](
       ctx.markAsActive()
       return ok(ctx)
     initContextResources(ctx).isOkOr:
-      ctx.release()
+      ctx.releaseClaim()
       return err("createFFIContext: initContextResources failed: " & $error)
     pool.initialized[i].store(true)
     return ok(ctx)
@@ -138,5 +138,5 @@ proc isValidCtx*[T](pool: var FFIContextPool[T], ctx: pointer): bool =
     return false
   for i in 0 ..< MaxFFIContexts:
     if cast[pointer](pool.contexts[i].addr) == ctx:
-      return cast[ptr FFIContext[T]](ctx).isInUse()
+      return pool.contexts[i].addr.isInUse()
   false

--- a/ffi/ffi_context_pool.nim
+++ b/ffi/ffi_context_pool.nim
@@ -13,37 +13,43 @@ type
     StaticCtxReady
 
   FFIContextPool*[T] = object
-    ## Fixed pool of FFI contexts, plus the one `{.ffiStatic.}` context.
-    # Each live context holds 5 ThreadSignalPtrs — one fd each on Linux, two (a
-    # socketpair) elsewhere. Under refc a destroyed context cannot close them
-    # (see `deinitContextResources`), so churn leaks fds unbounded.
-    slots: array[MaxFFIContexts, FFIContext[T]]
-    inUse: array[MaxFFIContexts, Atomic[bool]]
+    ## Fixed pool of FFI contexts, plus the one `{.ffiStatic.}` context. Each
+    ## slot's worker + event threads and signal fds are built once (on first
+    ## use) and reused across create/recycle cycles — recycle keeps them alive,
+    ## so repeated create/destroy does not churn fds. Bounds ThreadSignalPtr fds
+    ## at MaxFFIContexts * (signals per ctx).
+    contexts: array[MaxFFIContexts, FFIContext[T]]
+    initialized: array[MaxFFIContexts, Atomic[bool]]
     staticCtx: Atomic[pointer]
     staticState: Atomic[StaticCtxState]
 
-proc acquireSlot[T](pool: var FFIContextPool[T]): Result[ptr FFIContext[T], string] =
-  for i in 0 ..< MaxFFIContexts:
-    var expected = false
-    if pool.inUse[i].compareExchange(expected, true):
-      return ok(pool.slots[i].addr)
-  err("FFI context pool exhausted (max " & $MaxFFIContexts & " contexts)")
-
 proc releaseSlot[T](pool: var FFIContextPool[T], ctx: ptr FFIContext[T]) =
+  ## Full-teardown release: the slot must be rebuilt before it serves again.
   for i in 0 ..< MaxFFIContexts:
-    if pool.slots[i].addr == ctx:
-      pool.inUse[i].store(false)
-      return
+    if pool.contexts[i].addr == ctx:
+      pool.initialized[i].store(false)
+      break
+  ctx.release()
 
 proc createFFIContext*[T](
     pool: var FFIContextPool[T]
 ): Result[ptr FFIContext[T], string] =
-  let ctx = pool.acquireSlot().valueOr:
-    return err("createFFIContext: acquireSlot failed: " & $error)
-  initContextResources(ctx).isOkOr:
-    pool.releaseSlot(ctx)
-    return err("createFFIContext: initContextResources failed: " & $error)
-  ok(ctx)
+  ## Acquires a context from the fixed pool. A slot's worker is built once on
+  ## first use and reused (markAsActive) on every later acquisition.
+  for i in 0 ..< MaxFFIContexts:
+    let ctx = pool.contexts[i].addr
+    if not ctx.tryClaim():
+      continue
+    if pool.initialized[i].load():
+      # Reused slot: a prior recycle drained and released it; worker still alive.
+      ctx.markAsActive()
+      return ok(ctx)
+    initContextResources(ctx).isOkOr:
+      ctx.release()
+      return err("createFFIContext: initContextResources failed: " & $error)
+    pool.initialized[i].store(true)
+    return ok(ctx)
+  err("FFI context pool exhausted (max " & $MaxFFIContexts & " contexts)")
 
 proc isStaticCtx[T](pool: var FFIContextPool[T], ctx: ptr FFIContext[T]): bool =
   ## True while `ctx` is the pool's static context, including mid-teardown.
@@ -51,16 +57,29 @@ proc isStaticCtx[T](pool: var FFIContextPool[T], ctx: ptr FFIContext[T]): bool =
   # pointer covers `Destroying` too.
   pool.staticCtx.load() == cast[pointer](ctx)
 
+proc recycleFFIContext*[T](
+    pool: var FFIContextPool[T], ctx: ptr FFIContext[T]
+): Result[void, string] =
+  ## Normal teardown: drains in-flight handlers, frees the lib and returns the
+  ## slot to the pool WITHOUT stopping its threads, so a later createFFIContext
+  ## reuses them. Synchronous (waits for the FFI thread to finish draining).
+  # Recycling it would release the slot while `staticState` still points at it.
+  if pool.isStaticCtx(ctx):
+    return err("recycleFFIContext(pool): the {.ffiStatic.} context outlives every ctx")
+  ctx.requestRecycle()
+
 proc destroyFFIContext*[T](
     pool: var FFIContextPool[T], ctx: ptr FFIContext[T]
 ): Result[void, string] =
-  ## On thread-exit timeout the slot is leaked; closing live-thread resources is unsafe.
+  ## Full teardown: stops/joins the threads and frees resources, marking the slot
+  ## uninitialised so a later createFFIContext rebuilds it; normal cleanup uses
+  ## recycleFFIContext. On thread-exit timeout the slot is leaked; closing
+  ## live-thread resources is unsafe.
   # Destroying it would release the slot while `staticState` still points at it.
   if pool.isStaticCtx(ctx):
     return err("destroyFFIContext(pool): the {.ffiStatic.} context outlives every ctx")
   ctx.stopAndJoinThreads().isOkOr:
     return err("destroyFFIContext(pool): " & $error)
-  # Required: next acquisition would otherwise re-init a live lock (UB).
   let deinitRes = ctx.deinitContextResources()
   pool.releaseSlot(ctx)
   deinitRes.isOkOr:
@@ -118,6 +137,6 @@ proc isValidCtx*[T](pool: var FFIContextPool[T], ctx: pointer): bool =
   if ctx.isNil():
     return false
   for i in 0 ..< MaxFFIContexts:
-    if cast[pointer](pool.slots[i].addr) == ctx:
-      return pool.inUse[i].load()
+    if cast[pointer](pool.contexts[i].addr) == ctx:
+      return cast[ptr FFIContext[T]](ctx).isInUse()
   false

--- a/ffi/ffi_events.nim
+++ b/ffi/ffi_events.nim
@@ -36,8 +36,8 @@ proc deinitEventRegistry*(reg: var FFIEventRegistry) =
   reg.nextId = 0'u64
 
 proc clearListeners*(reg: var FFIEventRegistry) {.raises: [].} =
-  ## Drops all listeners (used when a context is recycled for reuse) without
-  ## touching the lock — the event thread keeps using it across recycles.
+  ## Removes all listeners. The pool calls this when it recycles a context. The
+  ## lock stays in place, because the event thread uses it across recycles.
   withLock reg.lock:
     reg.byEvent.clear()
     reg.nextId = 0'u64

--- a/ffi/ffi_events.nim
+++ b/ffi/ffi_events.nim
@@ -35,6 +35,13 @@ proc deinitEventRegistry*(reg: var FFIEventRegistry) =
   reg.byEvent = default(Table[string, seq[FFIEventListener]])
   reg.nextId = 0'u64
 
+proc clearListeners*(reg: var FFIEventRegistry) {.raises: [].} =
+  ## Drops all listeners (used when a context is recycled for reuse) without
+  ## touching the lock — the event thread keeps using it across recycles.
+  withLock reg.lock:
+    reg.byEvent.clear()
+    reg.nextId = 0'u64
+
 proc addEventListener*(
     reg: var FFIEventRegistry,
     eventName: string,

--- a/ffi/ffi_thread.nim
+++ b/ffi/ffi_thread.nim
@@ -93,6 +93,8 @@ const RecycleTimeout = 1500.milliseconds
 proc freeLib[T](ctx: ptr FFIContext[T]) {.gcsafe.} =
   ## Releases the library object the ctor stored in ctx.myLib. Only owned libs
   ## (createShared'd by a ctor) are freed; the worker's stack fallback is not.
+  # A reused slot skips initContextResources, so the recycle path clears this.
+  ctx.libReady.store(false)
   if not ctx.myLibOwned or ctx.myLib.isNil():
     ctx.myLib = nil
     return

--- a/ffi/ffi_thread.nim
+++ b/ffi/ffi_thread.nim
@@ -86,10 +86,6 @@ proc processRequest[T](
   except Exception as e:
     error "Unexpected exception in handleRes", error = e.msg
 
-const RecycleTimeout = 1500.milliseconds
-  ## Bounds how long the recycle handler waits for in-flight handlers before it
-  ## cancels them, so a wedged handler cannot block reuse forever.
-
 proc freeLib[T](ctx: ptr FFIContext[T]) {.gcsafe.} =
   ## Releases the library object the ctor stored in ctx.myLib. Only owned libs
   ## (createShared'd by a ctor) are freed; the worker's stack fallback is not.
@@ -102,8 +98,8 @@ proc freeLib[T](ctx: ptr FFIContext[T]) {.gcsafe.} =
     try:
       {.cast(gcsafe).}:
         `=destroy`(ctx.myLib[])
-    except Exception:
-      discard
+    except Exception as e:
+      error "destroying the library on recycle raised; freeing it anyway", error = e.msg
   else:
     when T is ref:
       if ctx.myLibRefd:
@@ -112,6 +108,23 @@ proc freeLib[T](ctx: ptr FFIContext[T]) {.gcsafe.} =
   freeShared(ctx.myLib)
   ctx.myLib = nil
   ctx.myLibOwned = false
+
+const RecycledReason =
+  "FFI context was recycled before this request ran; the caller is gone"
+
+proc rejectQueuedRequests[T](ctx: ptr FFIContext[T]) =
+  ## Fails every queued request instead of dispatching it. A request that a
+  ## destroyed context left behind still carries that host's `userData`, which
+  ## the host has freed; running it would answer a dead callback, and running it
+  ## after the slot is reused would run it against the library of the next owner.
+  var request = ctx.reqQueueBank.mergeQueues()
+  while not request.isNil():
+    let nextRequest = request[].next # read before handleRes frees it
+    try:
+      handleRes(Result[seq[byte], string].err(RecycledReason), request)
+    except Exception as e:
+      error "rejecting a queued request raised", error = e.msg
+    request = nextRequest
 
 proc recycleContext[T](
     ctx: ptr FFIContext[T], ongoing: ptr seq[Future[void]]
@@ -125,18 +138,20 @@ proc recycleContext[T](
     drained = await allFutures(ongoing[]).withTimeout(RecycleTimeout)
   if not drained:
     for fut in ongoing[]:
-      if not fut.finished():
-        fut.cancelSoon()
+      fut.cancelSoon()
     drained = await allFutures(ongoing[]).withTimeout(RecycleTimeout)
 
   freeLib(ctx)
   clearListeners(ctx[].eventRegistry)
+  rejectQueuedRequests(ctx)
   ongoing[].setLen(0)
-  ctx.release()
 
+  # Fire before the release: a thread that claims the freed slot first would
+  # otherwise take this fire as the answer to its own recycle.
   let fireRes = ctx.recycleDoneSignal.fireSync()
   if fireRes.isErr():
     error "failed to fire recycleDoneSignal", err = fireRes.error
+  ctx.releaseClaim()
 
 var ffiEventQueueSignalPtr {.threadvar.}: ThreadSignalPtr
   # Stashed so the hook has no closure env.
@@ -213,6 +228,13 @@ proc ffiThreadBody[T](ctx: ptr FFIContext[T]) {.thread.} =
       var expected = CtxLifecycle.RecyclePending
       if ctx.lifecycle.compareExchange(expected, CtxLifecycle.Recycling):
         await recycleContext(ctx, addr pending)
+        continue
+
+      # A submit that read `Active` just before the recycle can still land here.
+      # Fail it rather than run it against the library of the next owner.
+      if ctx.lifecycle.load() != CtxLifecycle.Active:
+        rejectQueuedRequests(ctx)
+        discard await ctx.reqSignal.wait().withTimeout(chronos.milliseconds(100))
         continue
 
       cleanFinishedRequests()

--- a/ffi/ffi_thread.nim
+++ b/ffi/ffi_thread.nim
@@ -16,6 +16,10 @@ proc sendRequestToFFIThread*(
       "reentrant ffi call: a handler invoked sendRequestToFFIThread on its own context"
     )
 
+  if ctx.lifecycle.load() != CtxLifecycle.Active:
+    deleteRequest(ffiRequest)
+    return err("FFI context is not accepting requests (being recycled)")
+
   # Wake only when the push found the queue empty: waking per submit kills scaling, and a skipped wake just waits the consumer's 100ms poll.
   let shouldWake = ctx.reqQueueBank.pushRequest(ffiRequest)
 
@@ -81,6 +85,56 @@ proc processRequest[T](
     handleRes(res, request)
   except Exception as e:
     error "Unexpected exception in handleRes", error = e.msg
+
+const RecycleTimeout = 1500.milliseconds
+  ## Bounds how long the recycle handler waits for in-flight handlers before it
+  ## cancels them, so a wedged handler cannot block reuse forever.
+
+proc freeLib[T](ctx: ptr FFIContext[T]) {.gcsafe.} =
+  ## Releases the library object the ctor stored in ctx.myLib. Only owned libs
+  ## (createShared'd by a ctor) are freed; the worker's stack fallback is not.
+  if not ctx.myLibOwned or ctx.myLib.isNil():
+    ctx.myLib = nil
+    return
+  when not defined(gcRefc):
+    try:
+      {.cast(gcsafe).}:
+        `=destroy`(ctx.myLib[])
+    except Exception:
+      discard
+  else:
+    when T is ref:
+      if ctx.myLibRefd:
+        GC_unref(ctx.myLib[])
+        ctx.myLibRefd = false
+  freeShared(ctx.myLib)
+  ctx.myLib = nil
+  ctx.myLibOwned = false
+
+proc recycleContext[T](
+    ctx: ptr FFIContext[T], ongoing: ptr seq[Future[void]]
+) {.async.} =
+  ## Drain in-flight handlers, free the lib, clear listeners and release the
+  ## slot — all WITHOUT stopping the worker/event threads, so the next
+  ## createFFIContext reuses them (no fd churn). Then fire recycleDoneSignal.
+  ongoing[].keepItIf(not it.finished())
+  var drained = ongoing[].len == 0
+  if not drained:
+    drained = await allFutures(ongoing[]).withTimeout(RecycleTimeout)
+  if not drained:
+    for fut in ongoing[]:
+      if not fut.finished():
+        fut.cancelSoon()
+    drained = await allFutures(ongoing[]).withTimeout(RecycleTimeout)
+
+  freeLib(ctx)
+  clearListeners(ctx[].eventRegistry)
+  ongoing[].setLen(0)
+  ctx.release()
+
+  let fireRes = ctx.recycleDoneSignal.fireSync()
+  if fireRes.isErr():
+    error "failed to fire recycleDoneSignal", err = fireRes.error
 
 var ffiEventQueueSignalPtr {.threadvar.}: ThreadSignalPtr
   # Stashed so the hook has no closure env.
@@ -151,6 +205,13 @@ proc ffiThreadBody[T](ctx: ptr FFIContext[T]) {.thread.} =
 
     while ctx.running.load():
       ctx.proveAlive()
+
+      # Recycle requested by the ffiDtor: drain + free lib + release the slot,
+      # keeping this thread alive for the next createFFIContext to reuse.
+      var expected = CtxLifecycle.RecyclePending
+      if ctx.lifecycle.compareExchange(expected, CtxLifecycle.Recycling):
+        await recycleContext(ctx, addr pending)
+        continue
 
       cleanFinishedRequests()
 

--- a/ffi/internal/ffi_codegen_common.nim
+++ b/ffi/internal/ffi_codegen_common.nim
@@ -1,0 +1,29 @@
+## Compile-time pieces that more than one `{.ffi.}` codegen path shares.
+
+import std/macros
+
+func unwrapPostfix*(n: NimNode): NimNode =
+  ## Strips the `*` of an exported name, so a name node reads the same whether
+  ## the writer exported it or not.
+  return
+    if n.kind == nnkPostfix:
+      n[1]
+    else:
+      n
+
+func procIdent*(prc: NimNode): NimNode =
+  return unwrapPostfix(prc[0])
+
+proc buildLibReadyGuard*(
+    ctxHandlerName, libTypeName: NimNode
+): NimNode {.compileTime.} =
+  ## Rejects a request that reaches the FFI thread before the ctor stores a
+  ## library. The guard applies only to a `ref` type. For an `object` type the
+  ## fallback is a usable zero value, but for a `ref` type it is nil. The guard
+  ## runs in the handler, behind the ctor in the queue. Thus a host can send a
+  ## call before it waits for the create callback.
+  quote:
+    when `libTypeName` is ref:
+      if not `ctxHandlerName`[].libReady.load():
+        return
+          err("library is not initialized: the constructor failed or has not run yet")

--- a/ffi/internal/ffi_export.nim
+++ b/ffi/internal/ffi_export.nim
@@ -1,0 +1,91 @@
+## Simple synchronous C export for a nim-ffi library.
+##
+## `{.ffi.}` / `{.ffiCtor.}` are the async, context-handle, CBOR-marshaled path —
+## the right tool for stateful, multi-call libraries. `{.ffiExport.}` covers the
+## other common case: a handful of DEAD-SIMPLE lifecycle/health entry points a host
+## loads with plain `dlopen` + `dlsym` and calls synchronously — no context, no
+## callback, no CBOR. The function's own return value crosses the ABI directly.
+##
+## You write NATIVE Nim types; `ffiExport` bridges to the C ABI for you:
+##   int / bool  -> C  int
+##   uint64      -> C  unsigned long long
+##   string      -> C  const char*   (kept alive in shared memory until the next call)
+##   (no return) -> C  void
+## and it injects the library's `initializeLibrary()` bootstrap so the Nim runtime
+## is up on first call — the host never invokes NimMain itself.
+##
+##   declareLibraryBase("myLib")                       # emits initializeLibrary()
+##   proc my_start(): int {.ffiExport.} = 0            # -> int my_start(void)
+##   proc my_alive(): uint64 {.ffiExport.} = beats     # -> unsigned long long my_alive(void)
+##   proc my_error(): string {.ffiExport.} = lastErr   # -> const char* my_error(void)
+##
+## Build the shared library with `--noMain --nimMainPrefix:libmyLib`. Arguments are
+## not supported (these are no-arg lifecycle calls); use `{.ffi.}` for calls that
+## take arguments.
+
+import std/macros
+
+proc cReturnType(t: NimNode): NimNode =
+  ## Native Nim return type -> the C-ABI type that actually crosses the boundary.
+  if t.kind == nnkEmpty:
+    return t                                   # void
+  if t.kind == nnkIdent:
+    case $t
+    of "int", "int32", "bool": return ident("cint")
+    of "uint", "uint64": return ident("culonglong")
+    of "string": return ident("cstring")
+    else: discard
+  return t                                     # already a C-compatible type
+
+macro ffiExport*(prc: untyped): untyped =
+  ## Mark a no-argument proc as a simple synchronous C export (see module doc):
+  ## native Nim return type, bridged to the C ABI, with the runtime bootstrapped.
+  prc.expectKind({nnkProcDef, nnkFuncDef})
+  let nameNode = if prc.name.kind == nnkPostfix: prc.name[1] else: prc.name
+  let exportName = $nameNode
+  let params = prc.params
+  if params.len > 1:
+    error("ffiExport supports no-argument procs; use {.ffi.} for calls with arguments")
+
+  let nativeRet = params[0]
+  let cRet = cReturnType(nativeRet)
+
+  # The user's body becomes a private impl proc; the exported wrapper converts.
+  let implName = genSym(nskProc, exportName & "Impl")
+  var impl = copyNimTree(prc)
+  impl[0] = implName            # rename
+  impl[4] = newEmptyNode()      # drop pragmas (internal, not exported)
+
+  let wrapName = ident(exportName)
+  let boot = quote do:
+    when declared(initializeLibrary):
+      initializeLibrary()
+
+  var res = newStmtList(impl)
+
+  if nativeRet.kind == nnkIdent and $nativeRet == "string":
+    # string -> const char*: keep the bytes alive in shared memory across the call.
+    let buf = genSym(nskVar, exportName & "Buf")
+    res.add quote do:
+      var `buf` {.global.}: pointer = nil
+      proc `wrapName`(): cstring {.exportc: `exportName`, cdecl, dynlib.} =
+        `boot`
+        let s = `implName`()
+        if `buf` != nil: deallocShared(`buf`)
+        `buf` = allocShared(s.len + 1)
+        if s.len > 0: copyMem(`buf`, unsafeAddr s[0], s.len)
+        cast[ptr char](cast[uint](`buf`) + uint(s.len))[] = '\0'
+        return cast[cstring](`buf`)
+  elif nativeRet.kind == nnkEmpty:
+    res.add quote do:
+      proc `wrapName`() {.exportc: `exportName`, cdecl, dynlib.} =
+        `boot`
+        `implName`()
+  else:
+    # scalar: convert the native result to the C return type (cint / culonglong / …).
+    res.add quote do:
+      proc `wrapName`(): `cRet` {.exportc: `exportName`, cdecl, dynlib.} =
+        `boot`
+        return `cRet`(`implName`())
+
+  return res

--- a/ffi/internal/ffi_export.nim
+++ b/ffi/internal/ffi_export.nim
@@ -8,15 +8,22 @@
 ## return value of the function crosses the ABI directly.
 ##
 ## Write native Nim types. `ffiExport` maps them to the C ABI:
-##   int / bool  -> C  int
-##   uint64      -> C  unsigned long long
-##   string      -> C  const char*   (stays alive in shared memory until the next call)
-##   (no return) -> C  void
+##   int / int64      -> C  long long
+##   int32 / bool     -> C  int
+##   uint / uint64    -> C  unsigned long long
+##   float            -> C  double
+##   string           -> C  const char*  (valid until the same thread calls again)
+##   (no return)      -> C  void
+## A return type with no mapping is a compile error.
+## The `const char*` buffer belongs to the calling thread. Copy the bytes before
+## that thread calls another `{.ffiExport.}` proc that returns a string.
 ## `ffiExport` also injects the `initializeLibrary()` call of the library. The Nim
 ## runtime therefore starts on the first call, and the host never calls NimMain.
+## The wrapper catches every exception of the body, prints it and returns the
+## zero value, because an exception must not cross the C ABI.
 ##
 ##   declareLibraryBase("myLib")                       # emits initializeLibrary()
-##   proc my_start(): int {.ffiExport.} = 0            # -> int my_start(void)
+##   proc my_start(): int {.ffiExport.} = 0            # -> long long my_start(void)
 ##   proc my_alive(): uint64 {.ffiExport.} = beats     # -> unsigned long long my_alive(void)
 ##   proc my_error(): string {.ffiExport.} = lastErr   # -> const char* my_error(void)
 ##
@@ -25,22 +32,65 @@
 
 import std/macros
 import ./ffi_route
+import ./ffi_codegen_common
 
-proc cReturnType(t: NimNode): NimNode =
+const passthroughCTypes = [
+  "cint", "cuint", "clong", "culong", "clonglong", "culonglong", "cfloat", "cdouble",
+  "cstring", "pointer",
+]
+
+proc cReturnType(t: NimNode, exportName: string): NimNode =
   ## Maps the native Nim return type to the C ABI type that crosses the boundary.
+  ## A type with no mapping is an error: emitting the Nim type as-is would export
+  ## a symbol whose ABI no host can call.
   if t.kind == nnkEmpty:
-    return t # void
+    return t
   if t.kind == nnkIdent:
     case $t
-    of "int", "int32", "bool":
+    of "int", "int64":
+      # `int` is pointer-wide, so `cint` would truncate it on a 64-bit host.
+      return ident("clonglong")
+    of "int8", "int16", "int32", "bool":
       return ident("cint")
     of "uint", "uint64":
       return ident("culonglong")
+    of "uint8", "uint16", "uint32":
+      return ident("cuint")
+    of "float", "float64":
+      return ident("cdouble")
+    of "float32":
+      return ident("cfloat")
     of "string":
       return ident("cstring")
     else:
-      discard
-  return t # already a C-compatible type
+      if $t in passthroughCTypes:
+        return t
+  error(
+    "`.ffiExport.` proc " & exportName & " returns " & t.repr &
+      ", which has no C ABI mapping. Return a scalar, a bool, a string, a C type, " &
+      "or nothing. For a richer return type, use `{.ffi.}`."
+  )
+
+proc withoutFFIPragmas(pragmas: NimNode): NimNode =
+  ## Drops only the pragma that routed the proc here, so a `raises` or `gcsafe`
+  ## the writer asked for still applies to the body.
+  if pragmas.kind != nnkPragma:
+    return newEmptyNode()
+  var kept = nnkPragma.newTree()
+  for p in pragmas:
+    let name =
+      if p.kind in {nnkExprColonExpr, nnkCall}:
+        p[0]
+      else:
+        p
+    if name.kind == nnkIdent and $name in ["ffi", "ffiExport"]:
+      continue
+    kept.add(p)
+  return
+    if kept.len == 0:
+      newEmptyNode()
+    else:
+      kept
 
 proc buildFFIExportProc*(prc: NimNode): NimNode {.compileTime.} =
   ## Emits the synchronous C export. `{.ffi.}` and `{.ffiExport.}` share it.
@@ -48,50 +98,64 @@ proc buildFFIExportProc*(prc: NimNode): NimNode {.compileTime.} =
   let exportName = $procIdent(prc)
   let params = prc.params
   let nativeRet = params[0]
-  let cRet = cReturnType(nativeRet)
+  let cRet = cReturnType(nativeRet, exportName)
 
-  # The user body becomes a private impl proc. The exported wrapper converts the
-  # result.
+  # The user body becomes a private impl proc that the exported wrapper calls.
   let implName = genSym(nskProc, exportName & "Impl")
   var impl = copyNimTree(prc)
-  impl[0] = implName # rename
-  impl[4] = newEmptyNode() # remove the pragmas: this proc stays internal
+  impl[0] = implName
+  impl[4] = withoutFFIPragmas(prc[4])
 
   let wrapName = ident(exportName)
   let boot = quote:
     when declared(initializeLibrary):
       initializeLibrary()
 
+  # A Nim exception that unwinds through a cdecl frame into the host is
+  # undefined behaviour, so every wrapper catches and reports instead.
+  let raiseNote = newLit("error: " & exportName & " raised: ")
+
   var res = newStmtList(impl)
 
   if nativeRet.kind == nnkIdent and $nativeRet == "string":
-    # string -> const char*: keep the bytes alive in shared memory across the call.
+    # One buffer per calling thread: a process-wide buffer would let one thread
+    # free the bytes another thread is still reading.
     let buf = genSym(nskVar, exportName & "Buf")
     res.add quote do:
-      var `buf` {.global.}: pointer = nil
-      proc `wrapName`(): cstring {.exportc: `exportName`, cdecl, dynlib.} =
+      var `buf` {.threadvar.}: pointer
+      proc `wrapName`(): cstring {.exportc: `exportName`, cdecl, dynlib, raises: [].} =
         `boot`
-        let s = `implName`()
-        if `buf` != nil:
+        var s = ""
+        try:
+          s = `implName`()
+        except CatchableError as e:
+          echo `raiseNote`, e.msg
+        if not `buf`.isNil():
           deallocShared(`buf`)
         `buf` = allocShared(s.len + 1)
         if s.len > 0:
           copyMem(`buf`, unsafeAddr s[0], s.len)
-        cast[ptr char](cast[uint](`buf`) + uint(s.len))[] = '\0'
+        cast[ptr UncheckedArray[char]](`buf`)[s.len] = '\0'
         return cast[cstring](`buf`)
 
   elif nativeRet.kind == nnkEmpty:
     res.add quote do:
-      proc `wrapName`() {.exportc: `exportName`, cdecl, dynlib.} =
+      proc `wrapName`() {.exportc: `exportName`, cdecl, dynlib, raises: [].} =
         `boot`
-        `implName`()
+        try:
+          `implName`()
+        except CatchableError as e:
+          echo `raiseNote`, e.msg
 
   else:
-    # scalar: convert the native result to the C return type (cint / culonglong / …).
     res.add quote do:
-      proc `wrapName`(): `cRet` {.exportc: `exportName`, cdecl, dynlib.} =
+      proc `wrapName`(): `cRet` {.exportc: `exportName`, cdecl, dynlib, raises: [].} =
         `boot`
-        return `cRet`(`implName`())
+        try:
+          return `cRet`(`implName`())
+        except CatchableError as e:
+          echo `raiseNote`, e.msg
+          return `cRet`(0)
 
   return res
 

--- a/ffi/internal/ffi_export.nim
+++ b/ffi/internal/ffi_export.nim
@@ -1,63 +1,64 @@
 ## Simple synchronous C export for a nim-ffi library.
 ##
-## `{.ffi.}` / `{.ffiCtor.}` are the async, context-handle, CBOR-marshaled path —
-## the right tool for stateful, multi-call libraries. `{.ffiExport.}` covers the
-## other common case: a handful of DEAD-SIMPLE lifecycle/health entry points a host
-## loads with plain `dlopen` + `dlsym` and calls synchronously — no context, no
-## callback, no CBOR. The function's own return value crosses the ABI directly.
+## `{.ffi.}` and `{.ffiCtor.}` give the async path. That path uses a context
+## handle and encodes the data with CBOR. It fits a library that keeps state
+## across many calls. `{.ffiExport.}` covers the other common case: a few simple
+## lifecycle entry points. The host loads them with `dlopen` and `dlsym`, then
+## calls them synchronously. There is no context, no callback and no CBOR. The
+## return value of the function crosses the ABI directly.
 ##
-## You write NATIVE Nim types; `ffiExport` bridges to the C ABI for you:
+## Write native Nim types. `ffiExport` maps them to the C ABI:
 ##   int / bool  -> C  int
 ##   uint64      -> C  unsigned long long
-##   string      -> C  const char*   (kept alive in shared memory until the next call)
+##   string      -> C  const char*   (stays alive in shared memory until the next call)
 ##   (no return) -> C  void
-## and it injects the library's `initializeLibrary()` bootstrap so the Nim runtime
-## is up on first call — the host never invokes NimMain itself.
+## `ffiExport` also injects the `initializeLibrary()` call of the library. The Nim
+## runtime therefore starts on the first call, and the host never calls NimMain.
 ##
 ##   declareLibraryBase("myLib")                       # emits initializeLibrary()
 ##   proc my_start(): int {.ffiExport.} = 0            # -> int my_start(void)
 ##   proc my_alive(): uint64 {.ffiExport.} = beats     # -> unsigned long long my_alive(void)
 ##   proc my_error(): string {.ffiExport.} = lastErr   # -> const char* my_error(void)
 ##
-## Build the shared library with `--noMain --nimMainPrefix:libmyLib`. Arguments are
-## not supported (these are no-arg lifecycle calls); use `{.ffi.}` for calls that
-## take arguments.
+## Build the shared library with `--noMain --nimMainPrefix:libmyLib`. A proc with
+## `{.ffiExport.}` takes no arguments. For a call with arguments, use `{.ffi.}`.
 
 import std/macros
+import ./ffi_route
 
 proc cReturnType(t: NimNode): NimNode =
-  ## Native Nim return type -> the C-ABI type that actually crosses the boundary.
+  ## Maps the native Nim return type to the C ABI type that crosses the boundary.
   if t.kind == nnkEmpty:
-    return t                                   # void
+    return t # void
   if t.kind == nnkIdent:
     case $t
-    of "int", "int32", "bool": return ident("cint")
-    of "uint", "uint64": return ident("culonglong")
-    of "string": return ident("cstring")
-    else: discard
-  return t                                     # already a C-compatible type
+    of "int", "int32", "bool":
+      return ident("cint")
+    of "uint", "uint64":
+      return ident("culonglong")
+    of "string":
+      return ident("cstring")
+    else:
+      discard
+  return t # already a C-compatible type
 
-macro ffiExport*(prc: untyped): untyped =
-  ## Mark a no-argument proc as a simple synchronous C export (see module doc):
-  ## native Nim return type, bridged to the C ABI, with the runtime bootstrapped.
+proc buildFFIExportProc*(prc: NimNode): NimNode {.compileTime.} =
+  ## Emits the synchronous C export. `{.ffi.}` and `{.ffiExport.}` share it.
   prc.expectKind({nnkProcDef, nnkFuncDef})
-  let nameNode = if prc.name.kind == nnkPostfix: prc.name[1] else: prc.name
-  let exportName = $nameNode
+  let exportName = $procIdent(prc)
   let params = prc.params
-  if params.len > 1:
-    error("ffiExport supports no-argument procs; use {.ffi.} for calls with arguments")
-
   let nativeRet = params[0]
   let cRet = cReturnType(nativeRet)
 
-  # The user's body becomes a private impl proc; the exported wrapper converts.
+  # The user body becomes a private impl proc. The exported wrapper converts the
+  # result.
   let implName = genSym(nskProc, exportName & "Impl")
   var impl = copyNimTree(prc)
-  impl[0] = implName            # rename
-  impl[4] = newEmptyNode()      # drop pragmas (internal, not exported)
+  impl[0] = implName # rename
+  impl[4] = newEmptyNode() # remove the pragmas: this proc stays internal
 
   let wrapName = ident(exportName)
-  let boot = quote do:
+  let boot = quote:
     when declared(initializeLibrary):
       initializeLibrary()
 
@@ -71,16 +72,20 @@ macro ffiExport*(prc: untyped): untyped =
       proc `wrapName`(): cstring {.exportc: `exportName`, cdecl, dynlib.} =
         `boot`
         let s = `implName`()
-        if `buf` != nil: deallocShared(`buf`)
+        if `buf` != nil:
+          deallocShared(`buf`)
         `buf` = allocShared(s.len + 1)
-        if s.len > 0: copyMem(`buf`, unsafeAddr s[0], s.len)
+        if s.len > 0:
+          copyMem(`buf`, unsafeAddr s[0], s.len)
         cast[ptr char](cast[uint](`buf`) + uint(s.len))[] = '\0'
         return cast[cstring](`buf`)
+
   elif nativeRet.kind == nnkEmpty:
     res.add quote do:
       proc `wrapName`() {.exportc: `exportName`, cdecl, dynlib.} =
         `boot`
         `implName`()
+
   else:
     # scalar: convert the native result to the C return type (cint / culonglong / …).
     res.add quote do:
@@ -89,3 +94,12 @@ macro ffiExport*(prc: untyped): untyped =
         return `cRet`(`implName`())
 
   return res
+
+macro ffiExport*(prc: untyped): untyped =
+  ## Marks a proc that takes no arguments as a simple synchronous C export. The
+  ## macro maps the native Nim return type to the C ABI and starts the Nim
+  ## runtime. `{.ffi.}` reaches the same path from the shape alone. See the
+  ## module doc.
+  prc.expectKind({nnkProcDef, nnkFuncDef})
+  assertFFIPath(prc, fpExport)
+  return buildFFIExportProc(prc)

--- a/ffi/internal/ffi_library.nim
+++ b/ffi/internal/ffi_library.nim
@@ -179,6 +179,12 @@ macro declareLibrary*(
   let addName = libraryName & "_add_event_listener"
   let addErr = "error: invalid context in " & addName
   let addBody = quote:
+    # Runs on the foreign caller thread, which may not be the one that ran a
+    # prior entry point: initialize this thread's GC before any Nim allocation
+    # ($eventName / the registry Table+seq), else the per-thread allocator
+    # region is uninitialized and faults.
+    when declared(initializeLibrary):
+      initializeLibrary()
     var ret: uint64 = 0
     if isNil(ctx):
       echo `addErr`
@@ -210,6 +216,8 @@ macro declareLibrary*(
   let removeName = libraryName & "_remove_event_listener"
   let removeErr = "error: invalid context in " & removeName
   let removeBody = quote:
+    when declared(initializeLibrary):
+      initializeLibrary()
     var ret: cint = 1
     if isNil(ctx):
       echo `removeErr`

--- a/ffi/internal/ffi_library.nim
+++ b/ffi/internal/ffi_library.nim
@@ -179,10 +179,10 @@ macro declareLibrary*(
   let addName = libraryName & "_add_event_listener"
   let addErr = "error: invalid context in " & addName
   let addBody = quote:
-    # Runs on the foreign caller thread, which may not be the one that ran a
-    # prior entry point: initialize this thread's GC before any Nim allocation
-    # ($eventName / the registry Table+seq), else the per-thread allocator
-    # region is uninitialized and faults.
+    # This code runs on the foreign caller thread. That thread can differ from
+    # the thread of an earlier entry point. If the GC of the thread is not
+    # ready, the first Nim allocation ($eventName, the registry Table and seq)
+    # faults. Therefore initialize the GC here.
     when declared(initializeLibrary):
       initializeLibrary()
     var ret: uint64 = 0

--- a/ffi/internal/ffi_macro.nim
+++ b/ffi/internal/ffi_macro.nim
@@ -1051,6 +1051,20 @@ proc buildFFIProc(
       helperCall.add(ident(name))
 
     let lambdaBody = newStmtList()
+    if not firstIsHandle:
+      # Reject a request that reached the FFI thread without a `{.ffiCtor.}`
+      # having stored a library — `myLibOwned` is what distinguishes that from
+      # the worker's default-valued stack fallback. Only for `ref` library
+      # types: an `object` fallback is a usable zero value callers may rely on,
+      # but a `ref` one is `nil`, so the user body would deref nil on its first
+      # field access. Emitted in the handler, i.e. on the FFI thread behind any
+      # queued ctor, so calling without awaiting the create callback still works.
+      lambdaBody.add quote do:
+        when `libTypeName` is ref:
+          if not `ctxHandlerName`[].myLibOwned:
+            return err(
+              "library is not initialized: the constructor failed or has not run yet"
+            )
     let retValIdent = ident("retVal")
     lambdaBody.add quote do:
       let `retValIdent` = (await `helperCall`).valueOr:

--- a/ffi/internal/ffi_macro.nim
+++ b/ffi/internal/ffi_macro.nim
@@ -7,6 +7,8 @@ import ../ffi_thread_request
 import ../codegen/[meta, string_helpers]
 import ./c_macro_helpers
 import ./ffi_scalar
+import ./ffi_route
+import ./ffi_export
 when defined(ffiGenBindings):
   import ../codegen/rust
   import ../codegen/cpp
@@ -531,7 +533,7 @@ proc replyEncode(
   return quote:
     # A `seq[byte]` result goes on the wire as CBOR, the same as every other
     # `abi = cbor` return. The C, C++ and Rust decoders expect CBOR. They reject
-    # raw bytes with "value encoded in non-canonical form".
+    # raw bytes with the error "value encoded in non-canonical form".
     when typeof(`typedResIdent`.value) is void:
       return ok(newSeq[byte]())
     elif typeof(`typedResIdent`.value) is FFIHandleRoot:
@@ -1145,29 +1147,64 @@ proc buildFFIProc(
     echo stmts.repr
   return stmts
 
+proc buildFFIDtorProc(prc: NimNode, abiFormat: ABIFormat): NimNode {.compileTime.}
+proc buildFFIEventProc(prc: NimNode, leading: seq[NimNode]): NimNode {.compileTime.}
+
 macro ffi*(args: varargs[untyped]): untyped =
-  ## Simplified FFI macro for procs or types: a type registers for binding gen; a
-  ## proc takes a library-type param plus optional Nim params, returns
-  ## Future[Result[RetType, string]], and gets a C wrapper taking one CBOR buffer.
+  ## Simplified FFI macro for a type or a proc. A type registers for binding
+  ## generation. For a proc, `routeFFIProc` reads the signature and picks the
+  ## path: a context method, a static call, a synchronous export, a destructor,
+  ## or an event. See `ffi/internal/ffi_route.nim` for the rules.
   requireBeforeGenBindings("`.ffi.`")
   # Annotated node is the last vararg; leading args are `"abi = ..."` specs.
   let prc = args[^1]
-  let abiFormat = resolveFFISpecs(args[0 ..^ 2])
+  let leading = args[0 ..^ 2]
 
   # A value type stands alone (no library required); its `c` companion is emitted later by `genBindings()`, since a type-pragma macro can only return a TypeDef.
   if prc.kind == nnkTypeDef:
-    gateFFITypeABIFormat(abiFormat, "`.ffi.` type")
+    let typeABIFormat = resolveFFISpecs(leading)
+    gateFFITypeABIFormat(typeABIFormat, "`.ffi.` type")
     var cleanTypeDef = prc.copyNimTree()
     if cleanTypeDef[0].kind == nnkPragmaExpr:
       cleanTypeDef[0] = cleanTypeDef[0][0]
-    return registerFFITypeInfo(cleanTypeDef, abiFormat)
+    return registerFFITypeInfo(cleanTypeDef, typeABIFormat)
 
+  if prc.kind notin {nnkProcDef, nnkFuncDef}:
+    error("`.ffi.` must be applied to a type or a proc definition")
   requireLibraryDeclared("`.ffi.`")
-  return buildFFIProc(prc, abiFormat, isStatic = false)
+
+  let path = routeFFIProc(prc)
+
+  # An event may lead with a wire-name literal, which the ABI parser rejects, so
+  # it resolves its own specs.
+  if path == fpEvent:
+    return buildFFIEventProc(prc, leading)
+
+  let abiFormat = resolveFFISpecs(leading)
+  case path
+  of fpExport:
+    # The export crosses the ABI with its own return value, so no ABI applies.
+    if leading.len > 0:
+      error(
+        "`.ffi.` proc " & $procIdent(prc) &
+          " is a synchronous export and takes no `abi = ...` spec"
+      )
+    return buildFFIExportProc(prc)
+  of fpDtor:
+    gateABIFormat(abiFormat, "`.ffi.` destructor")
+    return buildFFIDtorProc(prc, abiFormat)
+  of fpStatic:
+    gateABIFormat(abiFormat, "`.ffi.` static proc")
+    return buildFFIProc(prc, abiFormat, isStatic = true)
+  of fpMethod:
+    return buildFFIProc(prc, abiFormat, isStatic = false)
+  of fpEvent:
+    error("unreachable: the event path returns above")
 
 macro ffiStatic*(args: varargs[untyped]): untyped =
   ## Context-independent `{.ffi.}`: no library receiver, and no `ctx` in the C
-  ## wrapper, so a host calls it without constructing the library.
+  ## wrapper, so a host calls it without constructing the library. `{.ffi.}`
+  ## reaches the same path from the shape alone.
   requireBeforeGenBindings("`.ffiStatic.`")
   requireLibraryDeclared("`.ffiStatic.`")
   let prc = args[^1]
@@ -1175,6 +1212,7 @@ macro ffiStatic*(args: varargs[untyped]): untyped =
   gateABIFormat(abiFormat, "`.ffiStatic.` proc")
   if prc.kind notin {nnkProcDef, nnkFuncDef}:
     error("`.ffiStatic.` must be applied to a proc definition")
+  assertFFIPath(prc, fpStatic)
   return buildFFIProc(prc, abiFormat, isStatic = true)
 
 proc buildCtorRequestType(
@@ -1330,7 +1368,7 @@ proc buildCtorProcessFFIRequestProc(
       when `libTypeName` is ref:
         GC_ref(`myLibIdent`[])
         `myLibRefdIdent` = true
-    # After the store, so an observer never sees the fallback.
+    # Set the flag after the store, so an observer never sees the fallback.
     `libReadyIdent`.store(true)
 
   newBody.add quote do:
@@ -1602,16 +1640,9 @@ macro ffiCtor*(args: varargs[untyped]): untyped =
     echo stmts.repr
   return stmts
 
-macro ffiDtor*(args: varargs[untyped]): untyped =
-  ## C-exported FFIContext destructor. Sync (no return) or async (`Future[void]`);
-  ## a non-empty body becomes an async `ffiTeardownHook` the FFI thread awaits at
-  ## shutdown, so teardown runs on the worker thread. RET_ERR on null/invalid ctx.
-  requireBeforeGenBindings("`.ffiDtor.`")
-  requireLibraryDeclared("`.ffiDtor.`")
-  let prc = args[^1]
-  let abiFormat = resolveABIFormat(args[0 ..^ 2])
-  gateABIFormat(abiFormat, "`.ffiDtor.` proc")
-
+proc buildFFIDtorProc(prc: NimNode, abiFormat: ABIFormat): NimNode {.compileTime.} =
+  ## Emits the C-exported FFIContext destructor. `{.ffi.}` and `{.ffiDtor.}`
+  ## share it.
   let procName = prc[0]
   let formalParams = prc[3]
   let bodyNode = prc[^1]
@@ -1723,30 +1754,30 @@ macro ffiDtor*(args: varargs[untyped]): untyped =
     echo stmts.repr
   return stmts
 
-macro ffiEvent*(args: varargs[untyped]): untyped =
-  ## Declares a library-initiated event: the empty-bodied proc is filled with a
-  ## `dispatchFFIEventCbor` call. Wire name defaults to `camelToSnakeCase` of the
-  ## proc name (a string literal overrides it) and is the cross-binding source of truth.
-  ##
+macro ffiDtor*(args: varargs[untyped]): untyped =
+  ## C-exported FFIContext destructor. Sync (no return) or async (`Future[void]`);
+  ## a non-empty body becomes an async `ffiTeardownHook` the FFI thread awaits at
+  ## shutdown, so teardown runs on the worker thread. RET_ERR on null/invalid ctx.
+  ## `{.ffi.}` reaches the same path from the shape alone.
+  requireBeforeGenBindings("`.ffiDtor.`")
+  requireLibraryDeclared("`.ffiDtor.`")
+  let prc = args[^1]
+  let abiFormat = resolveABIFormat(args[0 ..^ 2])
+  gateABIFormat(abiFormat, "`.ffiDtor.` proc")
+  assertFFIPath(prc, fpDtor)
+  return buildFFIDtorProc(prc, abiFormat)
+
+proc buildFFIEventProc(prc: NimNode, leading: seq[NimNode]): NimNode {.compileTime.} =
+  ## Emits the event dispatcher. `{.ffi.}` and `{.ffiEvent.}` share it.
   ## One parameter rides the wire directly (a scalar, or an existing `{.ffi.}`
   ## object). Two or more are bundled into a synthesised, registered envelope
   ## object named `<WireNamePascalCase>Payload` whose fields are the parameters,
   ## so the foreign side still decodes one typed value.
-  requireBeforeGenBindings("`.ffiEvent.`")
-  requireLibraryDeclared("`.ffiEvent.`")
-  if args.len < 1:
-    error("ffiEvent must be applied to a proc declaration")
-
-  let prc = args[^1]
-  if prc.kind notin {nnkProcDef, nnkFuncDef}:
-    error("ffiEvent must be applied to a proc declaration")
-
   let procName = prc[0]
   var userProcName = procName
   if procName.kind == nnkPostfix:
     userProcName = procName[1]
 
-  let leading = args[0 ..^ 2]
   let (wireName, abiSpecStart) = resolveEventWireName(leading, userProcName)
   let abiFormat = resolveABIFormat(leading[abiSpecStart ..^ 1])
   gateABIFormat(abiFormat, "`.ffiEvent.` proc")
@@ -1848,6 +1879,22 @@ macro ffiEvent*(args: varargs[untyped]): untyped =
   when defined(ffiDumpMacros):
     echo resultStmts.repr
   return resultStmts
+
+macro ffiEvent*(args: varargs[untyped]): untyped =
+  ## Declares a library-initiated event: the empty-bodied proc is filled with a
+  ## `dispatchFFIEventCbor` call. Wire name defaults to `camelToSnakeCase` of the
+  ## proc name (a string literal overrides it) and is the cross-binding source of truth.
+  ## `{.ffi.}` reaches the same path from the shape alone.
+  requireBeforeGenBindings("`.ffiEvent.`")
+  requireLibraryDeclared("`.ffiEvent.`")
+  if args.len < 1:
+    error("ffiEvent must be applied to a proc declaration")
+
+  let prc = args[^1]
+  if prc.kind notin {nnkProcDef, nnkFuncDef}:
+    error("ffiEvent must be applied to a proc declaration")
+  assertFFIPath(prc, fpEvent)
+  return buildFFIEventProc(prc, args[0 ..^ 2])
 
 proc reportScalarFastPathDrops(procs: seq[FFIProcMeta]) {.compileTime.} =
   ## Fail loudly on scalar-fast-path procs a target can't bind, unless

--- a/ffi/internal/ffi_macro.nim
+++ b/ffi/internal/ffi_macro.nim
@@ -1721,6 +1721,11 @@ macro ffiEvent*(args: varargs[untyped]): untyped =
   ## Declares a library-initiated event: the empty-bodied proc is filled with a
   ## `dispatchFFIEventCbor` call. Wire name defaults to `camelToSnakeCase` of the
   ## proc name (a string literal overrides it) and is the cross-binding source of truth.
+  ##
+  ## One parameter rides the wire directly (a scalar, or an existing `{.ffi.}`
+  ## object). Two or more are bundled into a synthesised, registered envelope
+  ## object named `<WireNamePascalCase>Payload` whose fields are the parameters,
+  ## so the foreign side still decodes one typed value.
   requireBeforeGenBindings("`.ffiEvent.`")
   requireLibraryDeclared("`.ffiEvent.`")
   if args.len < 1:
@@ -1747,30 +1752,66 @@ macro ffiEvent*(args: varargs[untyped]): untyped =
 
   let formalParams = prc[3]
 
-  if formalParams.len != 2:
-    error(
-      "ffiEvent (first pass) supports exactly one parameter; got " &
-        $(formalParams.len - 1)
-    )
+  if formalParams.len < 2:
+    error("ffiEvent requires at least one parameter")
 
-  let paramDef = formalParams[1]
-  let payloadParamName = paramDef[0]
-  let payloadTypeNode = paramDef[1]
-
-  let payloadTypeNameStr =
-    case payloadTypeNode.kind
-    of nnkIdent:
-      $payloadTypeNode
-    else:
-      payloadTypeNode.repr
+  # Flatten the parameter list (a grouped `a, b: T` expands to one entry each).
+  var paramNames: seq[NimNode] = @[]
+  var paramTypes: seq[NimNode] = @[]
+  for i in 1 ..< formalParams.len:
+    let p = formalParams[i]
+    for j in 0 ..< p.len - 2:
+      rejectRawPtrType(
+        p[^2], "`.ffiEvent.` proc " & $userProcName & " parameter " & $p[j]
+      )
+      paramNames.add(p[j])
+      paramTypes.add(p[^2])
 
   let wireNameLit = newStrLitNode(wireName)
+  let resultStmts = newStmtList()
+
+  var payloadTypeNameStr: string
+  var dispatchPayload: NimNode
+
+  if paramNames.len == 1:
+    let payloadTypeNode = paramTypes[0]
+    payloadTypeNameStr =
+      if payloadTypeNode.kind == nnkIdent:
+        $payloadTypeNode
+      else:
+        payloadTypeNode.repr
+    dispatchPayload = paramNames[0]
+  else:
+    # Synthesise + register an envelope object, then dispatch an instance built
+    # from the parameters.
+    let payloadType = ident(snakeToPascalCase(wireName) & "Payload")
+    payloadTypeNameStr = $payloadType
+
+    var paramNameStrs: seq[string] = @[]
+    for n in paramNames:
+      paramNameStrs.add($n)
+    let typeSection = buildCtorRequestType(payloadType, paramNameStrs, paramTypes)
+    discard registerFFITypeInfo(typeSection[0], abiFormat)
+    resultStmts.add(typeSection)
+
+    let envelope = nnkObjConstr.newTree(payloadType)
+    for i in 0 ..< paramNames.len:
+      # `cstring` rides as `string` in the envelope (per storageType).
+      let value =
+        if paramTypes[i].kind == nnkIdent and $paramTypes[i] == "cstring":
+          newCall(ident("$"), paramNames[i])
+        else:
+          paramNames[i]
+      envelope.add(nnkExprColonExpr.newTree(paramNames[i], value))
+    dispatchPayload = envelope
+
   let dispatchBody =
-    newStmtList(newCall(ident("dispatchFFIEventCbor"), wireNameLit, payloadParamName))
+    newStmtList(newCall(ident("dispatchFFIEventCbor"), wireNameLit, dispatchPayload))
 
   var newParams = newSeq[NimNode]()
-  newParams.add(formalParams[0])
-  newParams.add(paramDef)
+  newParams.add(formalParams[0]) # return type (typically empty/void)
+  for i in 1 ..< formalParams.len:
+    newParams.add(formalParams[i])
 
   let pragmas =
     if prc.len >= 5 and prc[4].kind != nnkEmpty:
@@ -1785,6 +1826,7 @@ macro ffiEvent*(args: varargs[untyped]): untyped =
     procType = prc.kind,
     pragmas = pragmas,
   )
+  resultStmts.add(generated)
 
   ffiEventRegistry.add(
     FFIEventMeta(
@@ -1798,8 +1840,8 @@ macro ffiEvent*(args: varargs[untyped]): untyped =
   )
 
   when defined(ffiDumpMacros):
-    echo generated.repr
-  return generated
+    echo resultStmts.repr
+  return resultStmts
 
 proc reportScalarFastPathDrops(procs: seq[FFIProcMeta]) {.compileTime.} =
   ## Fail loudly on scalar-fast-path procs a target can't bind, unless

--- a/ffi/internal/ffi_macro.nim
+++ b/ffi/internal/ffi_macro.nim
@@ -1044,27 +1044,16 @@ proc buildFFIProc(
       lambdaParams.add(newIdentDefs(ident(extraParamNames[i]), extraParamTypes[i]))
 
     let helperCall = newTree(nnkCall, userProcName)
-    if not firstIsHandle and not isStatic:
+    let bindsLib = not firstIsHandle and not isStatic
+    if bindsLib:
       let ctxMyLib = newDotExpr(newTree(nnkDerefExpr, ctxHandlerName), ident("myLib"))
       helperCall.add(newTree(nnkDerefExpr, ctxMyLib))
     for name in extraParamNames:
       helperCall.add(ident(name))
 
     let lambdaBody = newStmtList()
-    if not firstIsHandle:
-      # Reject a request that reached the FFI thread without a `{.ffiCtor.}`
-      # having stored a library — `myLibOwned` is what distinguishes that from
-      # the worker's default-valued stack fallback. Only for `ref` library
-      # types: an `object` fallback is a usable zero value callers may rely on,
-      # but a `ref` one is `nil`, so the user body would deref nil on its first
-      # field access. Emitted in the handler, i.e. on the FFI thread behind any
-      # queued ctor, so calling without awaiting the create callback still works.
-      lambdaBody.add quote do:
-        when `libTypeName` is ref:
-          if not `ctxHandlerName`[].myLibOwned:
-            return err(
-              "library is not initialized: the constructor failed or has not run yet"
-            )
+    if bindsLib:
+      lambdaBody.add(buildLibReadyGuard(ctxHandlerName, libTypeName))
     let retValIdent = ident("retVal")
     lambdaBody.add quote do:
       let `retValIdent` = (await `helperCall`).valueOr:
@@ -1330,6 +1319,7 @@ proc buildCtorProcessFFIRequestProc(
   let myLibIdent = newDotExpr(newTree(nnkDerefExpr, ctxIdent), ident("myLib"))
   let myLibOwnedIdent = newDotExpr(newTree(nnkDerefExpr, ctxIdent), ident("myLibOwned"))
   let myLibRefdIdent = newDotExpr(newTree(nnkDerefExpr, ctxIdent), ident("myLibRefd"))
+  let libReadyIdent = newDotExpr(newTree(nnkDerefExpr, ctxIdent), ident("libReady"))
   newBody.add quote do:
     `myLibIdent` = createShared(`libTypeName`)
     `myLibIdent`[] = `libValIdent`
@@ -1340,6 +1330,8 @@ proc buildCtorProcessFFIRequestProc(
       when `libTypeName` is ref:
         GC_ref(`myLibIdent`[])
         `myLibRefdIdent` = true
+    # After the store, so an observer never sees the fallback.
+    `libReadyIdent`.store(true)
 
   newBody.add quote do:
     return ok($cast[uint](`ctxIdent`))

--- a/ffi/internal/ffi_macro.nim
+++ b/ffi/internal/ffi_macro.nim
@@ -9,6 +9,7 @@ import ./c_macro_helpers
 import ./ffi_scalar
 import ./ffi_route
 import ./ffi_export
+import ./ffi_codegen_common
 when defined(ffiGenBindings):
   import ../codegen/rust
   import ../codegen/cpp
@@ -394,12 +395,7 @@ proc buildFFINewReqProc(reqTypeName, body: NimNode): NimNode =
           `reqObjIdent`.`fieldName` = `fieldName`
       )
 
-  let reqNameLit = newLit(
-    if reqTypeName.kind == nnkPostfix:
-      $reqTypeName[1]
-    else:
-      $reqTypeName
-  )
+  let reqNameLit = newLit($unwrapPostfix(reqTypeName))
   newBody.add(
     quote do:
       # Encode into shared memory, avoiding a second seq[byte] copy.
@@ -1087,12 +1083,7 @@ proc buildFFIProc(
       ffiBody.add(stmt)
 
     let reqPtrIdent = genSym(nskLet, "reqPtr")
-    let reqNameLit = newLit(
-      if reqTypeName.kind == nnkPostfix:
-        $reqTypeName[1]
-      else:
-        $reqTypeName
-    )
+    let reqNameLit = newLit($unwrapPostfix(reqTypeName))
     ffiBody.add quote do:
       let `reqPtrIdent` = FFIThreadRequest.initFromPtr(
         callback, userData, cstring(`reqNameLit`), reqCbor, int(reqCborLen)
@@ -1173,15 +1164,16 @@ macro ffi*(args: varargs[untyped]): untyped =
     error("`.ffi.` must be applied to a type or a proc definition")
   requireLibraryDeclared("`.ffi.`")
 
-  let path = routeFFIProc(prc)
+  proc gatedABIFormat(what: string): ABIFormat =
+    let abiFormat = resolveFFISpecs(leading)
+    gateABIFormat(abiFormat, what)
+    return abiFormat
 
-  # An event may lead with a wire-name literal, which the ABI parser rejects, so
-  # it resolves its own specs.
-  if path == fpEvent:
+  case routeFFIProc(prc)
+  of fpEvent:
+    # An event may lead with a wire-name literal, which the ABI parser rejects,
+    # so it resolves its own specs.
     return buildFFIEventProc(prc, leading)
-
-  let abiFormat = resolveFFISpecs(leading)
-  case path
   of fpExport:
     # The export crosses the ABI with its own return value, so no ABI applies.
     if leading.len > 0:
@@ -1191,15 +1183,11 @@ macro ffi*(args: varargs[untyped]): untyped =
       )
     return buildFFIExportProc(prc)
   of fpDtor:
-    gateABIFormat(abiFormat, "`.ffi.` destructor")
-    return buildFFIDtorProc(prc, abiFormat)
+    return buildFFIDtorProc(prc, gatedABIFormat("`.ffi.` destructor"))
   of fpStatic:
-    gateABIFormat(abiFormat, "`.ffi.` static proc")
-    return buildFFIProc(prc, abiFormat, isStatic = true)
+    return buildFFIProc(prc, gatedABIFormat("`.ffi.` static proc"), isStatic = true)
   of fpMethod:
-    return buildFFIProc(prc, abiFormat, isStatic = false)
-  of fpEvent:
-    error("unreachable: the event path returns above")
+    return buildFFIProc(prc, resolveFFISpecs(leading), isStatic = false)
 
 macro ffiStatic*(args: varargs[untyped]): untyped =
   ## Context-independent `{.ffi.}`: no library receiver, and no `ctx` in the C
@@ -1259,12 +1247,7 @@ proc buildCtorFFINewReqProc(reqTypeName: NimNode, paramNames: seq[string]): NimN
   let retType = newTree(nnkPtrTy, ident("FFIThreadRequest"))
   formalParams = @[retType] & formalParams
 
-  let reqNameLit = newLit(
-    if reqTypeName.kind == nnkPostfix:
-      $reqTypeName[1]
-    else:
-      $reqTypeName
-  )
+  let reqNameLit = newLit($unwrapPostfix(reqTypeName))
   var newBody = newStmtList()
   newBody.add quote do:
     return FFIThreadRequest.initFromPtr(
@@ -1846,7 +1829,7 @@ proc buildFFIEventProc(prc: NimNode, leading: seq[NimNode]): NimNode {.compileTi
     newStmtList(newCall(ident("dispatchFFIEventCbor"), wireNameLit, dispatchPayload))
 
   var newParams = newSeq[NimNode]()
-  newParams.add(formalParams[0]) # return type (typically empty/void)
+  newParams.add(formalParams[0])
   for i in 1 ..< formalParams.len:
     newParams.add(formalParams[i])
 

--- a/ffi/internal/ffi_macro.nim
+++ b/ffi/internal/ffi_macro.nim
@@ -392,13 +392,18 @@ proc buildFFINewReqProc(reqTypeName, body: NimNode): NimNode =
           `reqObjIdent`.`fieldName` = `fieldName`
       )
 
+  let reqNameLit = newLit(
+    if reqTypeName.kind == nnkPostfix:
+      $reqTypeName[1]
+    else:
+      $reqTypeName
+  )
   newBody.add(
     quote do:
-      let typeStr = $T
       # Encode into shared memory, avoiding a second seq[byte] copy.
       let (sharedData, sharedLen) = cborEncodeShared(`reqObjIdent`)
       return FFIThreadRequest.initFromOwnedShared(
-        callback, userData, typeStr.cstring, sharedData, sharedLen
+        callback, userData, cstring(`reqNameLit`), sharedData, sharedLen
       )
   )
 
@@ -1077,10 +1082,15 @@ proc buildFFIProc(
       ffiBody.add(stmt)
 
     let reqPtrIdent = genSym(nskLet, "reqPtr")
+    let reqNameLit = newLit(
+      if reqTypeName.kind == nnkPostfix:
+        $reqTypeName[1]
+      else:
+        $reqTypeName
+    )
     ffiBody.add quote do:
-      let typeStr = $`reqTypeName`
       let `reqPtrIdent` = FFIThreadRequest.initFromPtr(
-        callback, userData, typeStr.cstring, reqCbor, int(reqCborLen)
+        callback, userData, cstring(`reqNameLit`), reqCbor, int(reqCborLen)
       )
     ffiBody.add buildSendAndReply(reqPtrIdent)
 
@@ -1208,11 +1218,16 @@ proc buildCtorFFINewReqProc(reqTypeName: NimNode, paramNames: seq[string]): NimN
   let retType = newTree(nnkPtrTy, ident("FFIThreadRequest"))
   formalParams = @[retType] & formalParams
 
+  let reqNameLit = newLit(
+    if reqTypeName.kind == nnkPostfix:
+      $reqTypeName[1]
+    else:
+      $reqTypeName
+  )
   var newBody = newStmtList()
   newBody.add quote do:
-    let typeStr = $T
     return FFIThreadRequest.initFromPtr(
-      callback, userData, typeStr.cstring, reqCbor, int(reqCborLen)
+      callback, userData, cstring(`reqNameLit`), reqCbor, int(reqCborLen)
     )
 
   let newReqProc = newProc(
@@ -1299,9 +1314,18 @@ proc buildCtorProcessFFIRequestProc(
       return err($error)
 
   let myLibIdent = newDotExpr(newTree(nnkDerefExpr, ctxIdent), ident("myLib"))
+  let myLibOwnedIdent = newDotExpr(newTree(nnkDerefExpr, ctxIdent), ident("myLibOwned"))
+  let myLibRefdIdent = newDotExpr(newTree(nnkDerefExpr, ctxIdent), ident("myLibRefd"))
   newBody.add quote do:
     `myLibIdent` = createShared(`libTypeName`)
     `myLibIdent`[] = `libValIdent`
+    `myLibOwnedIdent` = true
+    # Root the ref lib under refc: it lives only via this ptr in non-GC
+    # createShared memory, invisible to the cycle collector. freeLib unroots it.
+    when defined(gcRefc):
+      when `libTypeName` is ref:
+        GC_ref(`myLibIdent`[])
+        `myLibRefdIdent` = true
 
   newBody.add quote do:
     return ok($cast[uint](`ctxIdent`))
@@ -1649,7 +1673,7 @@ macro ffiDtor*(args: varargs[untyped]): untyped =
   let poolIdent = ident($libTypeName & "FFIPool")
   ffiBody.add quote do:
     let `destroyResIdent` =
-      `poolIdent`.destroyFFIContext(cast[ptr FFIContext[`libTypeName`]](ctx))
+      `poolIdent`.recycleFFIContext(cast[ptr FFIContext[`libTypeName`]](ctx))
     if `destroyResIdent`.isErr():
       return RET_ERR
 

--- a/ffi/internal/ffi_route.nim
+++ b/ffi/internal/ffi_route.nim
@@ -1,0 +1,99 @@
+## Picks the FFI path of a proc from the shape of its signature.
+##
+## `{.ffi.}`, `{.ffiStatic.}`, `{.ffiExport.}`, `{.ffiDtor.}` and `{.ffiEvent.}`
+## own five disjoint shapes, so one router serves all five. Each shape that the
+## router claims fails to compile under any other pragma today, so the router
+## only turns a compile error into the meaning the writer intended.
+##
+## `{.ffiCtor.}` stays explicit, because its shape is not free. A ctor differs
+## from a static call by one token: the type inside `Result`. A static call that
+## returns the library type builds today and exports a working C symbol. A
+## router would silently give it the ctor ABI instead.
+
+import std/macros
+import ../codegen/meta
+
+type FFIPath* = enum
+  fpMethod ## A library or handle receiver, and an async result.
+  fpStatic ## No receiver, and an async result.
+  fpExport ## No arguments, and a synchronous result.
+  fpDtor ## A library receiver, and no result.
+  fpEvent ## A payload parameter, and no result.
+
+func pathPragma*(path: FFIPath): string =
+  case path
+  of fpMethod: "`.ffi.`"
+  of fpStatic: "`.ffiStatic.`"
+  of fpExport: "`.ffiExport.`"
+  of fpDtor: "`.ffiDtor.`"
+  of fpEvent: "`.ffiEvent.`"
+
+func pathShape*(path: FFIPath): string =
+  case path
+  of fpMethod:
+    "the first parameter is the library type or an {.ffiHandle.} type, and the " &
+      "return type is Future[Result[T, string]]"
+  of fpStatic:
+    "there is no library receiver, and the return type is Future[Result[T, string]]"
+  of fpExport:
+    "there are no parameters, and the return type is a plain Nim type"
+  of fpDtor:
+    "there is one library parameter, and the return type is nothing or Future[void]"
+  of fpEvent:
+    "there is a payload parameter that is not the library type, and there is no result"
+
+func isFuture(t: NimNode): bool =
+  return
+    t.kind == nnkBracketExpr and t.len == 2 and t[0].kind == nnkIdent and
+    $t[0] == "Future"
+
+func isFutureVoid(t: NimNode): bool =
+  return isFuture(t) and t[1].kind == nnkIdent and $t[1] == "void"
+
+proc isLibReceiver(t: NimNode): bool {.compileTime.} =
+  ## The receiver is the type that `declareLibrary` recorded, or a handle type.
+  if t.kind != nnkIdent:
+    return false
+  return ($t == currentLibType and currentLibType.len > 0) or isFFIHandleTypeName($t)
+
+func procIdent*(prc: NimNode): NimNode =
+  return
+    if prc[0].kind == nnkPostfix:
+      prc[0][1]
+    else:
+      prc[0]
+
+proc routeFFIProc*(prc: NimNode): FFIPath {.compileTime.} =
+  ## Reads the receiver and the return type, then names the path.
+  let params = prc[3]
+  let ret = params[0]
+  let hasReceiver = params.len > 1 and isLibReceiver(params[1][1])
+
+  if hasReceiver:
+    return if ret.kind == nnkEmpty or isFutureVoid(ret): fpDtor else: fpMethod
+  if params.len == 1 and not isFuture(ret):
+    return fpExport
+  # A static call always returns Future[Result[T, string]], so a payload
+  # parameter with no result can only be an event.
+  if params.len > 1 and ret.kind == nnkEmpty:
+    return fpEvent
+  return fpStatic
+
+proc assertFFIPath*(prc: NimNode, want: FFIPath) {.compileTime.} =
+  ## Guards an explicit pragma against a signature that routes elsewhere.
+  let got = routeFFIProc(prc)
+  if got == want:
+    return
+  let name = $procIdent(prc)
+  # A receiver is the one mismatch a caller can read straight off the signature.
+  if want == fpStatic and got == fpMethod:
+    error(
+      "`.ffiStatic.` proc " & name & " takes " & prc[3][1][1].repr &
+        " as its first parameter, which is the library type or an {.ffiHandle.} type. " &
+        "A receiver belongs to a context. Make it an `{.ffi.}` method instead."
+    )
+  error(
+    pathPragma(want) & " proc " & name & " has the shape of a " & pathPragma(got) &
+      " proc. Use " & pathPragma(got) & " here, or make sure that " & pathShape(want) &
+      "."
+  )

--- a/ffi/internal/ffi_route.nim
+++ b/ffi/internal/ffi_route.nim
@@ -12,6 +12,7 @@
 
 import std/macros
 import ../codegen/meta
+import ./ffi_codegen_common
 
 type FFIPath* = enum
   fpMethod ## A library or handle receiver, and an async result.
@@ -56,16 +57,9 @@ proc isLibReceiver(t: NimNode): bool {.compileTime.} =
     return false
   return ($t == currentLibType and currentLibType.len > 0) or isFFIHandleTypeName($t)
 
-func procIdent*(prc: NimNode): NimNode =
-  return
-    if prc[0].kind == nnkPostfix:
-      prc[0][1]
-    else:
-      prc[0]
-
 proc routeFFIProc*(prc: NimNode): FFIPath {.compileTime.} =
   ## Reads the receiver and the return type, then names the path.
-  let params = prc[3]
+  let params = prc.params
   let ret = params[0]
   let hasReceiver = params.len > 1 and isLibReceiver(params[1][1])
 
@@ -88,7 +82,7 @@ proc assertFFIPath*(prc: NimNode, want: FFIPath) {.compileTime.} =
   # A receiver is the one mismatch a caller can read straight off the signature.
   if want == fpStatic and got == fpMethod:
     error(
-      "`.ffiStatic.` proc " & name & " takes " & prc[3][1][1].repr &
+      "`.ffiStatic.` proc " & name & " takes " & prc.params[1][1].repr &
         " as its first parameter, which is the library type or an {.ffiHandle.} type. " &
         "A receiver belongs to a context. Make it an `{.ffi.}` method instead."
     )

--- a/ffi/internal/ffi_scalar.nim
+++ b/ffi/internal/ffi_scalar.nim
@@ -6,10 +6,11 @@ import ../codegen/meta
 proc buildLibReadyGuard*(
     ctxHandlerName, libTypeName: NimNode
 ): NimNode {.compileTime.} =
-  ## Rejects a request that reached the FFI thread with no library constructed.
-  ## Only for `ref` types: an `object` fallback is a usable zero value callers may
-  ## rely on, a `ref` one is nil. Sits in the handler, behind any queued ctor, so
-  ## calling without awaiting the create callback still works.
+  ## Rejects a request that reaches the FFI thread before the ctor stores a
+  ## library. The guard applies only to a `ref` type. For an `object` type the
+  ## fallback is a usable zero value, but for a `ref` type it is nil. The guard
+  ## runs in the handler, behind the ctor in the queue. Thus a host can send a
+  ## call before it waits for the create callback.
   quote:
     when `libTypeName` is ref:
       if not `ctxHandlerName`[].libReady.load():

--- a/ffi/internal/ffi_scalar.nim
+++ b/ffi/internal/ffi_scalar.nim
@@ -3,6 +3,19 @@
 import std/macros
 import ../codegen/meta
 
+proc buildLibReadyGuard*(
+    ctxHandlerName, libTypeName: NimNode
+): NimNode {.compileTime.} =
+  ## Rejects a request that reached the FFI thread with no library constructed.
+  ## Only for `ref` types: an `object` fallback is a usable zero value callers may
+  ## rely on, a `ref` one is nil. Sits in the handler, behind any queued ctor, so
+  ## calling without awaiting the create callback still works.
+  quote:
+    when `libTypeName` is ref:
+      if not `ctxHandlerName`[].libReady.load():
+        return
+          err("library is not initialized: the constructor failed or has not run yet")
+
 const scalarPodTypeNames = [
   "int", "int8", "int16", "int32", "int64", "uint", "uint8", "uint16", "uint32",
   "uint64", "byte", "float", "float32", "float64", "bool",
@@ -61,6 +74,9 @@ proc buildScalarPath*(
   handlerBody.add quote do:
     let `reqIdent` = cast[ptr FFIThreadRequest](request)
     let `ctxHandlerName` = cast[`ctxType`](reqHandler)
+
+  # ctxType is `ptr FFIContext[LibType]`; the guard needs the library type.
+  handlerBody.add(buildLibReadyGuard(ctxHandlerName, ctxType[0][1]))
 
   let helperCall = newTree(nnkCall, userProcName)
   let ctxMyLib = newDotExpr(newTree(nnkDerefExpr, ctxHandlerName), ident("myLib"))

--- a/ffi/internal/ffi_scalar.nim
+++ b/ffi/internal/ffi_scalar.nim
@@ -2,20 +2,7 @@
 
 import std/macros
 import ../codegen/meta
-
-proc buildLibReadyGuard*(
-    ctxHandlerName, libTypeName: NimNode
-): NimNode {.compileTime.} =
-  ## Rejects a request that reaches the FFI thread before the ctor stores a
-  ## library. The guard applies only to a `ref` type. For an `object` type the
-  ## fallback is a usable zero value, but for a `ref` type it is nil. The guard
-  ## runs in the handler, behind the ctor in the queue. Thus a host can send a
-  ## call before it waits for the create callback.
-  quote:
-    when `libTypeName` is ref:
-      if not `ctxHandlerName`[].libReady.load():
-        return
-          err("library is not initialized: the constructor failed or has not run yet")
+import ./ffi_codegen_common
 
 const scalarPodTypeNames = [
   "int", "int8", "int16", "int32", "int64", "uint", "uint8", "uint16", "uint32",

--- a/tests/unit/fixtures/router_dtor_wrong_shape_fixture.nim
+++ b/tests/unit/fixtures/router_dtor_wrong_shape_fixture.nim
@@ -1,0 +1,13 @@
+## Must fail: `{.ffiDtor.}` on a method shape (see tests/unit/test_ffi_router_reject.nim).
+
+import ffi, chronos
+
+type RouterRejLib = object
+  base: int
+
+declareLibrary("routerrej", RouterRejLib)
+
+proc routerrejBad*(lib: RouterRejLib): Future[Result[int, string]] {.ffiDtor.} =
+  return ok(lib.base)
+
+genBindings()

--- a/tests/unit/fixtures/router_event_wrong_shape_fixture.nim
+++ b/tests/unit/fixtures/router_event_wrong_shape_fixture.nim
@@ -1,0 +1,13 @@
+## Must fail: `{.ffiEvent.}` on a static shape (see tests/unit/test_ffi_router_reject.nim).
+
+import ffi, chronos
+
+type RouterRejLib = object
+  base: int
+
+declareLibrary("routerrej", RouterRejLib)
+
+proc routerrejBad*(n: int): Future[Result[int, string]] {.ffiEvent.} =
+  return ok(n)
+
+genBindings()

--- a/tests/unit/fixtures/router_export_wrong_shape_fixture.nim
+++ b/tests/unit/fixtures/router_export_wrong_shape_fixture.nim
@@ -1,0 +1,13 @@
+## Must fail: `{.ffiExport.}` on a static shape (see tests/unit/test_ffi_router_reject.nim).
+
+import ffi, chronos
+
+type RouterRejLib = object
+  base: int
+
+declareLibrary("routerrej", RouterRejLib)
+
+proc routerrejBad*(): Future[Result[int, string]] {.ffiExport.} =
+  return ok(1)
+
+genBindings()

--- a/tests/unit/test_ctx_after_failed_ctor.nim
+++ b/tests/unit/test_ctx_after_failed_ctor.nim
@@ -83,11 +83,11 @@ suite "{.ffi.} call after a failed constructor":
     check not ctx.isNil()
     check s.retCode.load() == int(RET_ERR)
     # `myLib` is non-nil even here: the FFI thread points it at a default-valued
-    # fallback before dispatching. `myLibOwned` is what says the ctor stored a real
+    # fallback before dispatching. `libReady` is what says the ctor stored a real
     # library.
     check not ctx[].myLib.isNil() # the fallback, not a constructed library
     check ctx[].myLib[].isNil() # ...and for a `ref` lib that fallback is nil
-    check not ctx[].myLibOwned
+    check not ctx[].libReady.load()
 
   # The synchronous return only reports that the request was accepted; the
   # rejection itself comes back through the callback.

--- a/tests/unit/test_ctx_after_failed_ctor.nim
+++ b/tests/unit/test_ctx_after_failed_ctor.nim
@@ -1,0 +1,142 @@
+import std/[atomics, os]
+import unittest2
+import results
+import ffi
+
+# A failing {.ffiCtor.} still hands the caller a live context — the ctor body
+# runs on the FFI thread, long after the C entry point returned the pointer.
+# `myLib` is not nil (the FFI thread points it at a default-valued fallback), but
+# for a `ref` library type that default IS nil, so a later {.ffi.} call used to
+# hand the user body a nil ref and crash on its first field access.
+
+type FailedCtorLib = ref object
+  marker: int
+
+# Stub the importc NimMain declareLibrary emits (plain-exe link).
+{.emit: "void libfailedctorNimMain(void) {}".}
+
+declareLibrary("failedctor", FailedCtorLib)
+
+type FailedCtorConfig {.ffi.} = object
+  shouldFail: bool
+
+proc failedctor_create*(
+    config: FailedCtorConfig
+): Future[Result[FailedCtorLib, string]] {.ffiCtor.} =
+  if config.shouldFail:
+    return err("ctor deliberately failed")
+  return ok(FailedCtorLib(marker: 1))
+
+# Both bodies touch a field, which is what faults on a nil ref receiver.
+proc failedctor_ping*(lib: FailedCtorLib): Future[Result[string, string]] {.ffi.} =
+  return ok("pong:" & $lib.marker)
+
+proc failedctor_echo*(
+    lib: FailedCtorLib, note: string
+): Future[Result[string, string]] {.ffi.} =
+  return ok(note & ":" & $lib.marker)
+
+type CallbackState = object
+  called: Atomic[bool]
+  retCode: Atomic[int]
+
+proc resetState(s: var CallbackState) =
+  s.called.store(false)
+  s.retCode.store(-1)
+
+proc recordingCallback(
+    retCode: cint, msg: ptr cchar, len: csize_t, userData: pointer
+) {.cdecl, gcsafe, raises: [].} =
+  let s = cast[ptr CallbackState](userData)
+  s[].retCode.store(int(retCode))
+  s[].called.store(true)
+
+proc encodedPtr(bytes: var seq[byte]): ptr byte =
+  if bytes.len == 0:
+    nil
+  else:
+    cast[ptr byte](addr bytes[0])
+
+proc waitCalled(s: var CallbackState): bool =
+  var tries = 0
+  while not s.called.load() and tries < 500:
+    os.sleep(5)
+    inc tries
+  s.called.load()
+
+proc createFailedCtx(s: var CallbackState): ptr FFIContext[FailedCtorLib] =
+  ## Drives the ctor down its error path and returns the still-live context.
+  resetState(s)
+  var cfg =
+    cborEncode(FailedctorCreateCtorReq(config: FailedCtorConfig(shouldFail: true)))
+  let ret =
+    failedctor_create(encodedPtr(cfg), cfg.len.csize_t, recordingCallback, addr s)
+  if ret.isNil():
+    return nil
+  discard waitCalled(s)
+  cast[ptr FFIContext[FailedCtorLib]](ret)
+
+suite "{.ffi.} call after a failed constructor":
+  test "the failed ctor reports the error but leaves the context alive":
+    var s: CallbackState
+    let ctx = createFailedCtx(s)
+    check not ctx.isNil()
+    check s.retCode.load() == int(RET_ERR)
+    # `myLib` is non-nil even here: the FFI thread points it at a default-valued
+    # fallback before dispatching. `myLibOwned` is what says the ctor stored a real
+    # library.
+    check not ctx[].myLib.isNil() # the fallback, not a constructed library
+    check ctx[].myLib[].isNil() # ...and for a `ref` lib that fallback is nil
+    check not ctx[].myLibOwned
+
+  # The synchronous return only reports that the request was accepted; the
+  # rejection itself comes back through the callback.
+  test "a no-arg call on an uninitialized library reports RET_ERR, no crash":
+    var s: CallbackState
+    let ctx = createFailedCtx(s)
+    check not ctx.isNil()
+
+    resetState(s)
+    var req = cborEncode(FailedctorPingReq())
+    let ret =
+      failedctor_ping(ctx, recordingCallback, addr s, encodedPtr(req), req.len.csize_t)
+    check ret == RET_OK
+    check waitCalled(s)
+    check s.retCode.load() == int(RET_ERR)
+
+  test "an argument-taking call on an uninitialized library reports RET_ERR, no crash":
+    var s: CallbackState
+    let ctx = createFailedCtx(s)
+    check not ctx.isNil()
+
+    resetState(s)
+    var req = cborEncode(FailedctorEchoReq(note: "hello"))
+    let ret =
+      failedctor_echo(ctx, recordingCallback, addr s, encodedPtr(req), req.len.csize_t)
+    check ret == RET_OK
+    check waitCalled(s)
+    check s.retCode.load() == int(RET_ERR)
+
+  # The guard runs on the FFI thread, behind the queued ctor, so it must not
+  # penalise a host that fires a call without first awaiting the create callback.
+  test "a call issued before the successful ctor callback still succeeds":
+    var ctorState: CallbackState
+    resetState(ctorState)
+    var cfg =
+      cborEncode(FailedctorCreateCtorReq(config: FailedCtorConfig(shouldFail: false)))
+    let raw = failedctor_create(
+      encodedPtr(cfg), cfg.len.csize_t, recordingCallback, addr ctorState
+    )
+    check not raw.isNil()
+    let ctx = cast[ptr FFIContext[FailedCtorLib]](raw)
+
+    # Deliberately no wait: the request queues behind the in-flight ctor.
+    var callState: CallbackState
+    resetState(callState)
+    var req = cborEncode(FailedctorPingReq())
+    let ret = failedctor_ping(
+      ctx, recordingCallback, addr callState, encodedPtr(req), req.len.csize_t
+    )
+    check ret == RET_OK
+    check waitCalled(callState)
+    check callState.retCode.load() == int(RET_OK)

--- a/tests/unit/test_ctx_after_failed_ctor.nim
+++ b/tests/unit/test_ctx_after_failed_ctor.nim
@@ -3,16 +3,17 @@ import unittest2
 import results
 import ffi
 
-# A failing {.ffiCtor.} still hands the caller a live context — the ctor body
-# runs on the FFI thread, long after the C entry point returned the pointer.
-# `myLib` is not nil (the FFI thread points it at a default-valued fallback), but
-# for a `ref` library type that default IS nil, so a later {.ffi.} call used to
-# hand the user body a nil ref and crash on its first field access.
+# A {.ffiCtor.} that fails still gives the caller a live context. The ctor body
+# runs on the FFI thread, long after the C entry point returns the pointer.
+# `myLib` is not nil, because the FFI thread points it at a default fallback.
+# For a `ref` library type that fallback is nil. A later {.ffi.} call therefore
+# gave the user body a nil ref and crashed on the first field access.
 
 type FailedCtorLib = ref object
   marker: int
 
-# Stub the importc NimMain declareLibrary emits (plain-exe link).
+# A stub for the NimMain proc that declareLibrary imports. The test links as a
+# plain executable.
 {.emit: "void libfailedctorNimMain(void) {}".}
 
 declareLibrary("failedctor", FailedCtorLib)
@@ -27,7 +28,7 @@ proc failedctor_create*(
     return err("ctor deliberately failed")
   return ok(FailedCtorLib(marker: 1))
 
-# Both bodies touch a field, which is what faults on a nil ref receiver.
+# Both bodies read a field. A nil ref receiver faults on that read.
 proc failedctor_ping*(lib: FailedCtorLib): Future[Result[string, string]] {.ffi.} =
   return ok("pong:" & $lib.marker)
 
@@ -65,7 +66,7 @@ proc waitCalled(s: var CallbackState): bool =
   s.called.load()
 
 proc createFailedCtx(s: var CallbackState): ptr FFIContext[FailedCtorLib] =
-  ## Drives the ctor down its error path and returns the still-live context.
+  ## Sends the ctor down its error path and returns the context, which stays alive.
   resetState(s)
   var cfg =
     cborEncode(FailedctorCreateCtorReq(config: FailedCtorConfig(shouldFail: true)))
@@ -82,15 +83,15 @@ suite "{.ffi.} call after a failed constructor":
     let ctx = createFailedCtx(s)
     check not ctx.isNil()
     check s.retCode.load() == int(RET_ERR)
-    # `myLib` is non-nil even here: the FFI thread points it at a default-valued
-    # fallback before dispatching. `libReady` is what says the ctor stored a real
-    # library.
-    check not ctx[].myLib.isNil() # the fallback, not a constructed library
-    check ctx[].myLib[].isNil() # ...and for a `ref` lib that fallback is nil
+    # `myLib` is not nil even here. The FFI thread points it at a default
+    # fallback before it dispatches the request. `libReady` shows if the ctor
+    # stored a real library.
+    check not ctx[].myLib.isNil() # the fallback, not a real library
+    check ctx[].myLib[].isNil() # for a `ref` lib the fallback is nil
     check not ctx[].libReady.load()
 
-  # The synchronous return only reports that the request was accepted; the
-  # rejection itself comes back through the callback.
+  # The synchronous return only reports that the FFI thread accepted the
+  # request. The callback delivers the rejection.
   test "a no-arg call on an uninitialized library reports RET_ERR, no crash":
     var s: CallbackState
     let ctx = createFailedCtx(s)
@@ -117,8 +118,8 @@ suite "{.ffi.} call after a failed constructor":
     check waitCalled(s)
     check s.retCode.load() == int(RET_ERR)
 
-  # The guard runs on the FFI thread, behind the queued ctor, so it must not
-  # penalise a host that fires a call without first awaiting the create callback.
+  # The guard runs on the FFI thread, behind the ctor in the queue. Thus a host
+  # can send a call before it waits for the create callback.
   test "a call issued before the successful ctor callback still succeeds":
     var ctorState: CallbackState
     resetState(ctorState)
@@ -130,7 +131,7 @@ suite "{.ffi.} call after a failed constructor":
     check not raw.isNil()
     let ctx = cast[ptr FFIContext[FailedCtorLib]](raw)
 
-    # Deliberately no wait: the request queues behind the in-flight ctor.
+    # No wait here, on purpose: the request goes into the queue behind the ctor.
     var callState: CallbackState
     resetState(callState)
     var req = cborEncode(FailedctorPingReq())

--- a/tests/unit/test_ffi_context.nim
+++ b/tests/unit/test_ffi_context.nim
@@ -329,9 +329,9 @@ suite "sendRequestToFFIThread":
     check callbackErr(d) == "intentional failure"
 
   test "seq[byte] result rides as a CBOR byte string, not raw bytes":
-    # A `seq[byte]` return must be CBOR, the same as every other reply. The
-    # generated C, C++ and Rust decoders call `nimffi_dec_bytes` on the payload
-    # and reject a raw reply with "value encoded in non-canonical form".
+    # A `seq[byte]` return must be CBOR, the same as every other reply. The C,
+    # C++ and Rust decoders call `nimffi_dec_bytes` on the payload. They reject
+    # a raw reply with the error "value encoded in non-canonical form".
     var d: CallbackData
     initCallbackData(d)
     defer:
@@ -349,7 +349,7 @@ suite "sendRequestToFFIThread":
     waitCallback(d)
     check d.retCode == RET_OK
     let reply = callbackBytes(d)
-    # The wire contract is a CBOR byte-string header (major type 2, 0x40..0x5b)
+    # The wire contract is a CBOR byte-string header (major type 2, 0x40..0x5b),
     # and then the 4 payload bytes.
     check reply.len == 5
     check reply[0] == 0x44'u8

--- a/tests/unit/test_ffi_router.nim
+++ b/tests/unit/test_ffi_router.nim
@@ -1,0 +1,161 @@
+## `{.ffi.}` picks the path from the shape of the signature. This file writes one
+## proc per path with the same pragma, then calls each generated C wrapper.
+
+import std/[atomics, os]
+import unittest2
+import results
+import ffi
+
+type RouterLib = ref object
+  marker: int
+
+type RouterTick {.ffi.} = object
+  count: int
+
+# A stub for the NimMain proc that declareLibrary imports. The test links as a
+# plain executable.
+{.emit: "void librouterNimMain(void) {}".}
+
+declareLibrary("router", RouterLib)
+
+proc router_create*(seed: int): Future[Result[RouterLib, string]] {.ffiCtor.} =
+  return ok(RouterLib(marker: seed))
+
+# A library receiver, so the router picks the context method.
+proc router_marker*(lib: RouterLib): Future[Result[int, string]] {.ffi.} =
+  return ok(lib.marker)
+
+# No receiver, so the router picks the static call.
+proc router_version*(): Future[Result[string, string]] {.ffi.} =
+  return ok("router v1")
+
+# No arguments and a plain return type, so the router picks the synchronous
+# export.
+proc router_alive*(): int {.ffi.} =
+  7
+
+# A library receiver and no result, so the router picks the destructor.
+proc router_destroy*(lib: RouterLib) {.ffi.} =
+  discard
+
+# A payload parameter and no result, so the router picks the event. The leading
+# literal sets the wire name, exactly as {.ffiEvent.} accepts it.
+proc onRouterTick*(evt: RouterTick) {.ffi: "on_router_tick".} =
+  discard
+
+# The event queue is per-thread, so only a handler on the FFI thread can fire.
+proc router_tick*(lib: RouterLib): Future[Result[int, string]] {.ffi.} =
+  onRouterTick(RouterTick(count: 3))
+  return ok(lib.marker)
+
+type CallbackState = object
+  called: Atomic[bool]
+  retCode: Atomic[int]
+  msg: string
+
+proc resetState(s: var CallbackState) =
+  s.called.store(false)
+  s.retCode.store(-1)
+  s.msg = ""
+
+proc recordingCallback(
+    retCode: cint, msg: ptr cchar, len: csize_t, userData: pointer
+) {.cdecl, gcsafe, raises: [].} =
+  let s = cast[ptr CallbackState](userData)
+  if not msg.isNil() and len > 0:
+    s[].msg = newString(int(len))
+    copyMem(addr s[].msg[0], msg, int(len))
+  s[].retCode.store(int(retCode))
+  s[].called.store(true)
+
+proc encodedPtr(bytes: var seq[byte]): ptr byte =
+  if bytes.len == 0:
+    nil
+  else:
+    cast[ptr byte](addr bytes[0])
+
+proc waitCalled(s: var CallbackState): bool =
+  var tries = 0
+  while not s.called.load() and tries < 500:
+    os.sleep(5)
+    inc tries
+  s.called.load()
+
+proc createCtx(s: var CallbackState): pointer =
+  resetState(s)
+  var cfg = cborEncode(RouterCreateCtorReq(seed: 42))
+  let ret = router_create(encodedPtr(cfg), cfg.len.csize_t, recordingCallback, addr s)
+  discard waitCalled(s)
+  ret
+
+suite "{.ffi.} routes on the shape of the signature":
+  test "a library receiver routes to the context method":
+    var s: CallbackState
+    let ctx = createCtx(s)
+    check not ctx.isNil()
+    defer:
+      discard router_destroy(ctx)
+
+    resetState(s)
+    var req = cborEncode(RouterMarkerReq())
+    check router_marker(
+      cast[ptr FFIContext[RouterLib]](ctx),
+      recordingCallback,
+      addr s,
+      encodedPtr(req),
+      req.len.csize_t,
+    ) == RET_OK
+    check waitCalled(s)
+    check s.retCode.load() == int(RET_OK)
+    check cborDecode(cast[seq[byte]](s.msg), int).value == 42
+
+  test "no receiver routes to the static call, which needs no context":
+    var s: CallbackState
+    resetState(s)
+    var req = cborEncode(RouterVersionReq())
+    check router_version(recordingCallback, addr s, encodedPtr(req), req.len.csize_t) ==
+      RET_OK
+    check waitCalled(s)
+    check s.retCode.load() == int(RET_OK)
+    check cborDecode(cast[seq[byte]](s.msg), string).value == "router v1"
+
+  test "no arguments and a plain return type route to the synchronous export":
+    # The export returns its value directly, with no context and no callback.
+    check router_alive() == cint(7)
+
+  test "a payload parameter and no result route to the event":
+    var s: CallbackState
+    let ctx = createCtx(s)
+    check not ctx.isNil()
+    defer:
+      discard router_destroy(ctx)
+
+    var evt: CallbackState
+    resetState(evt)
+    check router_add_event_listener(
+      cast[ptr FFIContext[RouterLib]](ctx),
+      "on_router_tick".cstring,
+      recordingCallback,
+      addr evt,
+    ) != 0'u64
+
+    resetState(s)
+    var req = cborEncode(RouterTickReq())
+    check router_tick(
+      cast[ptr FFIContext[RouterLib]](ctx),
+      recordingCallback,
+      addr s,
+      encodedPtr(req),
+      req.len.csize_t,
+    ) == RET_OK
+    check waitCalled(evt)
+    let env = cborDecode(cast[seq[byte]](evt.msg), EventEnvelope[RouterTick])
+    check env.value.eventType == "on_router_tick"
+    check env.value.payload.count == 3
+
+  test "a library receiver and no result route to the destructor":
+    var s: CallbackState
+    let ctx = createCtx(s)
+    check not ctx.isNil()
+    check router_destroy(ctx) == RET_OK
+    check router_destroy(nil) == RET_ERR

--- a/tests/unit/test_ffi_router.nim
+++ b/tests/unit/test_ffi_router.nim
@@ -34,6 +34,21 @@ proc router_version*(): Future[Result[string, string]] {.ffi.} =
 proc router_alive*(): int {.ffi.} =
   7
 
+# `int` is pointer-wide, so the export must not narrow it to a C `int`.
+proc router_big*(): int {.ffi.} =
+  int(high(int32)) + 1
+
+proc router_banner*(): string {.ffi.} =
+  "router banner"
+
+var routerBeats = 0
+
+proc router_beat*() {.ffi.} =
+  inc routerBeats
+
+proc router_raises*(): int {.ffi.} =
+  raise newException(ValueError, "boom")
+
 # A library receiver and no result, so the router picks the destructor.
 proc router_destroy*(lib: RouterLib) {.ffi.} =
   discard
@@ -121,7 +136,21 @@ suite "{.ffi.} routes on the shape of the signature":
 
   test "no arguments and a plain return type route to the synchronous export":
     # The export returns its value directly, with no context and no callback.
-    check router_alive() == cint(7)
+    check router_alive() == clonglong(7)
+
+  test "an int export keeps its full width across the C ABI":
+    check router_big() == clonglong(int32.high) + 1
+
+  test "a string export returns bytes the caller can read":
+    check $router_banner() == "router banner"
+
+  test "a no-return export routes to a void C symbol":
+    let before = routerBeats
+    router_beat()
+    check routerBeats == before + 1
+
+  test "an exception in the body never crosses the C ABI":
+    check router_raises() == clonglong(0)
 
   test "a payload parameter and no result route to the event":
     var s: CallbackState

--- a/tests/unit/test_ffi_router_reject.nim
+++ b/tests/unit/test_ffi_router_reject.nim
@@ -1,0 +1,39 @@
+## `{.ffi.}` routes on the shape, but the named pragmas still assert it. Each
+## fixture compiles in a child `nim check`, so its expected failure is an
+## assertion rather than this file's own compile error.
+
+import std/[os, osproc, strutils, compilesettings]
+import unittest2
+
+const
+  fixtureDir = currentSourcePath().parentDir() / "fixtures"
+  nimExe = getCurrentCompilerExe()
+  ffiSearchPaths = querySettingSeq(searchPaths)
+
+proc checkFixture(name: string): tuple[output: string, exitCode: int] =
+  let cacheDir = getTempDir() / "ffi_router_reject_cache" / name
+  var cmd = quoteShell(nimExe) & " check --hints:off --warnings:off"
+  for p in ffiSearchPaths:
+    cmd.add(" --path:" & quoteShell(p))
+  cmd.add(" --nimcache:" & quoteShell(cacheDir))
+  cmd.add(" " & quoteShell(fixtureDir / (name & "_fixture.nim")))
+  execCmdEx(cmd)
+
+suite "a named pragma asserts the shape it claims":
+  test "{.ffiExport.} on a static shape names the proc and the right pragma":
+    let (output, code) = checkFixture("router_export_wrong_shape")
+    check code != 0
+    check output.contains("routerrejBad")
+    check output.contains("`.ffiStatic.`")
+
+  test "{.ffiDtor.} on a method shape names the proc and the right pragma":
+    let (output, code) = checkFixture("router_dtor_wrong_shape")
+    check code != 0
+    check output.contains("routerrejBad")
+    check output.contains("`.ffi.`")
+
+  test "{.ffiEvent.} on a static shape names the proc and the right pragma":
+    let (output, code) = checkFixture("router_event_wrong_shape")
+    check code != 0
+    check output.contains("routerrejBad")
+    check output.contains("`.ffiStatic.`")

--- a/tests/unit/test_rust_codegen.nim
+++ b/tests/unit/test_rust_codegen.nim
@@ -44,10 +44,11 @@ suite "nimTypeToRust: strings, pointers and containers":
     check nimTypeToRust("echoRequest") == "EchoRequest"
 
 suite "generateTypesRs: seq[byte] rides as a CBOR byte string":
-  ## A `seq[byte]` in a struct that is a `seq` element became a `Vec<u8>` integer
-  ## array (CBOR major type 4). The Nim decoder rejects that array with "value
-  ## encoded in non-canonical form". ByteBuf makes ciborium write a byte string
-  ## (major type 2), the same as every other backend.
+  ## A struct with a `seq[byte]` field can be a `seq` element. For that shape the
+  ## Rust backend wrote a `Vec<u8>` integer array (CBOR major type 4). The Nim
+  ## decoder rejects that array with the error "value encoded in non-canonical
+  ## form". ByteBuf makes ciborium write a byte string (major type 2), the same
+  ## as every other backend.
   setup:
     let types = @[
       FFITypeMeta(

--- a/tests/unit/test_wire_compat.nim
+++ b/tests/unit/test_wire_compat.nim
@@ -29,7 +29,7 @@ type WireBytesEntry {.ffi.} = object
 
 type WireNestedBytes {.ffi.} = object
   ## A `seq[byte]` in a struct that is a `seq` element. This shape broke the
-  ## Rust backend, which wrote an integer array in place of a ByteBuf.
+  ## Rust backend. The backend wrote an integer array in place of a ByteBuf.
   entries: seq[WireBytesEntry]
 
 proc toHex(bytes: openArray[byte]): string =
@@ -105,7 +105,7 @@ suite "wire format — seq[byte]":
 
 suite "wire format — seq[byte] nested in a seq-of-struct":
   ## A `seq[byte]` field in a struct that is a `seq` element must stay a CBOR
-  ## byte string (major type 2) at depth. Every backend must match this wire
+  ## byte string (major type 2) at depth. Every backend must obey this wire
   ## contract. The Rust generator broke it and wrote a `Vec<u8>` integer array.
   test "each nested seq[byte] rides as a byte string, request and response alike":
     let v = WireNestedBytes(
@@ -118,8 +118,8 @@ suite "wire format — seq[byte] nested in a seq-of-struct":
     check toHex(bytes) ==
       "a167656e747269657382a2626964627330646461746142aabba26269646273316464617461" &
       "43010203"
-    # The payloads must use byte-string headers (0x42 = bytes(2), 0x43 =
-    # bytes(3)), not array headers (0x82 or 0x83).
+    # The payloads must use a byte-string header (0x42 = bytes(2), 0x43 =
+    # bytes(3)). An array header (0x82 or 0x83) is wrong.
     check "6461746142aabb" in toHex(bytes) # "data" + 0x42 <AA BB>
     check "6461746143010203" in toHex(bytes) # "data" + 0x43 <01 02 03>
     let back = cborDecode(bytes, WireNestedBytes)


### PR DESCRIPTION
This branch brings the 0.2 line onto master. `master` is an ancestor of it, so the diff against master is purely additive.

### `{.ffi.}` picks the path from the shape of the signature

`ffi/internal/ffi_route.nim` reads the receiver and the return type of a proc, then picks one of five paths. One pragma now covers what needed five.

| Shape | Path |
|---|---|
| The first parameter is the library type or an `{.ffiHandle.}` type | Context method |
| No receiver, and the result is `Future[Result[T, string]]` | Static call |
| No parameters, and the result is a plain Nim type | Synchronous export |
| A library receiver, and no result or `Future[void]` | Destructor |
| A payload parameter, and no result | Event |

`{.ffiStatic.}`, `{.ffiExport.}`, `{.ffiDtor.}` and `{.ffiEvent.}` still work. Each one now asserts its own shape and names the correct pragma when the shape does not match.

`{.ffiCtor.}` stays explicit, because its shape is not free. A ctor differs from a static call by one token: the type inside `Result`. A router would give the ctor ABI to a static call that returns the library type.

### `{.ffiExport.}`, a simple synchronous C export

No context, no callback and no CBOR. The host loads the symbol with `dlopen` and `dlsym`, then calls it. The macro maps the Nim return type to the C ABI and injects `initializeLibrary()`, so the host never calls NimMain.

Each wrapper carries `raises: []` and catches every exception of the body, because an exception must not cross the C ABI. A return type with no C mapping is a compile error, rather than a symbol that no host can call. `int` maps to `long long`, so a 64-bit value keeps its full width.

A `string` return rides in a buffer that belongs to the calling thread. The bytes stay valid until that same thread calls another string export.

### Pooled contexts are recycled, not destroyed

Each pool slot builds its worker thread, its event thread and its signal fds once, then reuses them. The `ffiDtor` asks the FFI thread to drain the in-flight handlers, free the library and return the slot. The threads stay alive.

This bounds the `ThreadSignalPtr` fds at `MaxFFIContexts * (signals per context)`. Before, every create/destroy cycle churned about 6 fds, so fd numbers climbed past `FD_SETSIZE` and the `select()` of `waitSync` failed with `EINVAL` under load.

A recycle also fails every request that is still queued for that slot. Such a request carries the `userData` of a host that is gone, so it must never reach a handler, and it must never run against the library of the next owner.

### Multi-parameter `{.ffiEvent.}`

Two or more parameters are bundled into a synthesised, registered envelope object named `<WireNamePascalCase>Payload`, whose fields are the parameters. A single parameter still rides the wire directly, so this is backwards compatible. The foreign bindings gain the envelope as a first-class struct plus a typed handler. The timer example gains `on_job_scheduled(jobId, willRunCount)` to exercise the path.

### Fixes

- A `{.ffi.}` call against a `ref` library whose `{.ffiCtor.}` never stored a library is now rejected with a clear error. Before, the user body received a nil ref and faulted on its first field access. The guard runs in the generated handler, behind the ctor in the queue, so a host that calls without awaiting the create callback still succeeds.
- `add_event_listener` and `remove_event_listener` now call `initializeLibrary()`. They run on the foreign caller thread and allocate Nim memory, so the GC of that thread must be ready first.
- Request ids are `cstring` literals built at compile time. Before, `$T` allocated a Nim string on the foreign caller thread.

### Version

`ffi.nimble` keeps master's `0.3.0`. Bump it when you cut a release, not here.

### Known limits

- A recycle that times out strands its pool slot. `requestRecycle` reports the error, but nothing escalates to a full teardown, so the slot stays claimed. This needs a distinct "recycle timed out" outcome in the lifecycle.
- `sendRequestToFFIThread` reads the lifecycle, then pushes. A thread that is preempted between those two steps can still push into a slot that a new owner has claimed. A generation stamp on the request would close that gap.
- `ffi/internal/ffi_macro.nim` is near 2000 lines and holds every codegen path. It wants a split into per-path modules.

### How to land

The history is linear: 8 commits, no merge commit. `master` is an ancestor, so `git push origin integrate/master-into-v0.2:master` lands it as a fast-forward and keeps every commit. A squash or a rebase through the GitHub UI would rewrite that history.

`fix/ffi-call-after-failed-ctor` is a cherry-pick source, not an ancestor, so GitHub will not show it as merged. Delete it by hand.

`release/v0.2` stays frozen at `v0.2.2-rc.0`. That tag is what logos-delivery pins today, and this branch already contains it.
