### PR TITLE
fix(ffi): reset the pool slot on recycle, and give the host an opaque context token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,29 @@ All notable changes to this project are documented in this file.
   router would silently give it the ctor ABI instead.
 
 ### Fixed
+- **A recycled pool slot is reset before it serves the next owner.** The recycle
+  handler computed whether its in-flight handlers had drained and then tore down
+  regardless: it freed the library and returned the slot to the pool while
+  handlers still ran, and each of those answers a callback carrying `userData`
+  the host frees once teardown reports success. A drain that runs out of both
+  rounds now aborts the recycle, so `requestRecycle` (and the generated
+  `<lib>_destroy`) returns an error, the library stays alive and the slot stays
+  claimed. A host that sees that error must keep the `userData` of its in-flight
+  requests alive. The drain also counted the dispatcher rather than the handler,
+  and the dispatcher unwound as soon as the cancel reached its `race`;
+  `awaitWithStaleWarnings` now waits out the handler, which is never cancelled by
+  design. The reset clears the handle registry as well: ids are monotonic from 1,
+  so the next owner of a slot could pass id `1` and read an object of the
+  previous one.
+- A `{.ffi.}` constructor that failed after `createFFIContext` returned nil and
+  left its slot claimed for the life of the process. Both ABI paths now recycle
+  the slot before they return.
+- The `abi = c` wrappers leaked their reply box on every send failure: `freeBox`
+  runs only in the reply trampoline, which a rejected send never reaches. One
+  trigger is sticky — once `eventQueueStuck` latches, every later call fails.
+- Every `c_malloc` result in the runtime is checked. An out-of-memory condition
+  used to become a nil dereference; it now becomes an error the host receives
+  through its callback.
 - A `{.ffiDtor.}` body now runs when the context is recycled. Only the
   thread-exit epilogue awaited the teardown hook, and the emitted C destructor
   never takes that path, so a dtor body was dead code and the library kept every
@@ -84,6 +107,22 @@ directions. Internally the watchdog thread is gone — the heartbeat now runs on
 the dedicated event thread that also isolates user callbacks from the FFI thread.
 
 ### Changed
+- **The host holds an opaque context token, not the address of a pool slot.** A
+  slot keeps its address across a recycle, so a pointer from an earlier owner
+  passed validation again as soon as a new owner claimed the same slot, and then
+  dispatched onto the library of that new owner. A context now carries a
+  generation that every claim opens, and the value the constructors hand back is
+  an `FFICtxToken` packing the slot index and that generation; `resolveCtx`
+  rejects a token whose generation no longer matches. The two event-listener
+  entry points went through the same change — they used to dereference the host
+  pointer behind a nil check alone. **The C ABI is unchanged**: the token is
+  pointer-sized and the generated headers still declare `void* ctx`, so the
+  bindings are byte-identical and no foreign consumer changes. A Nim consumer
+  passes `ctx.ffiToken()` into a generated entry point and turns a token back
+  into a context with `<Lib>FFIPool.resolveCtx(token)`; `FFICtxToken` is a
+  distinct type, so every site is a compile error until it is updated.
+- `FFIHandleRegistry.release` takes the handle's `typeName` and applies the same
+  type-tag check as `lookup`, so a release cannot cross types.
 - **`abi = c` non-scalar procs no longer marshal through CBOR.** The foreign
   surface is unchanged — the generated headers and exported symbols are
   byte-identical — but the hop between the caller and the FFI thread now carries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,37 @@ All notable changes to this project are documented in this file.
   router would silently give it the ctor ABI instead.
 
 ### Fixed
+- **A claim and the generation it opens are one atomic operation.** `tryClaim`
+  set `inUse` and bumped `generation` in two steps, and between them a token of
+  the previous owner passed both checks in `resolveCtx`: `inUse` was already
+  true, and `generation` still held the value the token carried. The claim
+  marker is now the parity of the generation itself, seqlock style: even is
+  free, odd is claimed, and one CAS moves a slot from one to the other, so no
+  token can observe a half-claimed slot. Bumping the generation first was not
+  the answer: a claim that loses the race would then move the generation while
+  the winner holds a token issued under the old value. `inUse` is gone, and
+  `ctx.isInUse()` reads the parity.
+- **A request carries the claim it was submitted under.** Every entry point
+  resolved its token once and then enqueued with no second check, so a request
+  that landed in the queue during the recycle window survived into the next
+  claim, and the new library ran it and answered the callback of the old host.
+  `FFIThreadRequest` gains a `generation` field that the entry point stamps from
+  the resolved token. `sendRequestToFFIThread` rejects a stamp that no longer
+  matches the live claim, and the FFI thread drops a dequeued request whose
+  stamp does not match, without calling its callback: that callback carries
+  `userData` the old host frees as soon as its recycle returns ok. A host that
+  races a submit against its own recycle therefore loses that request silently,
+  which is the safe side of the trade.
+- **A losing `requestRecycle` can no longer swallow the drain failure of the
+  winner.** The `recycleFailed` flag was cleared before the lifecycle CAS, so a
+  concurrent caller could clear it between the moment the recycle handler set it
+  and the moment the winner read it, and the winner then returned ok for a
+  failed drain. A clear after the CAS races too, because the FFI thread polls
+  and can finish the whole recycle in between. The flag is gone: the outcome now
+  lives in the lifecycle state machine as the terminal `RecycleFailed`, which
+  only the recycle handler writes and nothing clears. A later `requestRecycle`
+  on such a slot gets the existing "not Active" error, which is the right answer
+  for a wedged slot.
 - **A recycled pool slot is reset before it serves the next owner.** The recycle
   handler computed whether its in-flight handlers had drained and then tore down
   regardless: it freed the library and returned the slot to the pool while

--- a/ffi/alloc.nim
+++ b/ffi/alloc.nim
@@ -8,17 +8,25 @@ type SharedSeq*[T] = tuple[data: ptr UncheckedArray[T], len: int]
 
 proc alloc*(str: cstring): cstring =
   ## Fresh null-terminated `c_malloc` copy of `str`; free with `dealloc(cstring)`.
+  ## Nil when the allocation fails.
   if str.isNil():
     var ret = cast[cstring](c_malloc(1))
+    if ret.isNil():
+      return nil
     ret[0] = '\0'
     return ret
 
   let ret = cast[cstring](c_malloc(csize_t(len(str) + 1)))
+  if ret.isNil():
+    return nil
   copyMem(ret, str, len(str) + 1)
   return ret
 
 proc alloc*(str: string): cstring =
+  ## Nil when the allocation fails.
   var ret = cast[cstring](c_malloc(csize_t(str.len + 1)))
+  if ret.isNil():
+    return nil
   let s = cast[seq[char]](str)
   for i in 0 ..< str.len:
     ret[i] = s[i]
@@ -39,10 +47,13 @@ proc freeBox*(p: pointer) =
     c_free(p)
 
 proc allocSharedSeq*[T](s: seq[T]): SharedSeq[T] =
+  ## `(nil, 0)` for an empty seq and for a failed allocation.
   if s.len == 0:
     return (cast[ptr UncheckedArray[T]](nil), 0)
 
   let data = c_malloc(csize_t(sizeof(T) * s.len))
+  if data.isNil():
+    return (cast[ptr UncheckedArray[T]](nil), 0)
   copyMem(data, unsafeAddr s[0], sizeof(T) * s.len)
   return (cast[ptr UncheckedArray[T]](data), s.len)
 

--- a/ffi/cbor_serial.nim
+++ b/ffi/cbor_serial.nim
@@ -15,11 +15,14 @@ proc cborEncode*[T](x: T): seq[byte] =
 
 proc cborEncodeShared*[T](x: T): tuple[data: ptr UncheckedArray[byte], len: int] =
   ## Encodes `x` into a caller-owned `c_malloc` buffer (free via `cborFreeShared`).
-  ## Empty payloads return `(nil, 0)` without allocating.
+  ## Empty payloads return `(nil, 0)` without allocating, and so does a failed
+  ## allocation: the receiver reads an empty payload and answers a decode error.
   let bytes = Cbor.encode(x)
   if bytes.len == 0:
     return (nil, 0)
   let buf = cast[ptr UncheckedArray[byte]](c_malloc(csize_t(bytes.len)))
+  if buf.isNil():
+    return (nil, 0)
   copyMem(buf, unsafeAddr bytes[0], bytes.len)
   return (buf, bytes.len)
 

--- a/ffi/ffi_context.nim
+++ b/ffi/ffi_context.nim
@@ -15,14 +15,19 @@ import
 
 export ffi_events, ffi_handles
 
+type FFICtxToken* = distinct pointer
+  ## Opaque handle the host holds for a context. Distinct from `pointer` so a raw
+  ## address cannot be passed where a token belongs.
+
+proc isNil*(token: FFICtxToken): bool {.borrow.}
+proc `==`*(a, b: FFICtxToken): bool {.borrow.}
+
 type CtxLifecycle* {.pure.} = enum
-  ## State machine guarding a pooled FFI context (Atomic on FFIContext).
-  ##   Active         -> RecyclePending   when the ffiDtor requests recycle
-  ##   RecyclePending -> Recycling        FFI loop claimed it, draining handlers
-  ##   Recycling      -> Active           createFFIContext reuses the slot
+  ## Active -> RecyclePending (ffiDtor asks) -> Recycling (FFI loop drains) -> Active (slot reused) or RecycleFailed (drain timed out).
   Active
   RecyclePending
   Recycling
+  RecycleFailed # terminal: only the recycle handler writes it, nothing clears it
 
 type FFIContext*[T] = object
   myLib*: ptr T # main library object (Waku, LibP2P, SDS, …)
@@ -32,13 +37,14 @@ type FFIContext*[T] = object
   myLibOwned*: bool
     # true once a ctor stored a createShared'd lib into myLib (vs the worker's
     # stack fallback). freeLib only frees/destroys owned libs.
-  inUse*: Atomic[bool]
-    # Whether this pooled context is claimed. The recycle handler clears it on
-    # the FFI thread so the slot returns to the pool without recreating threads.
+  generation*: Atomic[uint]
+    # Seqlock-style claim marker, never reset: even = free, odd = claimed. One CAS both claims the slot and opens the new generation, so no token can see a half-claimed slot. The host token carries the odd value it was issued under, so it stops resolving once the slot serves a new owner.
+  token*: FFICtxToken
+    # The opaque handle the host holds for the current claim. Written by
+    # createFFIContext under the claim; read only by the owner.
   lifecycle*: Atomic[CtxLifecycle]
   recycleDoneSignal: ThreadSignalPtr
-    # fired by the recycle handler once the lib is freed, just before it releases
-    # the slot; the synchronous recycleFFIContext caller waits on it.
+    # fired by the recycle handler once the lib is freed, just before it releases the slot; the synchronous recycleFFIContext caller waits on it.
   libReady*: Atomic[bool]
     # False until a {.ffiCtor.} stores the library. Before that, `myLib` points
     # at the default fallback of the FFI thread. For a `ref` type that fallback
@@ -217,15 +223,28 @@ proc signalStop*[T](ctx: ptr FFIContext[T]): Result[void, string] =
   ok()
 
 proc tryClaim*[T](ctx: ptr FFIContext[T]): bool =
-  ## Atomically claim a free pooled context (false -> true).
-  var expected = false
-  ctx.inUse.compareExchange(expected, true)
+  ## Claims a free pooled context by moving its generation from even to odd: the slot keeps its address, so one CAS both claims it and opens the generation that separates this owner from the last.
+  let generation = ctx.generation.load()
+  if (generation and 1) == 1:
+    return false
+  var expected = generation
+  ctx.generation.compareExchange(expected, generation + 1)
+
+proc ffiToken*[T](ctx: ptr FFIContext[T]): FFICtxToken =
+  ## The opaque handle the host holds for `ctx`. Never a raw address: an address
+  ## outlives the claim it was handed out under.
+  ctx.token
 
 proc releaseClaim*[T](ctx: ptr FFIContext[T]) =
-  ctx.inUse.store(false)
+  ## Back to even, which is a generation no token was ever issued under.
+  ctx.generation.atomicInc()
 
 proc isInUse*[T](ctx: ptr FFIContext[T]): bool =
-  ctx.inUse.load()
+  (ctx.generation.load() and 1) == 1
+
+proc currentGeneration*[T](ctx: ptr FFIContext[T]): uint =
+  ## The generation of the live claim; a request carries it so the FFI thread can drop it once the slot changes owner.
+  ctx.generation.load()
 
 proc markAsActive*[T](ctx: ptr FFIContext[T]) =
   ## Reused context: its worker threads are still alive; re-arm for requests.
@@ -235,6 +254,8 @@ proc requestRecycle*[T](ctx: ptr FFIContext[T]): Result[void, string] =
   ## Ask the FFI thread to drain, free the lib and release the slot, WITHOUT
   ## stopping its worker/event threads, so the next createFFIContext reuses them.
   ## Synchronous: waits on recycleDoneSignal. No fd churn -> no select() limit.
+  ## An err means the caller must keep the callback userData of every in-flight
+  ## request alive: teardown did not complete. A request the host races against its own recycle is rejected or silently dropped, never answered.
   var expected = CtxLifecycle.Active
   if not ctx.lifecycle.compareExchange(expected, CtxLifecycle.RecyclePending):
     return err("requestRecycle: context is not Active (already recycling)")
@@ -252,6 +273,11 @@ proc requestRecycle*[T](ctx: ptr FFIContext[T]): Result[void, string] =
     return err("requestRecycle: failed waiting for recycle: " & $error)
   if not done:
     return err("requestRecycle: recycle did not complete in time")
+  if ctx.lifecycle.load() == CtxLifecycle.RecycleFailed:
+    return err(
+      "requestRecycle: in-flight handlers did not drain; the library and the pool " &
+        "slot are leaked, and their callbacks can still fire"
+    )
   ok()
 
 ## Per-thread exit wait before stopAndJoinThreads leaks ctx rather than hanging. Kept

--- a/ffi/ffi_context_pool.nim
+++ b/ffi/ffi_context_pool.nim
@@ -4,6 +4,22 @@ import ./ffi_context
 
 const MaxFFIContexts* = 32
 
+const
+  SlotBits = 5
+  SlotMask = (1'u shl SlotBits) - 1
+
+static:
+  doAssert MaxFFIContexts <= int(SlotMask) + 1,
+    "SlotBits is too small for MaxFFIContexts"
+
+proc makeToken(slot: int, generation: uint): FFICtxToken =
+  ## Host handle: the generation of the claim above the slot index. A claim makes the generation odd and non-zero, so a nil token never resolves.
+  cast[FFICtxToken]((generation shl SlotBits) or (uint(slot) and SlotMask))
+
+func tokenGeneration*(token: FFICtxToken): uint =
+  ## The claim a token was issued under: odd by construction, and 0 for a nil token.
+  cast[uint](token) shr SlotBits
+
 type
   StaticCtxState = enum
     ## Lifecycle of the pool's `{.ffiStatic.}` context; see `staticFFIContext`.
@@ -40,6 +56,7 @@ proc createFFIContext*[T](
     let ctx = pool.contexts[i].addr
     if not ctx.tryClaim():
       continue
+    ctx.token = makeToken(i, ctx.generation.load())
     if pool.initialized[i].load():
       # Reused slot: a prior recycle drained and released it; worker still alive.
       ctx.markAsActive()
@@ -63,6 +80,9 @@ proc recycleFFIContext*[T](
   ## Normal teardown: drains in-flight handlers, frees the lib and returns the
   ## slot to the pool WITHOUT stopping its threads, so a later createFFIContext
   ## reuses them. Synchronous (waits for the FFI thread to finish draining).
+  # `resolveCtx` answers nil for a stale token, and its result lands here.
+  if ctx.isNil():
+    return err("recycleFFIContext(pool): no context (nil)")
   # Recycling it would release the slot while `staticState` still points at it.
   if pool.isStaticCtx(ctx):
     return err("recycleFFIContext(pool): the {.ffiStatic.} context outlives every ctx")
@@ -75,6 +95,8 @@ proc destroyFFIContext*[T](
   ## uninitialised so a later createFFIContext rebuilds it; normal cleanup uses
   ## recycleFFIContext. On thread-exit timeout the slot is leaked; closing
   ## live-thread resources is unsafe.
+  if ctx.isNil():
+    return err("destroyFFIContext(pool): no context (nil)")
   # Destroying it would release the slot while `staticState` still points at it.
   if pool.isStaticCtx(ctx):
     return err("destroyFFIContext(pool): the {.ffiStatic.} context outlives every ctx")
@@ -132,11 +154,20 @@ proc destroyStaticFFIContext*[T](pool: var FFIContextPool[T]): Result[void, stri
     return err("destroyStaticFFIContext: " & $error)
   ok()
 
-proc isValidCtx*[T](pool: var FFIContextPool[T], ctx: pointer): bool =
-  ## Rejects nil / dangling pointers at the API boundary.
-  if ctx.isNil():
-    return false
-  for i in 0 ..< MaxFFIContexts:
-    if cast[pointer](pool.contexts[i].addr) == ctx:
-      return pool.contexts[i].addr.isInUse()
-  false
+proc resolveCtx*[T](
+    pool: var FFIContextPool[T], token: FFICtxToken
+): ptr FFIContext[T] =
+  ## The context a host token names, or nil when the token is nil, forged, or
+  ## issued for an earlier owner of the slot.
+  let generation = token.tokenGeneration()
+  if generation == 0:
+    return nil
+  # An issued generation is odd, so matching it also proves the slot is claimed.
+  let ctx = pool.contexts[int(cast[uint](token) and SlotMask)].addr
+  if ctx.generation.load() != generation:
+    return nil
+  ctx
+
+proc isValidCtx*[T](pool: var FFIContextPool[T], token: FFICtxToken): bool =
+  ## Rejects a nil, forged or stale token at the API boundary.
+  not pool.resolveCtx(token).isNil()

--- a/ffi/ffi_handles.nim
+++ b/ffi/ffi_handles.nim
@@ -45,8 +45,13 @@ proc lookup*(
     )
   ok(entry.obj)
 
-proc release*(reg: var FFIHandleRegistry, handle: uint64): bool {.discardable.} =
-  if not reg.byHandle.hasKey(handle):
+proc release*(
+    reg: var FFIHandleRegistry, handle: uint64, typeName: string
+): bool {.discardable.} =
+  ## Drops `handle`; false if absent or registered under another type. Same tag
+  ## check as `lookup`, so a release cannot cross types either.
+  let entry = reg.byHandle.getOrDefault(handle)
+  if entry.obj.isNil() or entry.typeName != typeName:
     return false
   reg.byHandle.del(handle)
   return true

--- a/ffi/ffi_thread.nim
+++ b/ffi/ffi_thread.nim
@@ -3,8 +3,14 @@
 ## `ctx.ffiHeartbeat` so the event thread can spot a wedged FFI thread.
 
 proc sendRequestToFFIThread*(
-    ctx: ptr FFIContext, ffiRequest: ptr FFIThreadRequest
+    ctx: ptr FFIContext, ffiRequest: ptr FFIThreadRequest, generation: uint
 ): Result[void, string] =
+  ## `generation` is the claim the caller resolved its token under; the request carries it so a slot that changes owner between the resolve and the dispatch answers nobody.
+
+  # A nil request means the allocator failed; report it instead of dereferencing.
+  if ffiRequest.isNil():
+    return err("out of memory: could not allocate the FFI request")
+
   if ctx.eventQueueStuck.load():
     deleteRequest(ffiRequest)
     return err("event queue stuck - library cannot accept new requests")
@@ -20,6 +26,11 @@ proc sendRequestToFFIThread*(
     deleteRequest(ffiRequest)
     return err("FFI context is not accepting requests (being recycled)")
 
+  ffiRequest.generation = generation
+  if generation != ctx.currentGeneration():
+    deleteRequest(ffiRequest)
+    return err("FFI context was recycled; the token names an owner that is gone")
+
   # Wake only when the push found the queue empty: waking per submit kills scaling, and a skipped wake just waits the consumer's 100ms poll.
   let shouldWake = ctx.reqQueueBank.pushRequest(ffiRequest)
 
@@ -31,6 +42,12 @@ proc sendRequestToFFIThread*(
 
   ok()
 
+proc sendRequestToFFIThread*(
+    ctx: ptr FFIContext, ffiRequest: ptr FFIThreadRequest
+): Result[void, string] =
+  ## For a caller holding the context itself (a ctor, the static ctx, a test): no token, so the live claim is the generation to stamp.
+  sendRequestToFFIThread(ctx, ffiRequest, ctx.currentGeneration())
+
 proc awaitWithStaleWarnings(
     retFut: Future[Result[seq[byte], string]],
     request: ptr FFIThreadRequest,
@@ -39,15 +56,22 @@ proc awaitWithStaleWarnings(
 ): Future[Result[seq[byte], string]] {.async.} =
   ## Pings RET_STALE_WARN every `interval` while the handler runs, then returns
   ## its real result. Never cancels the handler: a hard-cancel mid-call could
-  ## leave the underlying library partially applied.
+  ## leave the underlying library partially applied. A cancel of this future
+  ## therefore waits for the handler too — the recycle drain counts this future,
+  ## so an early unwind would report a slot as drained while its handler runs.
   let intervalMs = interval.milliseconds
   if intervalMs <= 0:
-    return await retFut
+    return await noCancel(retFut)
   var elapsed = 0'i64
   while not retFut.finished():
     let timer = sleepAsync(interval)
     # `race` doesn't cancel the loser, so the handler keeps running.
-    discard await race(retFut, timer)
+    try:
+      discard await race(retFut, timer)
+    except CancelledError:
+      if not timer.finished():
+        await noCancel(timer.cancelAndWait())
+      return await noCancel(retFut)
     if retFut.finished():
       if not timer.finished():
         await timer.cancelAndWait()
@@ -120,6 +144,10 @@ proc rejectQueuedRequests[T](ctx: ptr FFIContext[T]) =
   var request = ctx.reqQueueBank.mergeQueues()
   while not request.isNil():
     let nextRequest = request[].next # read before handleRes frees it
+    if request[].generation != ctx.currentGeneration():
+      deleteRequest(request)
+      request = nextRequest
+      continue
     try:
       handleRes(Result[seq[byte], string].err(RecycledReason), request)
     except Exception as e:
@@ -140,37 +168,53 @@ proc runTeardown[T](ctx: ptr FFIContext[T]) {.async.} =
   except CatchableError as e:
     error "library teardown raised", error = e.msg
 
+proc drainOngoing(ongoing: ptr seq[Future[void]]): Future[bool] {.async.} =
+  ## Waits out the in-flight dispatchers, then cancels them and waits again.
+  ## False when both rounds time out and handlers are still running.
+  ongoing[].keepItIf(not it.finished())
+  if ongoing[].len == 0:
+    return true
+  if await allFutures(ongoing[]).withTimeout(RecycleTimeout):
+    return true
+  for fut in ongoing[]:
+    fut.cancelSoon()
+  return await allFutures(ongoing[]).withTimeout(RecycleTimeout)
+
+proc resetForNextOwner[T](ctx: ptr FFIContext[T], ongoing: ptr seq[Future[void]]) =
+  freeLib(ctx)
+  clearListeners(ctx[].eventRegistry)
+  # A reused slot skips initContextResources, so the handle ids of the old owner
+  # would otherwise resolve for the next one.
+  ctx[].handles.releaseAll()
+  rejectQueuedRequests(ctx)
+  ongoing[].setLen(0)
+
 proc recycleContext[T](
     ctx: ptr FFIContext[T], ongoing: ptr seq[Future[void]]
 ) {.async.} =
-  ## Drain in-flight handlers, run the library teardown, free the lib, clear
-  ## listeners, then fire recycleDoneSignal and release the slot — all WITHOUT
-  ## stopping the worker/event threads, so the next createFFIContext reuses them
-  ## (no fd churn).
-  # Deferred: a raise out of the teardown must not strand the slot. Fire before
-  # the release, or a thread claiming the slot would take this as its own answer.
+  ## Drain in-flight handlers, run the library teardown, reset the slot, then fire recycleDoneSignal and release the slot, all WITHOUT stopping the worker/event threads, so the next createFFIContext reuses them (no fd churn). A drain that times out aborts the recycle: the slot stays claimed, the library stays alive, and the terminal `RecycleFailed` tells the host so.
+  var drained = false
+  # Deferred: a raise out of the teardown must not strand the slot. Fire before the release, or a thread claiming the slot would take this as its own answer.
   defer:
+    if not drained:
+      ctx.lifecycle.store(CtxLifecycle.RecycleFailed)
     let fireRes = ctx.recycleDoneSignal.fireSync()
     if fireRes.isErr():
       error "failed to fire recycleDoneSignal", err = fireRes.error
-    ctx.releaseClaim()
+    if drained:
+      ctx.releaseClaim()
 
-  ongoing[].keepItIf(not it.finished())
-  var drained = ongoing[].len == 0
+  drained = await drainOngoing(ongoing)
   if not drained:
-    drained = await allFutures(ongoing[]).withTimeout(RecycleTimeout)
-  if not drained:
-    for fut in ongoing[]:
-      fut.cancelSoon()
-    drained = await allFutures(ongoing[]).withTimeout(RecycleTimeout)
+    # A handler that still runs answers a callback carrying userData the host
+    # frees as soon as teardown reports success.
+    error "recycle drain timed out; leaking the pool slot and keeping the library",
+      inFlight = ongoing[].len, timeoutMs = RecycleTimeoutMs
+    return
 
-  # Before freeLib: the hook still needs `myLib` and its listeners.
+  # Before the reset: the teardown hook still needs `myLib` and its listeners.
   await runTeardown(ctx)
-
-  freeLib(ctx)
-  clearListeners(ctx[].eventRegistry)
-  rejectQueuedRequests(ctx)
-  ongoing[].setLen(0)
+  resetForNextOwner(ctx, ongoing)
 
 var ffiEventQueueSignalPtr {.threadvar.}: ThreadSignalPtr
   # Stashed so the hook has no closure env.
@@ -232,6 +276,11 @@ proc ffiThreadBody[T](ctx: ptr FFIContext[T]) {.thread.} =
           let nextRequest = request[].next # read before processRequest frees it
           # Tick per dispatch so a backlog can't flatline the heartbeat mid-drain.
           ctx.proveAlive()
+          if request[].generation != ctx.currentGeneration():
+            # A past owner submitted this; its callback carries userData that host frees once its recycle returns ok, so drop it unanswered.
+            deleteRequest(request)
+            request = nextRequest
+            continue
           if ctx.myLib.isNil():
             # Must stay inside the closure: keeps `ffiReqHandler` alive across awaits.
             ctx.myLib = addr ffiReqHandler

--- a/ffi/ffi_thread_request.nim
+++ b/ffi/ffi_thread_request.nim
@@ -32,6 +32,8 @@ type FFIThreadRequest* = object
     ## ORC-heap alloc.
   responded*: bool
     ## De-dupes the callback across timeout/completion; both on FFI thread, no race.
+  generation*: uint
+    ## Claim the submitter resolved its context under; the FFI thread drops the request when the slot has since changed owner.
 
 func ffiPackScalar*[T](x: T): uint64 =
   ## Bit-cast one scalar into a uint64 request slot. Reverse with `ffiUnpackScalar`.
@@ -55,11 +57,24 @@ func ffiUnpackScalar*[T](u: uint64, _: typedesc[T]): T =
   else:
     T(u)
 
+proc deleteRequest*(request: ptr FFIThreadRequest) =
+  if request.isNil():
+    return
+  if not request[].data.isNil:
+    c_free(request[].data)
+  if not request[].reqId.isNil:
+    c_free(cast[pointer](request[].reqId))
+  c_free(request)
+
 proc allocBaseRequest(
     callback: FFICallBack, userData: pointer, reqId: cstring
 ): ptr FFIThreadRequest =
   ## c_malloc the envelope and set routing fields; payload set by a helper below.
+  ## Nil when the allocation fails; every caller passes that nil on, and
+  ## `sendRequestToFFIThread` turns it into an error for the host.
   var ret = cast[ptr FFIThreadRequest](c_malloc(csize_t(sizeof(FFIThreadRequest))))
+  if ret.isNil():
+    return nil
   ret[].callback = callback
   ret[].userData = userData
   ret[].reqId = reqId.alloc()
@@ -68,14 +83,21 @@ proc allocBaseRequest(
   ret[].rawReply = false
   ret[].next = nil
   ret[].responded = false
+  ret[].generation = 0
   return ret
 
-proc copySharedPayload(req: ptr FFIThreadRequest, data: ptr byte, dataLen: int) =
-  ## c_malloc a fresh buffer and copy `dataLen` bytes in; empty payload is a no-op.
-  if dataLen > 0 and not data.isNil():
-    req[].data = cast[ptr UncheckedArray[byte]](c_malloc(csize_t(dataLen)))
-    copyMem(req[].data, data, dataLen)
-    req[].dataLen = dataLen
+proc copySharedPayload(req: ptr FFIThreadRequest, data: ptr byte, dataLen: int): bool =
+  ## c_malloc a fresh buffer and copy `dataLen` bytes in; empty payload is a
+  ## no-op. False only when the allocation fails.
+  if dataLen <= 0 or data.isNil():
+    return true
+  let buf = cast[ptr UncheckedArray[byte]](c_malloc(csize_t(dataLen)))
+  if buf.isNil():
+    return false
+  copyMem(buf, data, dataLen)
+  req[].data = buf
+  req[].dataLen = dataLen
+  return true
 
 proc adoptOwnedSharedPayload(
     req: ptr FFIThreadRequest, data: ptr UncheckedArray[byte], dataLen: int
@@ -97,8 +119,13 @@ proc initFromPtr*(
     dataLen: int,
 ): ptr type T =
   ## Copies raw ptr+len into a fresh buffer owned by the returned request.
+  ## Nil when an allocation fails.
   var ret = allocBaseRequest(callback, userData, reqId)
-  copySharedPayload(ret, data, dataLen)
+  if ret.isNil():
+    return nil
+  if not copySharedPayload(ret, data, dataLen):
+    deleteRequest(ret)
+    return nil
   return ret
 
 proc init*(
@@ -128,7 +155,13 @@ proc initFromOwnedShared*(
   ## Adopts an already-c_malloc'd buffer (no copy); `deleteRequest` c_frees it.
   ## Pass `(nil, 0)` for an empty payload. Set `rawReply` when the handler answers
   ## with raw (non-CBOR) bytes, so an empty reply reads as a real empty value.
+  ## Nil when the allocation fails, in which case it frees the adopted buffer:
+  ## nobody else owns it any more.
   var ret = allocBaseRequest(callback, userData, reqId)
+  if ret.isNil():
+    if not data.isNil():
+      c_free(data)
+    return nil
   adoptOwnedSharedPayload(ret, data, dataLen)
   ret[].rawReply = rawReply
   return ret
@@ -141,10 +174,13 @@ proc initScalar*(
     args: varargs[uint64],
 ): ptr type T =
   ## Scalar-fast-path request: packed args ride inline, no payload c_malloc.
+  ## Nil when the allocation fails.
   doAssert args.len <= MaxScalarArgs,
     "initScalar: " & $args.len & " scalar args exceed MaxScalarArgs (" & $MaxScalarArgs &
       ")"
   var ret = allocBaseRequest(callback, userData, reqId)
+  if ret.isNil():
+    return nil
   ret[].rawReply = true
   for i in 0 ..< args.len:
     ret[].scalarArgs[i] = args[i]
@@ -169,13 +205,6 @@ func ffiRawRetBytes*[T](x: T): seq[byte] =
     var b = newSeq[byte](sizeof(uint64))
     copyMem(addr b[0], unsafeAddr u, sizeof(uint64))
     b
-
-proc deleteRequest*(request: ptr FFIThreadRequest) =
-  if not request[].data.isNil:
-    c_free(request[].data)
-  if not request[].reqId.isNil:
-    c_free(cast[pointer](request[].reqId))
-  c_free(request)
 
 proc fireCallback*(res: Result[seq[byte], string], request: ptr FFIThreadRequest) =
   ## Answers the foreign callback at most once (timeout and completion both call

--- a/ffi/internal/c_macro_helpers.nim
+++ b/ffi/internal/c_macro_helpers.nim
@@ -707,7 +707,7 @@ proc stringTrampBody(boxName: NimNode): NimNode =
       box.fn(RET_ERR, "".cstring, e.msg.cstring, box.ud)
 
 proc ctxBindingGuard(
-    poolIdent, emptyReply, ctxIdent: NimNode, isStatic: bool
+    poolIdent, emptyReply, ctxIdent, ctxGenIdent: NimNode, isStatic: bool
 ): NimNode {.compileTime.} =
   ## Prologue that binds `ctxIdent`: a method validates the ctx it was handed, a
   ## static resolves the library's shared one.
@@ -725,11 +725,13 @@ proc ctxBindingGuard(
     let methodGuard = quote:
       if onReply.isNil():
         return RET_MISSING_CALLBACK
-      if not `poolIdent`.isValidCtx(cast[pointer](`ctxIdent`)):
+      let `ctxIdent` = `poolIdent`.resolveCtx(ctxToken)
+      if `ctxIdent`.isNil():
         onReply(
           RET_ERR, `emptyReply`, "ctx is not a valid FFI context".cstring, userData
         )
         return RET_ERR
+      let `ctxGenIdent` = ctxToken.tokenGeneration()
     methodGuard.insert(0, initGuard)
     return methodGuard
   let guard = quote:
@@ -739,6 +741,8 @@ proc ctxBindingGuard(
       let errStr = "ffiStatic: " & error
       onReply(RET_ERR, `emptyReply`, errStr.cstring, userData)
       return RET_ERR
+    # No token to carry a claim: the static context holds its slot for the life of the library.
+    let `ctxGenIdent` = `ctxIdent`.currentGeneration()
   guard.insert(0, initGuard)
   guard
 
@@ -752,6 +756,7 @@ proc exportedProc(
   # calling in. A host thread that exits leaks its heap; accepted.
   let envName = spec.envelope
   let ctxIdent = ident("ctx")
+  let ctxGenIdent = ident("ctxGen")
   # String reply: empty non-nil cstring on error; object reply: nil ptr gated by err_code.
   let emptyReply =
     if isStringType(spec.respType):
@@ -768,6 +773,11 @@ proc exportedProc(
       return RET_ERR
     let reqBuf = cast[ptr UncheckedArray[byte]](ownedCopy)
     let box = cast[ptr `boxName`](allocBox(sizeof(`boxName`)))
+    if box.isNil():
+      cwireFree(ownedWire)
+      freeBox(ownedCopy)
+      onReply(RET_ERR, `emptyReply`, "out of memory".cstring, userData)
+      return RET_ERR
     box.fn = onReply
     box.ud = userData
     let typeStr = $`envName`
@@ -776,19 +786,22 @@ proc exportedProc(
     )
     let sendRes =
       try:
-        ffi_context.sendRequestToFFIThread(`ctxIdent`, reqPtr)
+        ffi_context.sendRequestToFFIThread(`ctxIdent`, reqPtr, `ctxGenIdent`)
       except Exception as e:
         Result[void, string].err("sendRequestToFFIThread exception: " & e.msg)
     if sendRes.isErr():
       # A rejected send already `deleteRequest`ed the struct copy, which frees only
       # the struct itself; `ownedWire` still aliases its field buffers, so free them
-      # here — on success the FFI thread's unpack does it instead.
+      # here — on success the FFI thread's unpack does it instead. The box only
+      # ever reaches `freeBox` in the reply trampoline, which a rejected send
+      # never runs.
       cwireFree(ownedWire)
+      freeBox(box)
       onReply(RET_ERR, `emptyReply`, sendRes.error.cstring, userData)
       return RET_ERR
     return RET_OK
 
-  let fullBody = ctxBindingGuard(poolIdent, emptyReply, ctxIdent, isStatic)
+  let fullBody = ctxBindingGuard(poolIdent, emptyReply, ctxIdent, ctxGenIdent, isStatic)
   for stmt in body:
     fullBody.add(stmt)
 
@@ -799,9 +812,8 @@ proc exportedProc(
     newIdentDefs(ident("req"), nnkPtrTy.newTree(envWire)),
   ]
   if not isStatic:
-    let libFFICtx =
-      nnkPtrTy.newTree(nnkBracketExpr.newTree(ident("FFIContext"), spec.libType))
-    params.insert(newIdentDefs(ctxIdent, libFFICtx), 1)
+    # The host holds an opaque token; `ctxBindingGuard` resolves it into `ctx`.
+    params.insert(newIdentDefs(ident("ctxToken"), ident("FFICtxToken")), 1)
 
   newProc(
     name = ident($envName & "CAbiExport"),
@@ -836,18 +848,29 @@ proc exportedCtorProc(
           ("ffiCtor: failed to create FFIContext: " & $ctxRes.error).cstring,
           userData,
         )
-      return nil
+      return FFICtxToken(nil)
     let ctx = ctxRes.get()
     var ownedWire: `envWire`
     cwirePack(ownedWire, cwireUnpack(req[]))
     let ownedCopy = cwireOwnedCopy(ownedWire)
     if ownedCopy.isNil():
+      # The slot is already claimed and the caller gets nil, so nobody is left to
+      # destroy it. The callback carries the real error; a failure here has no
+      # channel left of its own.
+      discard `poolIdent`.recycleFFIContext(ctx)
       cwireFree(ownedWire)
       if not onCreated.isNil():
         onCreated(RET_ERR, "".cstring, "out of memory".cstring, userData)
-      return nil
+      return FFICtxToken(nil)
     let reqBuf = cast[ptr UncheckedArray[byte]](ownedCopy)
     let box = cast[ptr `boxName`](allocBox(sizeof(`boxName`)))
+    if box.isNil():
+      discard `poolIdent`.recycleFFIContext(ctx)
+      cwireFree(ownedWire)
+      freeBox(ownedCopy)
+      if not onCreated.isNil():
+        onCreated(RET_ERR, "".cstring, "out of memory".cstring, userData)
+      return FFICtxToken(nil)
     box.fn = onCreated
     box.ud = userData
     let typeStr = $`envName`
@@ -861,17 +884,19 @@ proc exportedCtorProc(
         Result[void, string].err("sendRequestToFFIThread exception: " & e.msg)
     if sendRes.isErr():
       # See exportedMethodProc: the rejected send freed the struct copy, not the
-      # field buffers `ownedWire` still aliases.
+      # field buffers `ownedWire` still aliases, and not the box.
+      discard `poolIdent`.recycleFFIContext(ctx)
       cwireFree(ownedWire)
+      freeBox(box)
       if not onCreated.isNil():
         onCreated(RET_ERR, "".cstring, sendRes.error.cstring, userData)
-      return nil
-    return cast[pointer](ctx)
+      return FFICtxToken(nil)
+    return ctx.ffiToken()
   body.insert(0, initGuard)
   newProc(
     name = ident($envName & "CAbiExport"),
     params = @[
-      ident("pointer"),
+      ident("FFICtxToken"),
       newIdentDefs(ident("req"), nnkPtrTy.newTree(envWire)),
       newIdentDefs(ident("onCreated"), cbType),
       newIdentDefs(ident("userData"), ident("pointer")),

--- a/ffi/internal/ffi_library.nim
+++ b/ffi/internal/ffi_library.nim
@@ -166,7 +166,6 @@ macro declareLibrary*(
     when not declared(`poolIdent`):
       var `poolIdent`*: FFIContextPool[`libType`]
 
-  let ctxType = nnkPtrTy.newTree(nnkBracketExpr.newTree(ident("FFIContext"), libType))
   let cdeclExportPragma = newTree(
     nnkPragma,
     ident("dynlib"),
@@ -178,6 +177,8 @@ macro declareLibrary*(
   # {libraryName}_add_event_listener
   let addName = libraryName & "_add_event_listener"
   let addErr = "error: invalid context in " & addName
+  # `ctxIdent` is substituted so the body below sees it (`quote` gensyms).
+  let ctxIdent = ident("ctx")
   let addBody = quote:
     # This code runs on the foreign caller thread. That thread can differ from
     # the thread of an earlier entry point. If the GC of the thread is not
@@ -186,7 +187,8 @@ macro declareLibrary*(
     when declared(initializeLibrary):
       initializeLibrary()
     var ret: uint64 = 0
-    if isNil(ctx):
+    let `ctxIdent` = `poolIdent`.resolveCtx(ctxToken)
+    if `ctxIdent`.isNil():
       echo `addErr`
       return ret
     let evtName =
@@ -194,7 +196,7 @@ macro declareLibrary*(
         ""
       else:
         $eventName
-    ret = addEventListener(ctx[].eventRegistry, evtName, callback, userData)
+    ret = addEventListener(`ctxIdent`[].eventRegistry, evtName, callback, userData)
     return ret
 
   stmts.add(
@@ -202,7 +204,7 @@ macro declareLibrary*(
       name = ident(addName),
       params = @[
         ident("uint64"),
-        newIdentDefs(ident("ctx"), ctxType),
+        newIdentDefs(ident("ctxToken"), ident("FFICtxToken")),
         newIdentDefs(ident("eventName"), ident("cstring")),
         newIdentDefs(ident("callback"), ident("FFICallBack")),
         newIdentDefs(ident("userData"), ident("pointer")),
@@ -219,10 +221,11 @@ macro declareLibrary*(
     when declared(initializeLibrary):
       initializeLibrary()
     var ret: cint = 1
-    if isNil(ctx):
+    let `ctxIdent` = `poolIdent`.resolveCtx(ctxToken)
+    if `ctxIdent`.isNil():
       echo `removeErr`
       return ret
-    if removeEventListener(ctx[].eventRegistry, listenerId):
+    if removeEventListener(`ctxIdent`[].eventRegistry, listenerId):
       ret = 0
     return ret
 
@@ -231,7 +234,7 @@ macro declareLibrary*(
       name = ident(removeName),
       params = @[
         ident("cint"),
-        newIdentDefs(ident("ctx"), ctxType),
+        newIdentDefs(ident("ctxToken"), ident("FFICtxToken")),
         newIdentDefs(ident("listenerId"), ident("uint64")),
       ],
       body = removeBody,

--- a/ffi/internal/ffi_macro.nim
+++ b/ffi/internal/ffi_macro.nim
@@ -629,7 +629,9 @@ macro processReq*(
   let newReqCall = newCall(ident("ffiNewReq"), callArgs)
 
   let sendCall = newCall(
-    newDotExpr(ident("ffi_context"), ident("sendRequestToFFIThread")), ctx, newReqCall,
+    newDotExpr(ident("ffi_context"), ident("sendRequestToFFIThread")),
+    ctx,
+    newReqCall,
     ctxGen,
   )
 

--- a/ffi/internal/ffi_macro.nim
+++ b/ffi/internal/ffi_macro.nim
@@ -274,13 +274,14 @@ proc unpackHandleField*(
         return err(`errPrefix` & error)
       cast[`userType`](ffiH)
 
-proc cExportedParams(ctxType: NimNode, withCtx = true): seq[NimNode] =
+proc cExportedParams(withCtx = true): seq[NimNode] =
   ## C-exported wrapper param list (cint; ctx, callback, userData, reqCbor,
-  ## reqCborLen). A `{.ffiStatic.}` wrapper drops the leading `ctx`.
+  ## reqCborLen). The leading param is the host's opaque context token, which the
+  ## guard resolves. A `{.ffiStatic.}` wrapper drops it.
   var params: seq[NimNode] = @[]
   params.add(ident("cint"))
   if withCtx:
-    params.add(newIdentDefs(ident("ctx"), ctxType))
+    params.add(newIdentDefs(ident("ctxToken"), ident("FFICtxToken")))
   params.add(newIdentDefs(ident("callback"), ident("FFICallBack")))
   params.add(newIdentDefs(ident("userData"), ident("pointer")))
   params.add(newIdentDefs(ident("reqCbor"), nnkPtrTy.newTree(ident("byte"))))
@@ -618,10 +619,9 @@ macro registerReqFFI*(reqTypeName, reqHandler, body: untyped): untyped =
   return stmts
 
 macro processReq*(
-    reqType, ctx, callback, userData: untyped, args: varargs[untyped]
+    reqType, ctx, ctxGen, callback, userData: untyped, args: varargs[untyped]
 ): untyped =
-  ## Expands T.processReq(ctx, callback, userData, args...) into a
-  ## sendRequestToFFIThread call, reporting errors via `callback`.
+  ## Expands T.processReq(ctx, ctxGen, callback, userData, args...) into a sendRequestToFFIThread call, reporting errors via `callback`.
   var callArgs = @[reqType, callback, userData]
   for a in args:
     callArgs.add a
@@ -629,7 +629,8 @@ macro processReq*(
   let newReqCall = newCall(ident("ffiNewReq"), callArgs)
 
   let sendCall = newCall(
-    newDotExpr(ident("ffi_context"), ident("sendRequestToFFIThread")), ctx, newReqCall
+    newDotExpr(ident("ffi_context"), ident("sendRequestToFFIThread")), ctx, newReqCall,
+    ctxGen,
   )
 
   let blockExpr = quote:
@@ -672,9 +673,11 @@ macro ffiRaw*(args: varargs[untyped]): untyped =
   let reqName = ident($procName & "Req")
   let returnType = ident("cint")
 
+  # The host holds an opaque token; the guard below resolves it into a context.
   var newParams = newSeq[NimNode]()
   newParams.add(returnType)
-  for i in 1 ..< formalParams.len:
+  newParams.add(newIdentDefs(ident("ctxToken"), ident("FFICtxToken")))
+  for i in 2 ..< formalParams.len:
     newParams.add(newIdentDefs(formalParams[i][0], formalParams[i][1]))
 
   let futReturnType = quote:
@@ -686,8 +689,10 @@ macro ffiRaw*(args: varargs[untyped]): untyped =
     for i in 4 ..< formalParams.len:
       userParams.add(newIdentDefs(formalParams[i][0], formalParams[i][1]))
 
-  var argsList = newSeq[NimNode]()
-  for i in 1 ..< formalParams.len:
+  let ctxIdent = formalParams[1][0]
+  let ctxGenIdent = ident("ctxGen")
+  var argsList = @[ctxIdent, ctxGenIdent]
+  for i in 2 ..< formalParams.len:
     argsList.add(formalParams[i][0])
 
   let dotExpr = newTree(nnkDotExpr, reqName, ident"processReq")
@@ -699,11 +704,15 @@ macro ffiRaw*(args: varargs[untyped]): untyped =
   let ffiBody = newStmtList(
     quote do:
       initializeLibrary()
-      if not `poolIdent`.isValidCtx(cast[pointer](ctx)):
-        return RET_ERR
-      ctx[].userData = userData
       if isNil(callback):
         return RET_MISSING_CALLBACK
+      let `ctxIdent` = `poolIdent`.resolveCtx(ctxToken)
+      if `ctxIdent`.isNil():
+        let errStr = "ctx is not a valid FFI context"
+        callback(RET_ERR, unsafeAddr errStr[0], cast[csize_t](errStr.len), userData)
+        return RET_ERR
+      let `ctxGenIdent` = ctxToken.tokenGeneration()
+      `ctxIdent`[].userData = userData
   )
 
   ffiBody.add(callNode)
@@ -956,20 +965,23 @@ proc buildFFIProc(
   let poolIdent = ident($libTypeName & "FFIPool")
 
   proc buildCtxGuard(): NimNode =
-    ## Nil-checks callback and validates `ctx`, replying `RET_ERR` before build.
+    ## Nil-checks callback and resolves the host token, replying `RET_ERR` before build. `ctxIdent`/`ctxGenIdent` are substituted so the send below sees them (`quote` gensyms).
+    let ctxIdent = ident("ctx")
+    let ctxGenIdent = ident("ctxGen")
     quote:
       if callback.isNil:
         return RET_MISSING_CALLBACK
-      if not `poolIdent`.isValidCtx(cast[pointer](ctx)):
+      let `ctxIdent` = `poolIdent`.resolveCtx(ctxToken)
+      if `ctxIdent`.isNil():
         let errStr = "ctx is not a valid FFI context"
         callback(RET_ERR, unsafeAddr errStr[0], cast[csize_t](errStr.len), userData)
         return RET_ERR
+      let `ctxGenIdent` = ctxToken.tokenGeneration()
 
   proc buildStaticCtxGuard(): NimNode =
-    ## Binds the library's static context; a static call may be the host's first
-    ## entry, hence `initializeLibrary`.
-    # `ctxIdent` is substituted so the send below sees it (`quote` gensyms).
+    ## Binds the library's static context; a static call may be the host's first entry, hence `initializeLibrary`.
     let ctxIdent = ident("ctx")
+    let ctxGenIdent = ident("ctxGen")
     quote:
       initializeLibrary()
       if callback.isNil():
@@ -978,6 +990,8 @@ proc buildFFIProc(
         let errStr = "ffiStatic: " & error
         callback(RET_ERR, unsafeAddr errStr[0], cast[csize_t](errStr.len), userData)
         return RET_ERR
+      # No token to carry a claim: the static context holds its slot for the life of the library.
+      let `ctxGenIdent` = `ctxIdent`.currentGeneration()
 
   proc buildSendAndReply(reqPtrIdent: NimNode): NimNode =
     ## Hands `reqPtrIdent` to the FFI thread and maps the outcome to a C return code.
@@ -985,7 +999,7 @@ proc buildFFIProc(
     quote:
       let `sendResIdent` =
         try:
-          ffi_context.sendRequestToFFIThread(ctx, `reqPtrIdent`)
+          ffi_context.sendRequestToFFIThread(ctx, `reqPtrIdent`, ctxGen)
         except Exception as exc:
           Result[void, string].err("sendRequestToFFIThread exception: " & exc.msg)
       if `sendResIdent`.isErr():
@@ -1070,7 +1084,7 @@ proc buildFFIProc(
         `lambdaNode`
 
     # C-exported wrapper: (ctx, callback, userData, reqCbor, reqCborLen).
-    let exportedParams = cExportedParams(ctxType, withCtx = not isStatic)
+    let exportedParams = cExportedParams(withCtx = not isStatic)
 
     let ffiBody = newStmtList()
     # Flattened: the guard's `let ctx` must be a sibling of the send to be in scope.
@@ -1355,7 +1369,7 @@ proc buildCtorProcessFFIRequestProc(
     `libReadyIdent`.store(true)
 
   newBody.add quote do:
-    return ok($cast[uint](`ctxIdent`))
+    return ok($cast[uint](`ctxIdent`.ffiToken()))
 
   let processProc = newProc(
     name = postfix(ident("processFFIRequest"), "*"),
@@ -1494,9 +1508,9 @@ macro ffiCtor*(args: varargs[untyped]): untyped =
   )
   let addToReg = addCtorRequestToRegistry(reqTypeName, libTypeName, abiFormat)
 
-  # C-exported proc: (reqCbor, reqCborLen, callback, userData) -> pointer
+  # C-exported proc: (reqCbor, reqCborLen, callback, userData) -> ctx token
   var exportedParams = newSeq[NimNode]()
-  exportedParams.add(ident("pointer"))
+  exportedParams.add(ident("FFICtxToken"))
   exportedParams.add(newIdentDefs(ident("reqCbor"), nnkPtrTy.newTree(ident("byte"))))
   exportedParams.add(newIdentDefs(ident("reqCborLen"), ident("csize_t")))
   exportedParams.add(newIdentDefs(ident("callback"), ident("FFICallBack")))
@@ -1516,7 +1530,7 @@ macro ffiCtor*(args: varargs[untyped]): untyped =
       if not callback.isNil:
         let errStr = "ffiCtor: failed to create FFIContext: " & $error
         callback(RET_ERR, unsafeAddr errStr[0], cast[csize_t](errStr.len), userData)
-      return nil
+      return FFICtxToken(nil)
 
   # Early validation: decode the CBOR payload to verify it parses cleanly.
   ffiBody.add quote do:
@@ -1525,10 +1539,14 @@ macro ffiCtor*(args: varargs[untyped]): untyped =
         cast[ptr UncheckedArray[byte]](reqCbor), int(reqCborLen), `reqTypeName`
       )
       if validateRes.isErr():
+        # The slot is already claimed and the caller gets nil, so nobody is left
+        # to destroy it. The callback carries the real error; a failure here has
+        # no channel left of its own.
+        discard `poolIdent`.recycleFFIContext(`ctxSym`)
         if not callback.isNil:
           let errStr = "ffiCtor: failed to decode request: " & $validateRes.error
           callback(RET_ERR, unsafeAddr errStr[0], cast[csize_t](errStr.len), userData)
-        return nil
+        return FFICtxToken(nil)
 
   let newReqCall = newCall(
     ident("ffiNewReq"),
@@ -1550,13 +1568,14 @@ macro ffiCtor*(args: varargs[untyped]): untyped =
       except Exception as exc:
         Result[void, string].err("sendRequestToFFIThread exception: " & exc.msg)
     if `sendResIdent`.isErr():
+      discard `poolIdent`.recycleFFIContext(`ctxSym`)
       if not callback.isNil:
         let errStr = "ffiCtor: failed to send request: " & $`sendResIdent`.error
         callback(RET_ERR, unsafeAddr errStr[0], cast[csize_t](errStr.len), userData)
-      return nil
+      return FFICtxToken(nil)
 
   ffiBody.add quote do:
-    return cast[pointer](`ctxSym`)
+    return `ctxSym`.ffiToken()
 
   let ffiProc = newProc(
     name = postfix(cExportProcName, "*"),
@@ -1667,8 +1686,11 @@ proc buildFFIDtorProc(prc: NimNode, abiFormat: ABIFormat): NimNode {.compileTime
     when declared(initializeLibrary):
       initializeLibrary()
 
+  let poolIdent = ident($libTypeName & "FFIPool")
+  let ctxSym = genSym(nskLet, "ctx")
   ffiBody.add quote do:
-    if ctx.isNil or cast[ptr FFIContext[`libTypeName`]](ctx)[].myLib.isNil:
+    let `ctxSym` = `poolIdent`.resolveCtx(ctx)
+    if `ctxSym`.isNil() or `ctxSym`[].myLib.isNil:
       return RET_ERR
 
   let isNoop =
@@ -1690,10 +1712,8 @@ proc buildFFIDtorProc(prc: NimNode, abiFormat: ABIFormat): NimNode {.compileTime
 
         ffiTeardownHook[`libTypeName`]() = `teardownImplName`
 
-  let poolIdent = ident($libTypeName & "FFIPool")
   ffiBody.add quote do:
-    let `destroyResIdent` =
-      `poolIdent`.recycleFFIContext(cast[ptr FFIContext[`libTypeName`]](ctx))
+    let `destroyResIdent` = `poolIdent`.recycleFFIContext(`ctxSym`)
     if `destroyResIdent`.isErr():
       return RET_ERR
 
@@ -1702,7 +1722,7 @@ proc buildFFIDtorProc(prc: NimNode, abiFormat: ABIFormat): NimNode {.compileTime
 
   let ffiProc = newProc(
     name = postfix(cExportProcName, "*"),
-    params = @[ident("cint"), newIdentDefs(ident("ctx"), ident("pointer"))],
+    params = @[ident("cint"), newIdentDefs(ident("ctx"), ident("FFICtxToken"))],
     body = ffiBody,
     pragmas = newTree(
       nnkPragma,

--- a/ffi/internal/ffi_scalar.nim
+++ b/ffi/internal/ffi_scalar.nim
@@ -110,7 +110,7 @@ proc buildScalarPath*(
 
   var scalarParams = @[
     ident("cint"),
-    newIdentDefs(ident("ctx"), ctxType),
+    newIdentDefs(ident("ctxToken"), ident("FFICtxToken")),
     newIdentDefs(ident("callback"), ident("FFICallBack")),
     newIdentDefs(ident("userData"), ident("pointer")),
   ]

--- a/tests/unit/fixtures/ffiraw_fixture.nim
+++ b/tests/unit/fixtures/ffiraw_fixture.nim
@@ -1,0 +1,16 @@
+## Compile fixture for the `{.ffiRaw.}` entry point (see
+## tests/unit/test_ffi_raw.nim): nothing else in the tree uses that pragma, so
+## its expansion would otherwise never be compiled.
+
+import ffi, chronos
+
+type RawLib = object
+
+declareLibrary("rawlib", RawLib)
+
+proc rawlib_echo*(
+    ctx: ptr FFIContext[RawLib], callback: FFICallBack, userData: pointer, msg: string
+): Future[Result[string, string]] {.ffiRaw.} =
+  return ok(msg)
+
+genBindings()

--- a/tests/unit/fixtures/foreign_thread_c_abi_fixture.nim
+++ b/tests/unit/fixtures/foreign_thread_c_abi_fixture.nim
@@ -69,7 +69,7 @@ proc packedWire[W, R](_: typedesc[W], envelope: R): W =
   cwirePack(wire, envelope)
   wire
 
-proc makeCtx(tag: string): ptr FFIContext[ThreadLib] =
+proc makeCtx(tag: string): FFICtxToken =
   var d: ReplyData
   initReplyData(d)
   defer:
@@ -86,8 +86,8 @@ proc makeCtx(tag: string): ptr FFIContext[ThreadLib] =
     .isNil()
   waitReply(d)
   doAssert d.retCode == RET_OK
-  # The ctor's reply text is the new ctx pointer as a decimal string.
-  cast[ptr FFIContext[ThreadLib]](cast[uint](parseBiggestUInt(d.text)))
+  # The ctor's reply text is the new ctx token as a decimal string.
+  cast[FFICtxToken](parseBiggestUInt(d.text))
 
 # Nim's createThread registers its new thread with the GC. A registered thread
 # cannot show the bug. The test thread must come from the platform API.
@@ -161,7 +161,7 @@ proc nimffi_call_on_foreign_thread(
 ): cint {.importc, nodecl.}
 
 proc callOnForeignThread(
-    ctx: ptr FFIContext[ThreadLib], req: ptr ThreadedcabiEchoReq_CWire, d: ptr ReplyData
+    ctx: FFICtxToken, req: ptr ThreadedcabiEchoReq_CWire, d: ptr ReplyData
 ): cint =
   ## This proc passes the export to C as an opaque pointer. Only the typedef
   ## above can differ from the generated signature.
@@ -193,7 +193,7 @@ proc runScenario(tag: string, rounds: int): bool =
       echo tag, ": round ", i, " failed: rc=", rc, " ret=", d.retCode, " text=", d.text
       return false
 
-  if ThreadLibFFIPool.destroyFFIContext(ctx).isErr():
+  if ThreadLibFFIPool.destroyFFIContext(ThreadLibFFIPool.resolveCtx(ctx)).isErr():
     echo tag, ": destroyFFIContext failed"
     return false
   return true

--- a/tests/unit/test_c_abi_dispatch.nim
+++ b/tests/unit/test_c_abi_dispatch.nim
@@ -134,7 +134,7 @@ proc makeCtx(tag: string): ptr FFIContext[WireLib] =
   doAssert not WirefastCreateCtorReqCAbiExport(addr wire, onStringReply, addr d).isNil()
   waitReply(d)
   doAssert d.retCode == RET_OK
-  cast[ptr FFIContext[WireLib]](cast[uint](parseBiggestUInt(d.text)))
+  WireLibFFIPool.resolveCtx(cast[FFICtxToken](parseBiggestUInt(d.text)))
 
 suite "abi = c non-scalar dispatch — CBOR-free wire transport":
   test "seq + Option request round-trips into an object reply":
@@ -153,7 +153,8 @@ suite "abi = c non-scalar dispatch — CBOR-free wire transport":
     defer:
       cwireFree(req)
 
-    check WirefastBulkReqCAbiExport(ctx, onBulkReply, addr d, addr req) == RET_OK
+    check WirefastBulkReqCAbiExport(ctx.ffiToken(), onBulkReply, addr d, addr req) ==
+      RET_OK
     waitReply(d)
 
     check d.retCode == RET_OK
@@ -177,7 +178,8 @@ suite "abi = c non-scalar dispatch — CBOR-free wire transport":
     defer:
       cwireFree(req)
 
-    check WirefastBulkReqCAbiExport(ctx, onBulkReply, addr d, addr req) == RET_OK
+    check WirefastBulkReqCAbiExport(ctx.ffiToken(), onBulkReply, addr d, addr req) ==
+      RET_OK
     waitReply(d)
 
     check d.retCode == RET_OK
@@ -201,7 +203,8 @@ suite "abi = c non-scalar dispatch — CBOR-free wire transport":
     defer:
       cwireFree(req)
 
-    check WirefastGreetReqCAbiExport(ctx, onStringReply, addr d, addr req) == RET_OK
+    check WirefastGreetReqCAbiExport(ctx.ffiToken(), onStringReply, addr d, addr req) ==
+      RET_OK
     waitReply(d)
 
     check d.retCode == RET_OK
@@ -223,7 +226,8 @@ suite "abi = c non-scalar dispatch — CBOR-free wire transport":
     defer:
       cwireFree(req)
 
-    check WirefastGreetReqCAbiExport(ctx, onStringReply, addr d, addr req) == RET_OK
+    check WirefastGreetReqCAbiExport(ctx.ffiToken(), onStringReply, addr d, addr req) ==
+      RET_OK
     waitReply(d)
 
     check d.retCode == RET_ERR

--- a/tests/unit/test_ctx_after_failed_ctor.nim
+++ b/tests/unit/test_ctx_after_failed_ctor.nim
@@ -75,7 +75,7 @@ proc createFailedCtx(s: var CallbackState): ptr FFIContext[FailedCtorLib] =
   if ret.isNil():
     return nil
   discard waitCalled(s)
-  cast[ptr FFIContext[FailedCtorLib]](ret)
+  FailedCtorLibFFIPool.resolveCtx(ret)
 
 suite "{.ffi.} call after a failed constructor":
   test "the failed ctor reports the error but leaves the context alive":
@@ -99,8 +99,9 @@ suite "{.ffi.} call after a failed constructor":
 
     resetState(s)
     var req = cborEncode(FailedctorPingReq())
-    let ret =
-      failedctor_ping(ctx, recordingCallback, addr s, encodedPtr(req), req.len.csize_t)
+    let ret = failedctor_ping(
+      ctx.ffiToken(), recordingCallback, addr s, encodedPtr(req), req.len.csize_t
+    )
     check ret == RET_OK
     check waitCalled(s)
     check s.retCode.load() == int(RET_ERR)
@@ -112,8 +113,9 @@ suite "{.ffi.} call after a failed constructor":
 
     resetState(s)
     var req = cborEncode(FailedctorEchoReq(note: "hello"))
-    let ret =
-      failedctor_echo(ctx, recordingCallback, addr s, encodedPtr(req), req.len.csize_t)
+    let ret = failedctor_echo(
+      ctx.ffiToken(), recordingCallback, addr s, encodedPtr(req), req.len.csize_t
+    )
     check ret == RET_OK
     check waitCalled(s)
     check s.retCode.load() == int(RET_ERR)
@@ -129,14 +131,18 @@ suite "{.ffi.} call after a failed constructor":
       encodedPtr(cfg), cfg.len.csize_t, recordingCallback, addr ctorState
     )
     check not raw.isNil()
-    let ctx = cast[ptr FFIContext[FailedCtorLib]](raw)
+    let ctx = FailedCtorLibFFIPool.resolveCtx(raw)
 
     # No wait here, on purpose: the request goes into the queue behind the ctor.
     var callState: CallbackState
     resetState(callState)
     var req = cborEncode(FailedctorPingReq())
     let ret = failedctor_ping(
-      ctx, recordingCallback, addr callState, encodedPtr(req), req.len.csize_t
+      ctx.ffiToken(),
+      recordingCallback,
+      addr callState,
+      encodedPtr(req),
+      req.len.csize_t,
     )
     check ret == RET_OK
     check waitCalled(callState)

--- a/tests/unit/test_ctx_validation.nim
+++ b/tests/unit/test_ctx_validation.nim
@@ -42,7 +42,7 @@ suite "ctx pointer validation at the FFI entry point":
   test "nil ctx with valid callback returns RET_ERR via callback, no crash":
     var s: CallbackState
     initCbState(s)
-    let nilCtx: ptr FFIContext[TestLib] = nil
+    let nilCtx = cast[FFICtxToken](nil)
     let ret = ctxval_ping(nilCtx, validationCallback, addr s, nil, 0.csize_t)
     check ret == RET_ERR
     check s.called.load()
@@ -51,7 +51,7 @@ suite "ctx pointer validation at the FFI entry point":
   test "invalid non-nil ctx (offset-pointer) returns RET_ERR, no crash":
     var s: CallbackState
     initCbState(s)
-    let invalidCtx = cast[ptr FFIContext[TestLib]](123)
+    let invalidCtx = cast[FFICtxToken](123)
     let ret = ctxval_ping(invalidCtx, validationCallback, addr s, nil, 0.csize_t)
     check ret == RET_ERR
     check s.called.load()

--- a/tests/unit/test_ffi_claim_generation.nim
+++ b/tests/unit/test_ffi_claim_generation.nim
@@ -1,0 +1,89 @@
+## The claim marker and the request stamp are cut from the same generation, so a
+## token or a request of a past owner never reaches the next one.
+
+import std/[atomics, os]
+import unittest2
+import results
+import ffi
+
+type ClaimLib = object
+
+registerReqFFI(NoopRequest, lib: ptr ClaimLib):
+  proc(): Future[Result[string, string]] {.async.} =
+    return ok("noop")
+
+# Module-level, as declareLibrary emits it: a recycled slot keeps its threads,
+# so the pool must outlive every test that claims from it.
+var gPool: FFIContextPool[ClaimLib]
+
+var gCalls: Atomic[int]
+
+proc countingCallback(
+    retCode: cint, msg: ptr cchar, len: csize_t, userData: pointer
+) {.cdecl, gcsafe, raises: [].} =
+  if retCode == RET_STALE_WARN:
+    return
+  gCalls.atomicInc()
+
+proc waitForCalls(n: int): bool =
+  for _ in 0 ..< 500:
+    if gCalls.load() >= n:
+      return true
+    os.sleep(10)
+  false
+
+suite "claim and generation are one atomic":
+  test "a claim leaves an odd generation and a token that names it":
+    let ctx = gPool.createFFIContext().valueOr:
+      checkpoint "createFFIContext failed: " & $error
+      check false
+      return
+    check ctx.isInUse()
+    check (ctx.currentGeneration() and 1) == 1
+    check ctx.ffiToken().tokenGeneration() == ctx.currentGeneration()
+    check gPool.isValidCtx(ctx.ffiToken())
+    check gPool.recycleFFIContext(ctx).isOk()
+
+  test "a losing claim leaves the owner's token alive":
+    let ctx = gPool.createFFIContext().valueOr:
+      checkpoint "createFFIContext failed: " & $error
+      check false
+      return
+    let token = ctx.ffiToken()
+    let generation = ctx.currentGeneration()
+    check not ctx.tryClaim()
+    check ctx.currentGeneration() == generation
+    check gPool.isValidCtx(token)
+    check gPool.recycleFFIContext(ctx).isOk()
+
+  test "a released slot carries an even generation that no token names":
+    let ctx = gPool.createFFIContext().valueOr:
+      checkpoint "createFFIContext failed: " & $error
+      check false
+      return
+    let token = ctx.ffiToken()
+    check gPool.recycleFFIContext(ctx).isOk()
+    check not ctx.isInUse()
+    check (ctx.currentGeneration() and 1) == 0
+    check not gPool.isValidCtx(token)
+
+suite "a request carries the claim it was submitted under":
+  test "a stamp from another claim is rejected at the send":
+    let ctx = gPool.createFFIContext().valueOr:
+      checkpoint "createFFIContext failed: " & $error
+      check false
+      return
+    defer:
+      check gPool.recycleFFIContext(ctx).isOk()
+
+    gCalls.store(0)
+    let staleGeneration = ctx.currentGeneration() - 2
+    check sendRequestToFFIThread(
+      ctx, NoopRequest.ffiNewReq(countingCallback, nil), staleGeneration
+    )
+      .isErr()
+    # The send owns the rejection, so the callback of the past owner stays untouched.
+    check gCalls.load() == 0
+
+    check sendRequestToFFIThread(ctx, NoopRequest.ffiNewReq(countingCallback, nil)).isOk()
+    check waitForCalls(1)

--- a/tests/unit/test_ffi_context.nim
+++ b/tests/unit/test_ffi_context.nim
@@ -153,7 +153,7 @@ suite "FFIContextPool":
       return
     check staticPool.staticFFIContext().tryGet() == first
     # Occupies a pool slot like any other context.
-    check staticPool.isValidCtx(first)
+    check staticPool.isValidCtx(first.ffiToken())
     check staticPool.destroyFFIContext(first).isErr()
     # Still live, and still the same context.
     check staticPool.staticFFIContext().tryGet() == first
@@ -462,7 +462,7 @@ suite "ffiCtor macro":
 
     let ctxAddr = ctorAddrFromCbor(callbackBytes(d))
     check ctxAddr != 0
-    let ctx = cast[ptr FFIContext[SimpleLib]](ctxAddr)
+    let ctx = SimpleLibFFIPool.resolveCtx(cast[FFICtxToken](ctxAddr))
 
     check not ctx[].myLib.isNil
     check ctx[].myLib[].value == 42
@@ -494,7 +494,7 @@ suite "simplified .ffi. macro":
 
     let ctxAddr = ctorAddrFromCbor(callbackBytes(ctorD))
     check ctxAddr != 0
-    let ctx = cast[ptr FFIContext[SimpleLib]](ctxAddr)
+    let ctx = SimpleLibFFIPool.resolveCtx(cast[FFICtxToken](ctxAddr))
     defer:
       check SimpleLibFFIPool.destroyFFIContext(ctx).isOk()
 
@@ -505,7 +505,7 @@ suite "simplified .ffi. macro":
 
     var reqBytes = cborEncode(TestlibSendReq(cfg: SendConfig(message: "hello")))
     let ret = testlib_send(
-      ctx, testCallback, addr d, encodedPtr(reqBytes), reqBytes.len.csize_t
+      ctx.ffiToken(), testCallback, addr d, encodedPtr(reqBytes), reqBytes.len.csize_t
     )
     check ret == RET_OK
 
@@ -535,7 +535,7 @@ suite "sync-body .ffi. is dispatched on FFI thread":
 
     let ctxAddr = ctorAddrFromCbor(callbackBytes(ctorD))
     check ctxAddr != 0
-    let ctx = cast[ptr FFIContext[SimpleLib]](ctxAddr)
+    let ctx = SimpleLibFFIPool.resolveCtx(cast[FFICtxToken](ctxAddr))
     defer:
       check SimpleLibFFIPool.destroyFFIContext(ctx).isOk()
 
@@ -546,7 +546,11 @@ suite "sync-body .ffi. is dispatched on FFI thread":
 
     var emptyBytes = cborEncode(TestlibVersionReq())
     let ret = testlib_version(
-      ctx, testCallback, addr d2, encodedPtr(emptyBytes), emptyBytes.len.csize_t
+      ctx.ffiToken(),
+      testCallback,
+      addr d2,
+      encodedPtr(emptyBytes),
+      emptyBytes.len.csize_t,
     )
     check ret == RET_OK
     waitCallback(d2)
@@ -596,7 +600,7 @@ suite "sync-body .ffi. runs on FFI thread (PR #23 regression)":
     check ctorD.retCode == RET_OK
     let ctxAddr = ctorAddrFromCbor(callbackBytes(ctorD))
     check ctxAddr != 0
-    let ctx = cast[ptr FFIContext[SimpleLib]](ctxAddr)
+    let ctx = SimpleLibFFIPool.resolveCtx(cast[FFICtxToken](ctxAddr))
     defer:
       check SimpleLibFFIPool.destroyFFIContext(ctx).isOk()
 
@@ -610,7 +614,7 @@ suite "sync-body .ffi. runs on FFI thread (PR #23 regression)":
 
     var reqBytes = cborEncode(TestlibRecordTidReq(req: RecordTidReq(dummy: 1)))
     let ret = testlib_record_tid(
-      ctx, testCallback, addr d, encodedPtr(reqBytes), reqBytes.len.csize_t
+      ctx.ffiToken(), testCallback, addr d, encodedPtr(reqBytes), reqBytes.len.csize_t
     )
     check ret == RET_OK
     waitCallback(d)
@@ -701,7 +705,7 @@ proc createSimpleCtx(): ptr FFIContext[SimpleLib] =
   let ctxAddr = ctorAddrFromCbor(callbackBytes(ctorD))
   if ctxAddr == 0:
     return nil
-  cast[ptr FFIContext[SimpleLib]](ctxAddr)
+  SimpleLibFFIPool.resolveCtx(cast[FFICtxToken](ctxAddr))
 
 ## Keeps stale pings apart from the one terminal answer so a test can assert both.
 type StaleData = object
@@ -765,7 +769,7 @@ suite "non-terminal RET_STALE_WARN progress signal":
 
     var reqBytes = cborEncode(TestlibSlowStaleReq(cfg: StaleConfig(dummy: 0)))
     let ret = testlib_slow_stale(
-      ctx, staleCallback, addr d, encodedPtr(reqBytes), reqBytes.len.csize_t
+      ctx.ffiToken(), staleCallback, addr d, encodedPtr(reqBytes), reqBytes.len.csize_t
     )
     check ret == RET_OK
 

--- a/tests/unit/test_ffi_handle.nim
+++ b/tests/unit/test_ffi_handle.nim
@@ -93,7 +93,8 @@ proc encodedPtr(b: var seq[byte]): ptr byte =
 template runCall(d, ctx, reqBytes, exportProc) =
   initCallbackData(d)
   var rb = reqBytes
-  check exportProc(ctx, testCallback, addr d, encodedPtr(rb), rb.len.csize_t) == RET_OK
+  check exportProc(ctx.ffiToken(), testCallback, addr d, encodedPtr(rb), rb.len.csize_t) ==
+    RET_OK
   waitCallback(d)
 
 suite "{.ffiHandle.} round-trip":

--- a/tests/unit/test_ffi_raw.nim
+++ b/tests/unit/test_ffi_raw.nim
@@ -1,0 +1,9 @@
+## `{.ffiRaw.}` has no user left in the tree, so its expansion is compiled here.
+
+import unittest2
+import ./fixture_gen
+
+suite "{.ffiRaw.} entry point":
+  test "the raw proc expands into an entry point that compiles":
+    let genned = genFixtureBindings("ffiraw_fixture", "c")
+    check genned.exitCode == 0

--- a/tests/unit/test_ffi_recycle_reset.nim
+++ b/tests/unit/test_ffi_recycle_reset.nim
@@ -235,6 +235,19 @@ suite "recycle with a handler that does not drain":
     check not wasCalled(gBlockData)
     check not ctx[].myLib.isNil()
 
+    # The failure is terminal, so the wedged slot answers every later caller the same way.
+    check RecycleLibFFIPool.recycleFFIContext(ctx).isErr()
+
+    var rd: CallbackData
+    initCallbackData(rd)
+    defer:
+      deinitCallbackData(rd)
+    var rejected = cborEncode(RecyclelibOpenReq(req: OpenReq(name: "after-failure")))
+    check recyclelib_open(
+      ctx.ffiToken(), testCallback, addr rd, encodedPtr(rejected), rejected.len.csize_t
+    ) == RET_ERR
+    check rd.retCode == RET_ERR
+
     # The slot stays claimed: handing it to a new owner is what the failed drain
     # rules out.
     let other = RecycleLibFFIPool.createFFIContext().get()

--- a/tests/unit/test_ffi_recycle_reset.nim
+++ b/tests/unit/test_ffi_recycle_reset.nim
@@ -1,0 +1,246 @@
+## Recycle hands the pool slot back with nothing of the previous owner left on
+## it: no live handles, and no teardown at all while a handler still runs.
+
+import std/[atomics, locks, os]
+import unittest2
+import results
+import ffi
+
+type RecycleLib = object
+
+# Stub the importc NimMain declareLibrary emits (plain-exe link).
+{.emit: "void librecyclelibNimMain(void) {}".}
+
+declareLibrary("recyclelib", RecycleLib)
+
+type Session {.ffiHandle.} = ref object
+  token: string
+
+type OpenReq {.ffi.} = object
+  name: string
+
+proc recyclelib_open*(
+    lib: RecycleLib, req: OpenReq
+): Future[Result[Session, string]] {.ffi.} =
+  return ok(Session(token: req.name))
+
+proc recyclelib_token*(
+    lib: RecycleLib, s: Session
+): Future[Result[string, string]] {.ffi.} =
+  return ok(s.token)
+
+var gHold: Atomic[bool]
+var gEntered: Atomic[bool]
+
+proc waitForRelease() {.async.} =
+  while gHold.load():
+    await sleepAsync(10.milliseconds)
+
+proc recyclelib_block*(lib: RecycleLib): Future[Result[int, string]] {.ffi.} =
+  ## Uncancellable on purpose: `cancelSoon` cannot unwind a `noCancel`, so the
+  ## drain of the recycle handler runs out of both rounds.
+  gEntered.store(true)
+  await noCancel(waitForRelease())
+  return ok(1)
+
+type CallbackData = object
+  lock: Lock
+  cond: Cond
+  called: bool
+  retCode: cint
+  msg: array[1024, byte]
+  msgLen: int
+
+proc initCallbackData(d: var CallbackData) =
+  d.lock.initLock()
+  d.cond.initCond()
+
+proc deinitCallbackData(d: var CallbackData) =
+  d.cond.deinitCond()
+  d.lock.deinitLock()
+
+proc testCallback(
+    retCode: cint, msg: ptr cchar, len: csize_t, userData: pointer
+) {.cdecl, gcsafe, raises: [].} =
+  let d = cast[ptr CallbackData](userData)
+  acquire(d[].lock)
+  d[].retCode = retCode
+  let n = min(int(len), d[].msg.len)
+  if n > 0 and not msg.isNil:
+    copyMem(addr d[].msg[0], msg, n)
+  d[].msgLen = n
+  d[].called = true
+  signal(d[].cond)
+  release(d[].lock)
+
+proc waitCallback(d: var CallbackData) =
+  acquire(d.lock)
+  while not d.called:
+    wait(d.cond, d.lock)
+  release(d.lock)
+
+proc wasCalled(d: var CallbackData): bool =
+  acquire(d.lock)
+  let called = d.called
+  release(d.lock)
+  called
+
+proc payload(d: var CallbackData): seq[byte] =
+  var b = newSeq[byte](d.msgLen)
+  if d.msgLen > 0:
+    copyMem(addr b[0], addr d.msg[0], d.msgLen)
+  b
+
+proc encodedPtr(b: var seq[byte]): ptr byte =
+  if b.len == 0:
+    nil
+  else:
+    cast[ptr byte](addr b[0])
+
+template runCall(d, ctx, reqBytes, exportProc) =
+  initCallbackData(d)
+  var rb = reqBytes
+  check exportProc(ctx.ffiToken(), testCallback, addr d, encodedPtr(rb), rb.len.csize_t) ==
+    RET_OK
+  waitCallback(d)
+
+# The blocked handler answers long after its test returns, so its state is a
+# global: a stack copy would be gone by then.
+var gBlockData: CallbackData
+
+suite "recycle opens a new generation on the slot":
+  test "the token of the previous owner no longer resolves":
+    let first = RecycleLibFFIPool.createFFIContext().get()
+    let staleToken = first.ffiToken()
+    check RecycleLibFFIPool.isValidCtx(staleToken)
+
+    check RecycleLibFFIPool.recycleFFIContext(first).isOk()
+    # Between the recycle and the next claim the slot is free, so the token is
+    # already dead. Reuse is the case the generation exists for.
+    check not RecycleLibFFIPool.isValidCtx(staleToken)
+
+    let second = RecycleLibFFIPool.createFFIContext().get()
+    # Lowest free slot wins: same address, new owner, new generation.
+    check second == first
+    check second.ffiToken() != staleToken
+    check not RecycleLibFFIPool.isValidCtx(staleToken)
+    check RecycleLibFFIPool.resolveCtx(staleToken).isNil()
+
+    var d: CallbackData
+    initCallbackData(d)
+    defer:
+      deinitCallbackData(d)
+    var rb = cborEncode(RecyclelibOpenReq(req: OpenReq(name: "stale")))
+    check recyclelib_open(
+      staleToken, testCallback, addr d, encodedPtr(rb), rb.len.csize_t
+    ) == RET_ERR
+    # Rejected before the enqueue: the callback carries the error, and the new
+    # owner never sees the request.
+    check wasCalled(d)
+    check d.retCode == RET_ERR
+    check second[].handles.byHandle.len == 0
+
+    check RecycleLibFFIPool.recycleFFIContext(second).isOk()
+
+  test "a destroyed context leaves no live token behind":
+    let ctx = RecycleLibFFIPool.createFFIContext().get()
+    let staleToken = ctx.ffiToken()
+    check RecycleLibFFIPool.destroyFFIContext(ctx).isOk()
+    check not RecycleLibFFIPool.isValidCtx(staleToken)
+
+    let next = RecycleLibFFIPool.createFFIContext().get()
+    check next == ctx
+    check not RecycleLibFFIPool.isValidCtx(staleToken)
+    check RecycleLibFFIPool.recycleFFIContext(next).isOk()
+
+  test "recycle and destroy reject a context that no token resolves to":
+    check RecycleLibFFIPool.recycleFFIContext(nil).isErr()
+    check RecycleLibFFIPool.destroyFFIContext(nil).isErr()
+
+suite "recycle clears the handle registry":
+  test "the handle ids of the previous owner do not resolve for the next one":
+    let first = RecycleLibFFIPool.createFFIContext().get()
+
+    var od: CallbackData
+    runCall(
+      od,
+      first,
+      cborEncode(RecyclelibOpenReq(req: OpenReq(name: "alpha"))),
+      recyclelib_open,
+    )
+    defer:
+      deinitCallbackData(od)
+    check od.retCode == RET_OK
+    let handle = cborDecode(payload(od), uint64).value
+    check handle == 1'u64
+    check first[].handles.byHandle.len == 1
+
+    check RecycleLibFFIPool.recycleFFIContext(first).isOk()
+    check first[].handles.byHandle.len == 0
+
+    let second = RecycleLibFFIPool.createFFIContext().get()
+    # Lowest free slot wins, so a fresh slot here would prove nothing.
+    check second == first
+
+    var td: CallbackData
+    runCall(td, second, cborEncode(RecyclelibTokenReq(s: handle)), recyclelib_token)
+    defer:
+      deinitCallbackData(td)
+    check td.retCode == RET_ERR
+
+    check RecycleLibFFIPool.recycleFFIContext(second).isOk()
+
+  test "handles of a reused slot start from a clean table":
+    let ctx = RecycleLibFFIPool.createFFIContext().get()
+    for i in 0 .. 4:
+      var od: CallbackData
+      runCall(
+        od,
+        ctx,
+        cborEncode(RecyclelibOpenReq(req: OpenReq(name: "s" & $i))),
+        recyclelib_open,
+      )
+      check od.retCode == RET_OK
+      deinitCallbackData(od)
+    check ctx[].handles.byHandle.len == 5
+
+    check RecycleLibFFIPool.recycleFFIContext(ctx).isOk()
+    check ctx[].handles.byHandle.len == 0
+
+suite "recycle with a handler that does not drain":
+  # Leaks its slot on purpose, so it runs last in this file.
+  test "the recycle reports the failure and keeps the library":
+    initCallbackData(gBlockData)
+    let ctx = RecycleLibFFIPool.createFFIContext().get()
+
+    gHold.store(true)
+    gEntered.store(false)
+    var rb = cborEncode(RecyclelibBlockReq())
+    check recyclelib_block(
+      ctx.ffiToken(), testCallback, addr gBlockData, encodedPtr(rb), rb.len.csize_t
+    ) == RET_OK
+    while not gEntered.load():
+      os.sleep(5)
+
+    let t0 = Moment.now()
+    let res = RecycleLibFFIPool.recycleFFIContext(ctx)
+    let elapsed = Moment.now() - t0
+
+    # Both drain rounds ran, and the caller learned that teardown did not finish.
+    check res.isErr()
+    check elapsed >= 2 * RecycleTimeout
+    check elapsed < RecycleWaitTimeout
+    # The host still owns the userData of the in-flight request, so the callback
+    # it carries must not have fired yet.
+    check not wasCalled(gBlockData)
+    check not ctx[].myLib.isNil()
+
+    # The slot stays claimed: handing it to a new owner is what the failed drain
+    # rules out.
+    let other = RecycleLibFFIPool.createFFIContext().get()
+    check other != ctx
+    check RecycleLibFFIPool.recycleFFIContext(other).isOk()
+
+    gHold.store(false)
+    waitCallback(gBlockData)
+    deinitCallbackData(gBlockData)

--- a/tests/unit/test_ffi_recycle_reset.nim.cfg
+++ b/tests/unit/test_ffi_recycle_reset.nim.cfg
@@ -1,0 +1,2 @@
+# File-wide: two drain rounds at the 1500ms default would cost 3s per matrix job.
+-d:ffiRecycleTimeoutMs=200

--- a/tests/unit/test_ffi_router.nim
+++ b/tests/unit/test_ffi_router.nim
@@ -96,7 +96,7 @@ proc waitCalled(s: var CallbackState): bool =
     inc tries
   s.called.load()
 
-proc createCtx(s: var CallbackState): pointer =
+proc createCtx(s: var CallbackState): FFICtxToken =
   resetState(s)
   var cfg = cborEncode(RouterCreateCtorReq(seed: 42))
   let ret = router_create(encodedPtr(cfg), cfg.len.csize_t, recordingCallback, addr s)
@@ -114,11 +114,7 @@ suite "{.ffi.} routes on the shape of the signature":
     resetState(s)
     var req = cborEncode(RouterMarkerReq())
     check router_marker(
-      cast[ptr FFIContext[RouterLib]](ctx),
-      recordingCallback,
-      addr s,
-      encodedPtr(req),
-      req.len.csize_t,
+      ctx, recordingCallback, addr s, encodedPtr(req), req.len.csize_t
     ) == RET_OK
     check waitCalled(s)
     check s.retCode.load() == int(RET_OK)
@@ -162,21 +158,13 @@ suite "{.ffi.} routes on the shape of the signature":
     var evt: CallbackState
     resetState(evt)
     check router_add_event_listener(
-      cast[ptr FFIContext[RouterLib]](ctx),
-      "on_router_tick".cstring,
-      recordingCallback,
-      addr evt,
+      ctx, "on_router_tick".cstring, recordingCallback, addr evt
     ) != 0'u64
 
     resetState(s)
     var req = cborEncode(RouterTickReq())
-    check router_tick(
-      cast[ptr FFIContext[RouterLib]](ctx),
-      recordingCallback,
-      addr s,
-      encodedPtr(req),
-      req.len.csize_t,
-    ) == RET_OK
+    check router_tick(ctx, recordingCallback, addr s, encodedPtr(req), req.len.csize_t) ==
+      RET_OK
     check waitCalled(evt)
     let env = cborDecode(cast[seq[byte]](evt.msg), EventEnvelope[RouterTick])
     check env.value.eventType == "on_router_tick"
@@ -187,4 +175,4 @@ suite "{.ffi.} routes on the shape of the signature":
     let ctx = createCtx(s)
     check not ctx.isNil()
     check router_destroy(ctx) == RET_OK
-    check router_destroy(nil) == RET_ERR
+    check router_destroy(cast[FFICtxToken](nil)) == RET_ERR

--- a/tests/unit/test_ffi_teardown.nim
+++ b/tests/unit/test_ffi_teardown.nim
@@ -53,7 +53,7 @@ proc createCtxWithLib(): ptr FFIContext[TeardownLib] =
   let ret = teardownlib_create(encodedPtr(cfg), cfg.len.csize_t, noopCallback, nil)
   if ret.isNil():
     return nil
-  let ctx = cast[ptr FFIContext[TeardownLib]](ret)
+  let ctx = TeardownLibFFIPool.resolveCtx(ret)
   var tries = 0
   while not ctx[].libReady.load() and tries < 500:
     os.sleep(5)
@@ -105,7 +105,7 @@ suite "{.ffiDtor.} teardown on the recycle path":
     check not ctx.isNil()
 
     gTeardownRan.store(false)
-    check teardownlib_destroy(cast[pointer](ctx)) == RET_OK
+    check teardownlib_destroy(ctx.ffiToken()) == RET_OK
     check gTeardownRan.load()
 
   test "a slot reused after teardown tears down again":

--- a/tests/unit/test_scalar_fastpath.nim
+++ b/tests/unit/test_scalar_fastpath.nim
@@ -147,7 +147,7 @@ proc makeCtx(base: int): ptr FFIContext[ScalarLib] =
   waitCallback(d)
   doAssert d.retCode == RET_OK
   let addrStr = cborDecode(callbackBytesOf(d), string).value
-  cast[ptr FFIContext[ScalarLib]](cast[uint](parseBiggestUInt(addrStr)))
+  ScalarLibFFIPool.resolveCtx(cast[FFICtxToken](parseBiggestUInt(addrStr)))
 
 suite "scalar fast path — C export shape":
   test "two int params + int return, threads through the base state":
@@ -160,7 +160,7 @@ suite "scalar fast path — C export shape":
     defer:
       deinitCallbackData(d)
 
-    check scalarfast_add(ctx, testCallback, addr d, 20, 3) == RET_OK
+    check scalarfast_add(ctx.ffiToken(), testCallback, addr d, 20, 3) == RET_OK
     waitCallback(d)
     check d.retCode == RET_OK
     check scalarInt(d) == 123
@@ -175,7 +175,7 @@ suite "scalar fast path — C export shape":
     defer:
       deinitCallbackData(d)
 
-    check scalarfast_version(ctx, testCallback, addr d) == RET_OK
+    check scalarfast_version(ctx.ffiToken(), testCallback, addr d) == RET_OK
     waitCallback(d)
     check d.retCode == RET_OK
     check scalarStr(d) == "scalarfast v1"
@@ -190,7 +190,7 @@ suite "scalar fast path — C export shape":
     defer:
       deinitCallbackData(d)
 
-    check scalarfast_blank(ctx, testCallback, addr d) == RET_OK
+    check scalarfast_blank(ctx.ffiToken(), testCallback, addr d) == RET_OK
     waitCallback(d)
     check d.retCode == RET_OK
     check d.msgLen == 0 # NOT 1 (would be the 0xf6 sentinel)
@@ -206,7 +206,7 @@ suite "scalar fast path — C export shape":
     defer:
       deinitCallbackData(d)
 
-    check scalarfast_scale(ctx, testCallback, addr d, 2.5) == RET_OK
+    check scalarfast_scale(ctx.ffiToken(), testCallback, addr d, 2.5) == RET_OK
     waitCallback(d)
     check d.retCode == RET_OK
     check scalarFloat(d) == 5.0
@@ -221,7 +221,7 @@ suite "scalar fast path — C export shape":
     defer:
       deinitCallbackData(d)
 
-    check scalarfast_positive(ctx, testCallback, addr d, -4) == RET_OK
+    check scalarfast_positive(ctx.ffiToken(), testCallback, addr d, -4) == RET_OK
     waitCallback(d)
     check d.retCode == RET_OK
     check scalarBool(d) == false
@@ -236,7 +236,7 @@ suite "scalar fast path — C export shape":
     defer:
       deinitCallbackData(d)
 
-    check scalarfast_checked(ctx, testCallback, addr d, -1) == RET_OK
+    check scalarfast_checked(ctx.ffiToken(), testCallback, addr d, -1) == RET_OK
     waitCallback(d)
     check d.retCode == RET_ERR
     check callbackErr(d) == "negative not allowed"
@@ -246,7 +246,7 @@ suite "scalar fast path — C export shape":
     initCallbackData(d)
     defer:
       deinitCallbackData(d)
-    let bogus = cast[ptr FFIContext[ScalarLib]](nil)
+    let bogus = cast[FFICtxToken](nil)
     check scalarfast_add(bogus, testCallback, addr d, 1, 2) == RET_ERR
 
 suite "scalar fast path — Nim-native shape":


### PR DESCRIPTION
## Summary

Follow-up work on the findings of #145. A recycled slot went back into service without a full reset, and the host kept an address that outlived its owner.

- **Teardown ignored its own drain result.** After both rounds timed out, `recycleContext` freed the library and returned the slot while handlers still ran, and those handlers answer a callback carrying `userData` the host frees on a successful teardown. It now aborts: library kept, slot kept, `requestRecycle` returns an error.
- **The drain counted the wrong futures.** It tracks the dispatcher, which unwound the moment `cancelSoon` reached its `race`. `awaitWithStaleWarnings` now catches that cancel and waits out the handler, which is never cancelled by design.
- **The handle registry survived the recycle.** Ids are monotonic from 1, so the next owner could pass id `1` and read the object of the previous one. The reset now calls `handles.releaseAll()`.
- **The host held the raw address of a pool slot,** and a slot keeps its address across a recycle. It now holds an opaque `FFICtxToken` packing the slot index and the generation of the claim; `tryClaim` opens a generation, `resolveCtx` rejects a stale one. The event-listener entry points went the same way — they used to dereference the host pointer behind a nil check alone.

Also: the `abi = c` wrappers leaked the reply box on every send failure; a constructor failing after `createFFIContext` left its slot claimed forever; `release(handle)` skipped the type-tag check `lookup` makes; `ffiRaw` never invoked the callback on an invalid ctx; and every `c_malloc` result is now checked.

## Impact on Library Users

The C ABI does not change — the token is pointer-sized and the header still says `void* ctx`. Regenerated bindings are byte-identical.

Nim callers pass `ctx.ffiToken()` into an entry point and `<Lib>FFIPool.resolveCtx(token)` to go back; `FFICtxToken` is distinct, so the compiler finds every site. `FFIHandleRegistry.release` gains a `typeName`.

A recycle whose drain times out now returns an error where it reported success. The host must then keep the `userData` of its in-flight requests alive: the context and library are leaked on purpose and their callbacks can still fire.

## Tests

New `tests/unit/test_ffi_recycle_reset.nim`, drain budget cut to 200 ms by a sibling `.cfg`. Six cases over the three behaviours: a token from the previous owner of a reused slot is rejected by `isValidCtx`, by `resolveCtx`, and by a real entry-point call that answers `RET_ERR` before the enqueue; a handle id of that previous owner resolves for the next one; and a handler that does not drain reports success. Each fails on `master`, and the last one segfaults at exit there in the ORC cycle collector.
