### PR TITLE
fix(ffi): run the {.ffiDtor.} teardown on the recycle path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ PLAN.md
 # Compiled test binaries (extensionless executables, also under tests/unit/)
 tests/unit/test_*
 !tests/unit/test_*.nim
+!tests/unit/test_*.nim.cfg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,22 @@ All notable changes to this project are documented in this file.
   router would silently give it the ctor ABI instead.
 
 ### Fixed
+- A `{.ffiDtor.}` body now runs when the context is recycled. The C destructor
+  the macro emits calls `recycleFFIContext`, but only the thread-exit epilogue of
+  the full-shutdown path awaited the teardown hook, and no generated wrapper
+  takes that path. A dtor body was therefore dead code, and a library kept every
+  loop it had spawned itself: the pooled worker survives a recycle by design, so
+  its dispatcher went on servicing them, invisible to a host whose handle was
+  gone. The recycle handler now awaits the hook after it drains the in-flight
+  requests and before it frees the library, so the dtor still sees `myLib` and
+  its events still reach the listeners. It runs only once a constructor has
+  stored a library, because `myLib` otherwise points at the zero-valued
+  fallback. At `-d:ffiTeardownTimeoutMs` (10 s by default) a slow body is asked
+  to cancel, and `RecycleWaitTimeout` covers that budget; a body that ignores
+  cancellation still holds the recycle, so keep the dtor cancellable. The slot
+  is released on every exit path, including a raise out of the dtor. Consumers
+  that already ship a non-empty dtor body should read it again: it went from
+  dead code to live shutdown code.
 - A `{.ffi.}` call against a `ref` library type whose `{.ffiCtor.}` never stored
   a library (it failed, or none ran) no longer crashes. Without a constructed
   library the FFI thread points `myLib` at a default-valued fallback; for an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,22 +49,14 @@ All notable changes to this project are documented in this file.
   router would silently give it the ctor ABI instead.
 
 ### Fixed
-- A `{.ffiDtor.}` body now runs when the context is recycled. The C destructor
-  the macro emits calls `recycleFFIContext`, but only the thread-exit epilogue of
-  the full-shutdown path awaited the teardown hook, and no generated wrapper
-  takes that path. A dtor body was therefore dead code, and a library kept every
-  loop it had spawned itself: the pooled worker survives a recycle by design, so
-  its dispatcher went on servicing them, invisible to a host whose handle was
-  gone. The recycle handler now awaits the hook after it drains the in-flight
-  requests and before it frees the library, so the dtor still sees `myLib` and
-  its events still reach the listeners. It runs only once a constructor has
-  stored a library, because `myLib` otherwise points at the zero-valued
-  fallback. At `-d:ffiTeardownTimeoutMs` (10 s by default) a slow body is asked
-  to cancel, and `RecycleWaitTimeout` covers that budget; a body that ignores
-  cancellation still holds the recycle, so keep the dtor cancellable. The slot
-  is released on every exit path, including a raise out of the dtor. Consumers
-  that already ship a non-empty dtor body should read it again: it went from
-  dead code to live shutdown code.
+- A `{.ffiDtor.}` body now runs when the context is recycled. Only the
+  thread-exit epilogue awaited the teardown hook, and the emitted C destructor
+  never takes that path, so a dtor body was dead code and the library kept every
+  loop it had spawned on the pooled worker. The recycle handler now awaits the
+  hook between the drain and `freeLib`, once a constructor has stored a library.
+  A body that overruns `-d:ffiTeardownTimeoutMs` (10 s) is cancelled, so keep the
+  dtor cancellable; the slot is released on every exit path. Consumers shipping a
+  non-empty dtor body should read it again: it is live now.
 - A `{.ffi.}` call against a `ref` library type whose `{.ffiCtor.}` never stored
   a library (it failed, or none ran) no longer crashes. Without a constructed
   library the FFI thread points `myLib` at a default-valued fallback; for an

--- a/ffi/event_thread.nim
+++ b/ffi/event_thread.nim
@@ -116,10 +116,8 @@ proc eventRun[T](ctx: ptr FFIContext[T]) {.async.} =
       if not notifiedStuck and ctx.eventQueueStuck.load():
         onNotResponding(ctx)
         notifiedStuck = true
-      # A recycle parks the FFI loop in the library teardown on purpose, so the
-      # heartbeat is meant to stall there. Reporting it would cry wolf on every
-      # shutdown, and the matching onResponding could never reach a host whose
-      # listeners clearListeners is about to drop.
+      # A recycle parks the loop in the teardown on purpose; a stall there is
+      # not a fault, and clearListeners drops the onResponding that would follow.
       if ctx.lifecycle.load() == CtxLifecycle.Active:
         hb.check(ctx)
 

--- a/ffi/event_thread.nim
+++ b/ffi/event_thread.nim
@@ -116,7 +116,12 @@ proc eventRun[T](ctx: ptr FFIContext[T]) {.async.} =
       if not notifiedStuck and ctx.eventQueueStuck.load():
         onNotResponding(ctx)
         notifiedStuck = true
-      hb.check(ctx)
+      # A recycle parks the FFI loop in the library teardown on purpose, so the
+      # heartbeat is meant to stall there. Reporting it would cry wolf on every
+      # shutdown, and the matching onResponding could never reach a host whose
+      # listeners clearListeners is about to drop.
+      if ctx.lifecycle.load() == CtxLifecycle.Active:
+        hb.check(ctx)
 
   # Catch anything enqueued between the last drain and the FFI thread's exit.
   ctx.drainEventQueue()

--- a/ffi/ffi_context.nim
+++ b/ffi/ffi_context.nim
@@ -73,10 +73,19 @@ const RecycleTimeoutMs* {.intdefine: "ffiRecycleTimeoutMs".} = 1500
   ## again. Override with `-d:ffiRecycleTimeoutMs=<ms>`.
 const RecycleTimeout* = RecycleTimeoutMs.milliseconds
 
+const TeardownTimeoutMs* {.intdefine: "ffiTeardownTimeoutMs".} = 10000
+  ## Bounds one `{.ffiDtor.}` teardown. A real library stop (network switch,
+  ## discovery loops, storage threads) outlasts a drain round, so this gets its
+  ## own budget. Override with `-d:ffiTeardownTimeoutMs=<ms>`.
+const TeardownTimeout* = TeardownTimeoutMs.milliseconds
+
 const
-  RecycleWaitTimeout* = 2 * RecycleTimeout + 2.seconds
-    ## Caller-side bound for synchronous recycle. It covers both drain rounds
-    ## plus slack, so it only fires when the worker itself is wedged.
+  RecycleWaitTimeout* = 2 * RecycleTimeout + TeardownTimeout + 2.seconds
+    ## Caller-side bound for synchronous recycle. It covers both drain rounds,
+    ## the teardown hook and slack, so it only fires when the worker itself is
+    ## wedged. The generated C destructor blocks its calling thread for up to
+    ## this long — 15 s at the default budgets — so a host should not call it
+    ## from a thread that must stay responsive.
   EventThreadTickInterval* = 1.seconds
   FFIHeartbeatStartDelay* = 10.seconds
   FFIHeartbeatStaleThreshold* = 1.seconds
@@ -248,8 +257,10 @@ proc requestRecycle*[T](ctx: ptr FFIContext[T]): Result[void, string] =
     return err("requestRecycle: recycle did not complete in time")
   ok()
 
-## Per-thread exit wait before stopAndJoinThreads leaks ctx rather than hanging; async
-## `{.ffiDtor.}` teardown can outlast the default. Override `-d:ffiThreadExitTimeoutMs=<ms>`.
+## Per-thread exit wait before stopAndJoinThreads leaks ctx rather than hanging. Kept
+## short so a wedged worker fails fast; raise it past `ffiTeardownTimeoutMs` when the
+## async `{.ffiDtor.}` teardown the exit epilogue awaits is slow.
+## Override `-d:ffiThreadExitTimeoutMs=<ms>`.
 const ThreadExitTimeoutMs* {.intdefine: "ffiThreadExitTimeoutMs".} = 1500
 const ThreadExitTimeout* = ThreadExitTimeoutMs.milliseconds
 

--- a/ffi/ffi_context.nim
+++ b/ffi/ffi_context.nim
@@ -74,18 +74,15 @@ const RecycleTimeoutMs* {.intdefine: "ffiRecycleTimeoutMs".} = 1500
 const RecycleTimeout* = RecycleTimeoutMs.milliseconds
 
 const TeardownTimeoutMs* {.intdefine: "ffiTeardownTimeoutMs".} = 10000
-  ## Bounds one `{.ffiDtor.}` teardown. A real library stop (network switch,
-  ## discovery loops, storage threads) outlasts a drain round, so this gets its
-  ## own budget. Override with `-d:ffiTeardownTimeoutMs=<ms>`.
+  ## Cancels a `{.ffiDtor.}` teardown that overruns; a real library stop outlasts
+  ## a drain round. Override with `-d:ffiTeardownTimeoutMs=<ms>`.
 const TeardownTimeout* = TeardownTimeoutMs.milliseconds
 
 const
   RecycleWaitTimeout* = 2 * RecycleTimeout + TeardownTimeout + 2.seconds
-    ## Caller-side bound for synchronous recycle. It covers both drain rounds,
-    ## the teardown hook and slack, so it only fires when the worker itself is
-    ## wedged. The generated C destructor blocks its calling thread for up to
-    ## this long — 15 s at the default budgets — so a host should not call it
-    ## from a thread that must stay responsive.
+    ## Caller-side bound for synchronous recycle: both drain rounds, the teardown
+    ## hook and slack, so it only fires when the worker itself is wedged. The
+    ## generated C destructor blocks its caller this long — 15 s by default.
   EventThreadTickInterval* = 1.seconds
   FFIHeartbeatStartDelay* = 10.seconds
   FFIHeartbeatStaleThreshold* = 1.seconds
@@ -258,9 +255,8 @@ proc requestRecycle*[T](ctx: ptr FFIContext[T]): Result[void, string] =
   ok()
 
 ## Per-thread exit wait before stopAndJoinThreads leaks ctx rather than hanging. Kept
-## short so a wedged worker fails fast; raise it past `ffiTeardownTimeoutMs` when the
-## async `{.ffiDtor.}` teardown the exit epilogue awaits is slow.
-## Override `-d:ffiThreadExitTimeoutMs=<ms>`.
+## short so a wedged worker fails fast; raise it past `ffiTeardownTimeoutMs` for a slow
+## `{.ffiDtor.}`. Override `-d:ffiThreadExitTimeoutMs=<ms>`.
 const ThreadExitTimeoutMs* {.intdefine: "ffiThreadExitTimeoutMs".} = 1500
 const ThreadExitTimeout* = ThreadExitTimeoutMs.milliseconds
 

--- a/ffi/ffi_thread.nim
+++ b/ffi/ffi_thread.nim
@@ -126,12 +126,40 @@ proc rejectQueuedRequests[T](ctx: ptr FFIContext[T]) =
       error "rejecting a queued request raised", error = e.msg
     request = nextRequest
 
+proc runTeardown[T](ctx: ptr FFIContext[T]) {.async.} =
+  ## Awaits the library's `{.ffiDtor.}` body, the only place that stops the work
+  ## the library spawned itself. `libReady` gates it: without a constructed
+  ## library `myLib` points at the worker's zero-valued fallback, which is nil
+  ## for a `ref` type, so the body would fault on its first field access.
+  ## `TeardownTimeout` asks a slow body to cancel; one that ignores cancellation
+  ## still holds the recycle.
+  let teardown = ffiTeardownHook[T]()
+  if teardown.isNil() or ctx.myLib.isNil() or not ctx.libReady.load():
+    return
+  try:
+    let done = await teardown(ctx.myLib).withTimeout(TeardownTimeout)
+    if not done:
+      error "library teardown cancelled at the timeout; releasing the library",
+        timeoutMs = TeardownTimeoutMs
+  except CatchableError as e:
+    error "library teardown raised", error = e.msg
+
 proc recycleContext[T](
     ctx: ptr FFIContext[T], ongoing: ptr seq[Future[void]]
 ) {.async.} =
-  ## Drain in-flight handlers, free the lib, clear listeners and release the
-  ## slot — all WITHOUT stopping the worker/event threads, so the next
-  ## createFFIContext reuses them (no fd churn). Then fire recycleDoneSignal.
+  ## Drain in-flight handlers, run the library teardown, free the lib, clear
+  ## listeners, then fire recycleDoneSignal and release the slot — all WITHOUT
+  ## stopping the worker/event threads, so the next createFFIContext reuses them
+  ## (no fd churn).
+  # Deferred so a raise out of the library teardown cannot strand the slot in
+  # `Recycling`. Fire before the release: a thread that claims the freed slot
+  # first would otherwise take this fire as the answer to its own recycle.
+  defer:
+    let fireRes = ctx.recycleDoneSignal.fireSync()
+    if fireRes.isErr():
+      error "failed to fire recycleDoneSignal", err = fireRes.error
+    ctx.releaseClaim()
+
   ongoing[].keepItIf(not it.finished())
   var drained = ongoing[].len == 0
   if not drained:
@@ -141,17 +169,13 @@ proc recycleContext[T](
       fut.cancelSoon()
     drained = await allFutures(ongoing[]).withTimeout(RecycleTimeout)
 
+  # Between the drain and freeLib: the hook still needs `myLib` and its listeners.
+  await runTeardown(ctx)
+
   freeLib(ctx)
   clearListeners(ctx[].eventRegistry)
   rejectQueuedRequests(ctx)
   ongoing[].setLen(0)
-
-  # Fire before the release: a thread that claims the freed slot first would
-  # otherwise take this fire as the answer to its own recycle.
-  let fireRes = ctx.recycleDoneSignal.fireSync()
-  if fireRes.isErr():
-    error "failed to fire recycleDoneSignal", err = fireRes.error
-  ctx.releaseClaim()
 
 var ffiEventQueueSignalPtr {.threadvar.}: ThreadSignalPtr
   # Stashed so the hook has no closure env.
@@ -252,12 +276,7 @@ proc ffiThreadBody[T](ctx: ptr FFIContext[T]) {.thread.} =
       except CatchableError as e:
         error "draining pending FFI requests on shutdown raised", error = e.msg
 
-    # Run the library's async {.ffiDtor.} shutdown before join if one exists and a request populated `myLib`; exceptions logged, never propagated.
-    let teardown = ffiTeardownHook[T]()
-    if not teardown.isNil() and not ctx.myLib.isNil():
-      try:
-        await teardown(ctx.myLib)
-      except CatchableError as e:
-        error "library teardown raised on shutdown", error = e.msg
+    # Same teardown the recycle path runs; here it precedes the thread join.
+    await runTeardown(ctx)
 
   waitFor ffiRun(ctx)

--- a/ffi/ffi_thread.nim
+++ b/ffi/ffi_thread.nim
@@ -127,12 +127,8 @@ proc rejectQueuedRequests[T](ctx: ptr FFIContext[T]) =
     request = nextRequest
 
 proc runTeardown[T](ctx: ptr FFIContext[T]) {.async.} =
-  ## Awaits the library's `{.ffiDtor.}` body, the only place that stops the work
-  ## the library spawned itself. `libReady` gates it: without a constructed
-  ## library `myLib` points at the worker's zero-valued fallback, which is nil
-  ## for a `ref` type, so the body would fault on its first field access.
-  ## `TeardownTimeout` asks a slow body to cancel; one that ignores cancellation
-  ## still holds the recycle.
+  ## Awaits the library's `{.ffiDtor.}` body. `libReady` gates it: without a ctor
+  ## `myLib` is the zero-valued fallback, nil for a `ref` type.
   let teardown = ffiTeardownHook[T]()
   if teardown.isNil() or ctx.myLib.isNil() or not ctx.libReady.load():
     return
@@ -151,9 +147,8 @@ proc recycleContext[T](
   ## listeners, then fire recycleDoneSignal and release the slot — all WITHOUT
   ## stopping the worker/event threads, so the next createFFIContext reuses them
   ## (no fd churn).
-  # Deferred so a raise out of the library teardown cannot strand the slot in
-  # `Recycling`. Fire before the release: a thread that claims the freed slot
-  # first would otherwise take this fire as the answer to its own recycle.
+  # Deferred: a raise out of the teardown must not strand the slot. Fire before
+  # the release, or a thread claiming the slot would take this as its own answer.
   defer:
     let fireRes = ctx.recycleDoneSignal.fireSync()
     if fireRes.isErr():
@@ -169,7 +164,7 @@ proc recycleContext[T](
       fut.cancelSoon()
     drained = await allFutures(ongoing[]).withTimeout(RecycleTimeout)
 
-  # Between the drain and freeLib: the hook still needs `myLib` and its listeners.
+  # Before freeLib: the hook still needs `myLib` and its listeners.
   await runTeardown(ctx)
 
   freeLib(ctx)
@@ -276,7 +271,6 @@ proc ffiThreadBody[T](ctx: ptr FFIContext[T]) {.thread.} =
       except CatchableError as e:
         error "draining pending FFI requests on shutdown raised", error = e.msg
 
-    # Same teardown the recycle path runs; here it precedes the thread join.
     await runTeardown(ctx)
 
   waitFor ffiRun(ctx)

--- a/ffi/internal/ffi_macro.nim
+++ b/ffi/internal/ffi_macro.nim
@@ -1740,13 +1740,10 @@ proc buildFFIDtorProc(prc: NimNode, abiFormat: ABIFormat): NimNode {.compileTime
 macro ffiDtor*(args: varargs[untyped]): untyped =
   ## C-exported FFIContext destructor. Sync (no return) or async (`Future[void]`);
   ## a non-empty body becomes an async `ffiTeardownHook` the FFI thread awaits on
-  ## both the recycle and the shutdown path, so teardown runs on the worker
-  ## thread. The wrapper blocks its caller until the body finishes, up to
-  ## `RecycleWaitTimeout` (15 s at the default budgets), so a host should not
-  ## call it from a thread that must stay responsive. Keep the body cancellable:
-  ## at `TeardownTimeout` it is cancelled, and one that ignores cancellation
-  ## holds the recycle. RET_ERR on null/invalid ctx. `{.ffi.}` reaches the same
-  ## path from the shape alone.
+  ## the recycle and the shutdown path. The wrapper blocks its caller until the
+  ## body finishes, up to `RecycleWaitTimeout` (15 s by default). Keep the body
+  ## cancellable: one that ignores `TeardownTimeout` holds the recycle. RET_ERR
+  ## on null/invalid ctx. `{.ffi.}` reaches the same path from the shape alone.
   requireBeforeGenBindings("`.ffiDtor.`")
   requireLibraryDeclared("`.ffiDtor.`")
   let prc = args[^1]

--- a/ffi/internal/ffi_macro.nim
+++ b/ffi/internal/ffi_macro.nim
@@ -1739,9 +1739,14 @@ proc buildFFIDtorProc(prc: NimNode, abiFormat: ABIFormat): NimNode {.compileTime
 
 macro ffiDtor*(args: varargs[untyped]): untyped =
   ## C-exported FFIContext destructor. Sync (no return) or async (`Future[void]`);
-  ## a non-empty body becomes an async `ffiTeardownHook` the FFI thread awaits at
-  ## shutdown, so teardown runs on the worker thread. RET_ERR on null/invalid ctx.
-  ## `{.ffi.}` reaches the same path from the shape alone.
+  ## a non-empty body becomes an async `ffiTeardownHook` the FFI thread awaits on
+  ## both the recycle and the shutdown path, so teardown runs on the worker
+  ## thread. The wrapper blocks its caller until the body finishes, up to
+  ## `RecycleWaitTimeout` (15 s at the default budgets), so a host should not
+  ## call it from a thread that must stay responsive. Keep the body cancellable:
+  ## at `TeardownTimeout` it is cancelled, and one that ignores cancellation
+  ## holds the recycle. RET_ERR on null/invalid ctx. `{.ffi.}` reaches the same
+  ## path from the shape alone.
   requireBeforeGenBindings("`.ffiDtor.`")
   requireLibraryDeclared("`.ffiDtor.`")
   let prc = args[^1]

--- a/tests/unit/test_ffi_teardown.nim
+++ b/tests/unit/test_ffi_teardown.nim
@@ -3,7 +3,9 @@ import unittest2
 import results
 import ffi
 
-# Exercises async {.ffiDtor.}: destroyFFIContext must block until teardown finishes.
+# Exercises async {.ffiDtor.}: both the destroy path and the recycle path must
+# block until teardown finishes. test_ffi_teardown.nim.cfg shortens
+# TeardownTimeout for every suite here, so read timings against 1s, not 10s.
 
 type TeardownLib = object
 
@@ -14,6 +16,7 @@ declareLibrary("teardownlib", TeardownLib)
 
 var gTeardownRan: Atomic[bool]
 var gTeardownThreadId: Atomic[int]
+var gTeardownHangs: Atomic[bool]
 
 type NoopConfig {.ffi.} = object
   dummy: int
@@ -24,8 +27,13 @@ proc teardownlib_create*(
   return ok(TeardownLib())
 
 proc teardownlib_destroy*(lib: TeardownLib): Future[void] {.ffiDtor.} =
-  ## Async teardown: sleeps, then records that it ran and on which thread.
-  await sleepAsync(200.milliseconds)
+  ## Async teardown: sleeps, then records that it ran and on which thread. While
+  ## `gTeardownHangs` is set it sleeps far past every timeout in play, so no
+  ## sanitizer slowdown can make a natural finish look like a cancelled one.
+  if gTeardownHangs.load():
+    await sleepAsync(TeardownTimeout + 60.seconds)
+  else:
+    await sleepAsync(200.milliseconds)
   gTeardownThreadId.store(getThreadId())
   gTeardownRan.store(true)
 
@@ -41,14 +49,16 @@ proc encodedPtr(bytes: var seq[byte]): ptr byte =
     cast[ptr byte](addr bytes[0])
 
 proc createCtxWithLib(): ptr FFIContext[TeardownLib] =
-  ## Spins up a context via the ctor and waits until `myLib` is populated.
+  ## Spins up a context via the ctor and waits until the library is ready.
+  # Waits on `libReady`, not `myLib`: the ctor sets the flag after the pointer,
+  # and `libReady` is what gates the teardown hook.
   var cfg = cborEncode(TeardownlibCreateCtorReq(config: NoopConfig(dummy: 0)))
   let ret = teardownlib_create(encodedPtr(cfg), cfg.len.csize_t, noopCallback, nil)
   if ret.isNil():
     return nil
   let ctx = cast[ptr FFIContext[TeardownLib]](ret)
   var tries = 0
-  while ctx[].myLib.isNil() and tries < 500:
+  while not ctx[].libReady.load() and tries < 500:
     os.sleep(5)
     inc tries
   ctx
@@ -74,4 +84,73 @@ suite "async {.ffiDtor.} teardown hook":
     let ctx = createCtxWithLib()
     check not ctx.isNil()
     check TeardownlibFFIPool.destroyFFIContext(ctx).isOk()
+    check gTeardownRan.load()
+
+suite "{.ffiDtor.} teardown on the recycle path":
+  # Recycle is the path the generated C destroy wrapper takes, so a dtor body
+  # that only ran on destroy would never run in a real host.
+  test "recycle blocks until the async teardown body completes":
+    let ctx = createCtxWithLib()
+    check not ctx.isNil()
+    check not ctx[].myLib.isNil()
+
+    gTeardownRan.store(false)
+    gTeardownThreadId.store(0)
+    let callerTid = getThreadId()
+
+    check TeardownlibFFIPool.recycleFFIContext(ctx).isOk()
+
+    check gTeardownRan.load()
+    check gTeardownThreadId.load() != 0
+    check gTeardownThreadId.load() != callerTid
+
+  test "the C-exported destroy wrapper runs the teardown":
+    let ctx = createCtxWithLib()
+    check not ctx.isNil()
+
+    gTeardownRan.store(false)
+    check teardownlib_destroy(cast[pointer](ctx)) == RET_OK
+    check gTeardownRan.load()
+
+  test "a slot reused after teardown tears down again":
+    let first = createCtxWithLib()
+    check not first.isNil()
+    check TeardownlibFFIPool.recycleFFIContext(first).isOk()
+
+    gTeardownRan.store(false)
+    let second = createCtxWithLib()
+    check not second.isNil()
+    # createFFIContext claims the lowest free slot, so a released slot comes
+    # back. Without this the test would pass on a fresh slot and prove nothing.
+    check second == first
+    check not second[].myLib.isNil()
+    check TeardownlibFFIPool.recycleFFIContext(second).isOk()
+    check gTeardownRan.load()
+
+  test "a teardown past TeardownTimeout still releases the slot":
+    let ctx = createCtxWithLib()
+    check not ctx.isNil()
+
+    gTeardownRan.store(false)
+    gTeardownHangs.store(true)
+    let t0 = Moment.now()
+    check TeardownlibFFIPool.recycleFFIContext(ctx).isOk()
+    let elapsed = Moment.now() - t0
+    gTeardownHangs.store(false)
+
+    # The timeout is what ended the wait, not an early bail: the hook outlasts
+    # TeardownTimeout, and its tail never ran because cancellation took it.
+    check elapsed >= TeardownTimeout
+    # The body sleeps a further minute, so returning inside the caller's own
+    # ceiling proves the timeout ended the wait, not the body finishing. Bounding
+    # by RecycleWaitTimeout keeps the isOk() check above the first to fail.
+    check elapsed < RecycleWaitTimeout
+    check not gTeardownRan.load()
+
+    # The slot is usable again, and the next owner tears down normally.
+    let next = createCtxWithLib()
+    check not next.isNil()
+    check next == ctx
+    check not next[].myLib.isNil()
+    check TeardownlibFFIPool.recycleFFIContext(next).isOk()
     check gTeardownRan.load()

--- a/tests/unit/test_ffi_teardown.nim
+++ b/tests/unit/test_ffi_teardown.nim
@@ -3,9 +3,8 @@ import unittest2
 import results
 import ffi
 
-# Exercises async {.ffiDtor.}: both the destroy path and the recycle path must
-# block until teardown finishes. test_ffi_teardown.nim.cfg shortens
-# TeardownTimeout for every suite here, so read timings against 1s, not 10s.
+# Exercises async {.ffiDtor.} on the destroy and the recycle path.
+# test_ffi_teardown.nim.cfg cuts TeardownTimeout to 1s for every suite here.
 
 type TeardownLib = object
 
@@ -27,9 +26,8 @@ proc teardownlib_create*(
   return ok(TeardownLib())
 
 proc teardownlib_destroy*(lib: TeardownLib): Future[void] {.ffiDtor.} =
-  ## Async teardown: sleeps, then records that it ran and on which thread. While
-  ## `gTeardownHangs` is set it sleeps far past every timeout in play, so no
-  ## sanitizer slowdown can make a natural finish look like a cancelled one.
+  ## Records that it ran and on which thread. `gTeardownHangs` makes it sleep
+  ## past every timeout in play, well clear of any sanitizer slowdown.
   if gTeardownHangs.load():
     await sleepAsync(TeardownTimeout + 60.seconds)
   else:
@@ -49,9 +47,8 @@ proc encodedPtr(bytes: var seq[byte]): ptr byte =
     cast[ptr byte](addr bytes[0])
 
 proc createCtxWithLib(): ptr FFIContext[TeardownLib] =
-  ## Spins up a context via the ctor and waits until the library is ready.
-  # Waits on `libReady`, not `myLib`: the ctor sets the flag after the pointer,
-  # and `libReady` is what gates the teardown hook.
+  ## Spins up a context and waits on `libReady`, the flag the teardown gates on.
+  # Not `myLib`: the worker points that at its fallback before the ctor runs.
   var cfg = cborEncode(TeardownlibCreateCtorReq(config: NoopConfig(dummy: 0)))
   let ret = teardownlib_create(encodedPtr(cfg), cfg.len.csize_t, noopCallback, nil)
   if ret.isNil():
@@ -87,8 +84,7 @@ suite "async {.ffiDtor.} teardown hook":
     check gTeardownRan.load()
 
 suite "{.ffiDtor.} teardown on the recycle path":
-  # Recycle is the path the generated C destroy wrapper takes, so a dtor body
-  # that only ran on destroy would never run in a real host.
+  # Recycle is the path the generated C destroy wrapper takes.
   test "recycle blocks until the async teardown body completes":
     let ctx = createCtxWithLib()
     check not ctx.isNil()
@@ -120,8 +116,7 @@ suite "{.ffiDtor.} teardown on the recycle path":
     gTeardownRan.store(false)
     let second = createCtxWithLib()
     check not second.isNil()
-    # createFFIContext claims the lowest free slot, so a released slot comes
-    # back. Without this the test would pass on a fresh slot and prove nothing.
+    # Lowest free slot wins, so a fresh slot here would prove nothing.
     check second == first
     check not second[].myLib.isNil()
     check TeardownlibFFIPool.recycleFFIContext(second).isOk()
@@ -138,16 +133,11 @@ suite "{.ffiDtor.} teardown on the recycle path":
     let elapsed = Moment.now() - t0
     gTeardownHangs.store(false)
 
-    # The timeout is what ended the wait, not an early bail: the hook outlasts
-    # TeardownTimeout, and its tail never ran because cancellation took it.
+    # The timeout ended the wait, not an early bail or the body finishing.
     check elapsed >= TeardownTimeout
-    # The body sleeps a further minute, so returning inside the caller's own
-    # ceiling proves the timeout ended the wait, not the body finishing. Bounding
-    # by RecycleWaitTimeout keeps the isOk() check above the first to fail.
     check elapsed < RecycleWaitTimeout
     check not gTeardownRan.load()
 
-    # The slot is usable again, and the next owner tears down normally.
     let next = createCtxWithLib()
     check not next.isNil()
     check next == ctx

--- a/tests/unit/test_ffi_teardown.nim.cfg
+++ b/tests/unit/test_ffi_teardown.nim.cfg
@@ -1,0 +1,3 @@
+# Applies to every suite in test_ffi_teardown.nim, not only the hang test: at the
+# 10s default that test would cost 10s on each job of the platform matrix.
+-d:ffiTeardownTimeoutMs=1000

--- a/tests/unit/test_ffi_teardown.nim.cfg
+++ b/tests/unit/test_ffi_teardown.nim.cfg
@@ -1,3 +1,2 @@
-# Applies to every suite in test_ffi_teardown.nim, not only the hang test: at the
-# 10s default that test would cost 10s on each job of the platform matrix.
+# File-wide: at the 10s default the hang test costs 10s on every matrix job.
 -d:ffiTeardownTimeoutMs=1000


### PR DESCRIPTION
## Summary

A `{.ffiDtor.}` body never ran. The C destructor that `buildFFIDtorProc` emits calls `recycleFFIContext` (`ffi/internal/ffi_macro.nim:1696`), but the only site that awaited `ffiTeardownHook` was the thread-exit epilogue of the full-shutdown path, which needs `ctx.running == false`. Only `destroyFFIContext` sets that, and no generated wrapper calls it. So the hook site sat on a path nobody takes, and every dtor body shipped by a consumer was dead code.

The consequence is worse than a skipped callback. `recycleContext` frees the library with `freeLib`, which is memory-only, and the pooled worker survives a recycle by design. Anything the library spawned itself keeps running on that dispatcher, invisible to a host whose handle is gone — and the next `createFFIContext` can hand the same slot, and the same event loop, to a different owner.

`recycleContext` now awaits the hook after it drains the in-flight requests and before it frees the library. Both call sites share one `runTeardown` helper so the recycle path and the destroy path cannot drift apart.

Nothing in-tree caught this: both examples (`examples/echo/echo.nim:57`, `examples/timer/timer.nim:154`) have no-op dtor bodies, and `tests/unit/test_ffi_teardown.nim` only exercised `destroyFFIContext`.

## Affected Areas

- `ffi/ffi_thread.nim` — new `runTeardown[T]`, called from `recycleContext` and from the thread-exit epilogue. The ordering is load-bearing: after the drain so no handler runs against a stopped library, before `freeLib` because the hook needs `myLib`, before `clearListeners` so events the teardown emits still reach the host. It runs only once `libReady` is set, because `myLib` otherwise points at the worker's zero-valued fallback, which is nil for a `ref` library type.
- `ffi/ffi_thread.nim` — `recycleContext` now fires `recycleDoneSignal` and releases the slot from a `defer`. The function awaits arbitrary consumer code, and a raise out of that code must not strand the slot in `Recycling`.
- `ffi/event_thread.nim` — the heartbeat check is skipped unless the lifecycle is `Active`. The worker ticks `proveAlive` only at the top of its loop, so a teardown parks the heartbeat for its whole duration; against a 1 s `FFIHeartbeatStaleThreshold` every healthy shutdown longer than a second would emit a `NotRespondingEvent`, and the matching `onResponding` could never arrive because `clearListeners` runs first. The `eventQueueStuck` check is untouched.
- `ffi/ffi_context.nim` — new `TeardownTimeoutMs` (`-d:ffiTeardownTimeoutMs`, 10 s default) and `RecycleWaitTimeout` widened to cover it, so a synchronous `recycleFFIContext` does not give up while a legitimate teardown runs.
- `ffi/internal/ffi_macro.nim` — the `{.ffiDtor.}` docstring now states where the body runs, how long the wrapper blocks its caller, and that the body must stay cancellable.
- `tests/unit/test_ffi_teardown.nim` — a recycle suite covering the hook on `recycleFFIContext`, through the C-exported wrapper, on a slot proven to be the reused one, and past the timeout.
- `.gitignore` — `tests/unit/test_*` (the rule for extensionless compiled binaries) also swallowed `tests/unit/test_ffi_teardown.nim.cfg`. Added a `!tests/unit/test_*.nim.cfg` escape hatch next to the existing `!tests/unit/test_*.nim`.

## Impact on Library Users

Behaviour change for any consumer that already ships a non-empty `{.ffiDtor.}` body: it went from dead code to live shutdown code, and it now runs on the ordinary destroy path. Read that body again before you take this bump.

**The generated destructor now blocks its caller for as long as the teardown takes**, up to `RecycleWaitTimeout` — 15 s at the default budgets, against 5 s before. Do not call it from a thread that must stay responsive.

**Keep the dtor cancellable.** At `TeardownTimeout` the hook is cancelled, but chronos `withTimeout` then waits for the cancellation to land, so a body that swallows `CancelledError` still holds the recycle. That is a slow-shutdown bug in the consumer, not something nim-ffi can bound from the outside.

`ThreadExitTimeoutMs` keeps its 1500 ms default. Raise it past `ffiTeardownTimeoutMs` if your dtor is slow on the `destroyFFIContext` path.

## Risk Assessment

- Backward compatible at the ABI and the API. No signature changes.
- The slot is released on every exit path of `recycleContext`, including a raise out of the dtor, because the release sits in a `defer`.
- `TeardownTimeout` is a cancellation request, not a hard ceiling. A dtor that ignores cancellation blocks the recycle, the caller then fails on `RecycleWaitTimeout`, and that slot does not return to the pool. Documented rather than papered over.
- Suppressing the heartbeat check during a recycle means a worker that genuinely wedges inside a teardown no longer raises `NotRespondingEvent`. `TeardownTimeout` and `RecycleWaitTimeout` are the bounds that cover that window instead, and the alternative was a false alarm on every normal shutdown.
- `ThreadExitTimeout` was deliberately left alone: `tests/unit/test_ffi_context.nim:261` asserts that `destroyFFIContext` gives up in under 3 s when the worker loop is wedged, and raising the default breaks that fast-bail guarantee.
- Not covered by a test: the `libReady` gate itself. Proving it needs a second library type with a failing constructor, and the reasoning rests on `ffi_codegen_common.nim:27`, which guards `{.ffi.}` calls the same way.

## References

- logos-messaging/logos-delivery#4108 — `logosdelivery_destroy` without `stop_node` performs no node shutdown. Part 2 of the proposed fix is this change.
- logos-messaging/logos-delivery#4109 — the library-side workaround that enqueues `STOP_NODE` before the recycle. It stays correct until liblogosdelivery can register a `{.ffiDtor.}` that awaits `LogosDelivery.stop` and collapse that hand-written destroy body back to a plain recycle.

This is necessary but not sufficient for #4108. nim-ffi cannot cancel work a library spawned on its own, so liblogosdelivery must still register the dtor.