### PR TITLE
fix(ffi): bound the request ingress queue and the request payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,21 @@ All notable changes to this project are documented in this file.
   returns the library type builds today and exports a working C symbol, so a
   router would silently give it the ctor ABI instead.
 
+### Changed
+- **A submit now has two limits, and fails instead of accepting without bound.**
+  The ingress queue took every request a producer offered, so a producer faster
+  than the FFI thread — or any producer once that thread is wedged — grew memory
+  without bound, and no request carried a maximum size. A submit is rejected once
+  its ingress queue holds `-d:ffiRequestQueueDepth` (1024) requests, or once its
+  payload passes `-d:ffiMaxRequestPayloadBytes` (8 MiB). Ingress is sharded over
+  16 queues, so a context holds at most 16384 requests. The payload cap measures
+  the buffer the request owns: on the `abi = c` path that is the packed wire
+  struct, and the buffers its fields point at stay uncounted, because that path
+  trusts its caller. Both limits come back as the error the submit already
+  returns, which the generated entry points report as `RET_ERR` through the
+  callback, so a host that stays under the limits sees no change. Raise either
+  define if your host needs more.
+
 ### Fixed
 - A `{.ffiDtor.}` body now runs when the context is recycled. Only the
   thread-exit epilogue awaited the teardown hook, and the emitted C destructor

--- a/ffi/ffi_context.nim
+++ b/ffi/ffi_context.nim
@@ -14,6 +14,7 @@ import
   ./cbor_serial
 
 export ffi_events, ffi_handles
+export ffi_request_queue.RequestQueueDepth
 
 type CtxLifecycle* {.pure.} = enum
   ## State machine guarding a pooled FFI context (Atomic on FFIContext).

--- a/ffi/ffi_request_queue.nim
+++ b/ffi/ffi_request_queue.nim
@@ -1,6 +1,7 @@
 ## Sharded, mutex-guarded MPSC ingress for `ptr FFIThreadRequest`: N intrusive
 ## FIFOs (one per producer) spread lock contention; the request is its own node
-## so enqueue never touches a Nim GC heap. Unbounded — submit never blocks.
+## so enqueue never touches a Nim GC heap. Bounded at `RequestQueueDepth` per
+## queue — a submit never blocks, it is rejected once the queue is full.
 
 import std/[atomics, locks]
 import ./ffi_thread_request
@@ -12,16 +13,26 @@ const
     ## Pads each queue past a cache line (128B on Apple silicon) to avoid false
     ## sharing between adjacent queues.
 
+const RequestQueueDepth* {.intdefine: "ffiRequestQueueDepth".} = 1024
+  ## Requests one queue holds. Caps the memory a producer that outruns the FFI
+  ## thread can pin. Override with `-d:ffiRequestQueueDepth=<n>`.
+
 static:
   # `myQueueIndex` masks with `and`, so the count must be a power of two.
   doAssert (RequestQueueCount and (RequestQueueCount - 1)) == 0,
     "RequestQueueCount must be a power of two"
 
 type
+  PushOutcome* = enum
+    QueueFull ## the request still belongs to the caller
+    Queued
+    QueuedWake ## the queue was empty: this push must wake the consumer
+
   RequestQueue = object
     lock: Lock
     head: ptr FFIThreadRequest ## consumer pops here (oldest)
     tail: ptr FFIThreadRequest ## producers append here (newest)
+    count: int
     pad: array[QueuePadBytes, byte]
 
   RequestQueueBank* = object
@@ -43,6 +54,7 @@ proc initRequestQueue*(bank: var RequestQueueBank) {.raises: [].} =
     queue.lock.initLock()
     queue.head = nil
     queue.tail = nil
+    queue.count = 0
 
 proc deinitRequestQueue*(bank: var RequestQueueBank) {.raises: [].} =
   ## Both producers and consumer must have stopped. Frees any still-queued request
@@ -59,19 +71,22 @@ proc deinitRequestQueue*(bank: var RequestQueueBank) {.raises: [].} =
 
 proc pushRequest*(
     bank: var RequestQueueBank, request: ptr FFIThreadRequest
-): bool {.raises: [].} =
-  ## Append `request` to this thread's queue (takes ownership). True only when the
-  ## queue was empty — the one push that must wake the sleeping consumer.
+): PushOutcome {.raises: [].} =
+  ## Append `request` to this thread's queue and take ownership. On `QueueFull`
+  ## the caller keeps the request.
   request[].next = nil
   let idx = myQueueIndex()
   withLock bank.queues[idx].lock:
+    if bank.queues[idx].count >= RequestQueueDepth:
+      return QueueFull
     let wasEmpty = bank.queues[idx].tail.isNil()
-    if bank.queues[idx].tail.isNil():
+    if wasEmpty:
       bank.queues[idx].head = request
     else:
       bank.queues[idx].tail[].next = request
     bank.queues[idx].tail = request
-    return wasEmpty
+    inc bank.queues[idx].count
+    return if wasEmpty: QueuedWake else: Queued
 
 proc mergeQueues*(bank: var RequestQueueBank): ptr FFIThreadRequest {.raises: [].} =
   ## Single-consumer: splice every queue into one chain and reset them. Caller owns
@@ -89,4 +104,5 @@ proc mergeQueues*(bank: var RequestQueueBank): ptr FFIThreadRequest {.raises: []
         tail = queue.tail
         queue.head = nil
         queue.tail = nil
+        queue.count = 0
   return head

--- a/ffi/ffi_thread.nim
+++ b/ffi/ffi_thread.nim
@@ -20,11 +20,23 @@ proc sendRequestToFFIThread*(
     deleteRequest(ffiRequest)
     return err("FFI context is not accepting requests (being recycled)")
 
-  # Wake only when the push found the queue empty: waking per submit kills scaling, and a skipped wake just waits the consumer's 100ms poll.
-  let shouldWake = ctx.reqQueueBank.pushRequest(ffiRequest)
+  let payloadLen = ffiRequest[].dataLen
+  if payloadLen > MaxRequestPayloadBytes:
+    deleteRequest(ffiRequest)
+    return err(
+      "request payload of " & $payloadLen & " bytes exceeds the " &
+        $MaxRequestPayloadBytes & " byte cap"
+    )
 
-  # A failed wake is non-fatal (poll-drain still dispatches); erroring here would double-fire the callback for a request that still completes.
-  if shouldWake:
+  # Wake only when the push found the queue empty: waking per submit kills scaling, and a skipped wake just waits the consumer's 100ms poll.
+  case ctx.reqQueueBank.pushRequest(ffiRequest)
+  of QueueFull:
+    deleteRequest(ffiRequest)
+    return err("request queue full: " & $RequestQueueDepth & " requests already queued")
+  of Queued:
+    discard
+  of QueuedWake:
+    # A failed wake is non-fatal (poll-drain still dispatches); erroring here would double-fire the callback for a request that still completes.
     ctx.reqSignal.fireSync().isOkOr:
       error "failed to wake FFI thread after enqueue (request still queued)",
         error = error

--- a/ffi/ffi_thread_request.nim
+++ b/ffi/ffi_thread_request.nim
@@ -10,6 +10,12 @@ import ./ffi_types, ./alloc, ./cbor_serial
 const EmptyErrorMarker = "unknown error"
   ## RET_ERR fallback message; keeps the callback msg ptr non-nil.
 
+const MaxRequestPayloadBytes* {.intdefine: "ffiMaxRequestPayloadBytes".} =
+  8 * 1024 * 1024
+  ## Largest `data` a submit accepts. On the `abi = c` path `data` is the packed
+  ## wire struct, so the buffers its fields point at stay uncounted. Override
+  ## with `-d:ffiMaxRequestPayloadBytes=<n>`.
+
 const MaxScalarArgs* = 8
   ## Inline scalar fast-path capacity; more params can't use it (compile-time checked).
 

--- a/tests/bench/README.md
+++ b/tests/bench/README.md
@@ -19,6 +19,8 @@ FFI_SUBMIT_THREADS="1,8,16,32,64,100" nimble bench_ffi_submit
 
 It is also a correctness stress test: the aggregate callback count must match the submit count **exactly** (no drops or double-fires), with zero submit errors and (under asan/lsan/tsan) zero leaks or races.
 
+The bench submits far faster than the single FFI thread drains, so it raises the ingress cap in `bench_ffi_submit.nim.cfg` (`-d:ffiRequestQueueDepth=262144`) to keep timing the submit path alone. With the production default of 1024 the queue fills, the submits come back rejected, and the numbers would measure backpressure instead. Push `FFI_SUBMIT_PER_THREAD` or `FFI_SUBMIT_THREADS` past that cap and the run fails with the submit-error count.
+
 ```sh
 nimble bench_ffi_submit
 # smaller / faster (handy under sanitizers — they distort timing, so disable the gate):

--- a/tests/bench/bench_ffi_submit.nim
+++ b/tests/bench/bench_ffi_submit.nim
@@ -85,14 +85,19 @@ proc runOnce(
   joinThreads(threads)
   let submitSec = (Moment.now() - start).nanoseconds.float / 1_000_000_000.0
 
-  if not waitForCompletions(total):
-    quit("timed out waiting for callbacks: got " & $gCompleted.load() & " of " & $total)
+  # A rejected submit fires no callback, so wait only for the accepted ones.
+  let sendErrors = gSendErrors.load()
+  let accepted = total - sendErrors
+  if not waitForCompletions(accepted):
+    quit(
+      "timed out waiting for callbacks: got " & $gCompleted.load() & " of " & $accepted
+    )
   os.sleep(50) # let any erroneous extra callbacks land before reading overruns
 
   IterResult(
     submitRate: total.float / submitSec,
-    sendErrors: gSendErrors.load(),
-    overruns: max(0, gCompleted.load() - total),
+    sendErrors: sendErrors,
+    overruns: max(0, gCompleted.load() - accepted),
   )
 
 proc enforceScalingGate(medianRate: seq[float]) =

--- a/tests/bench/bench_ffi_submit.nim.cfg
+++ b/tests/bench/bench_ffi_submit.nim.cfg
@@ -1,0 +1,3 @@
+# The bench outruns the consumer on purpose, so the production cap would reject
+# most submits. Hold the largest documented sweep: 100 threads x 20000, 16 queues.
+-d:ffiRequestQueueDepth=262144

--- a/tests/unit/test_ffi_ingress_limits.nim
+++ b/tests/unit/test_ffi_ingress_limits.nim
@@ -1,0 +1,79 @@
+import std/[atomics, os, strutils]
+import unittest2
+import results
+import ffi
+
+type TestLib = object
+
+var gHandlerEntered: Atomic[bool]
+var gHandlerRelease: Atomic[bool]
+var gAnswered: Atomic[int]
+
+proc countingCallback(
+    retCode: cint, msg: ptr cchar, len: csize_t, userData: pointer
+) {.cdecl, gcsafe, raises: [].} =
+  if retCode == RET_STALE_WARN:
+    return
+  discard gAnswered.fetchAdd(1)
+
+template spinUntil(cond: untyped): bool =
+  block:
+    var waitedMs = 0
+    while not (cond) and waitedMs < 5000:
+      os.sleep(1)
+      inc waitedMs
+    cond
+
+registerReqFFI(BlockRequest, lib: ptr TestLib):
+  proc(): Future[Result[string, string]] {.async.} =
+    # Blocks the FFI thread outright, so every later submit stays queued.
+    gHandlerEntered.store(true)
+    while not gHandlerRelease.load():
+      os.sleep(1)
+    return ok("released")
+
+registerReqFFI(EchoRequest, lib: ptr TestLib):
+  proc(message: string): Future[Result[string, string]] {.async.} =
+    return ok(message)
+
+proc echoReq(payload: string): ptr FFIThreadRequest =
+  EchoRequest.ffiNewReq(countingCallback, nil, payload)
+
+suite "request ingress limits":
+  test "a full ingress queue rejects the submit, and drains back to accepting":
+    var pool: FFIContextPool[TestLib]
+    let ctx = pool.createFFIContext().valueOr:
+      assert false, "createFFIContext failed: " & $error
+      return
+    defer:
+      gHandlerRelease.store(true)
+      discard pool.destroyFFIContext(ctx)
+
+    check sendRequestToFFIThread(ctx, BlockRequest.ffiNewReq(countingCallback, nil))
+      .isOk()
+    check spinUntil(gHandlerEntered.load())
+
+    for _ in 0 ..< RequestQueueDepth:
+      check sendRequestToFFIThread(ctx, echoReq("queued")).isOk()
+
+    let rejected = sendRequestToFFIThread(ctx, echoReq("one too many"))
+    check rejected.isErr() and "request queue full" in rejected.error
+
+    gHandlerRelease.store(true)
+    check spinUntil(gAnswered.load() == RequestQueueDepth + 1)
+    check sendRequestToFFIThread(ctx, echoReq("after the drain")).isOk()
+
+  test "a payload over the cap is rejected at the submit":
+    var pool: FFIContextPool[TestLib]
+    let ctx = pool.createFFIContext().valueOr:
+      assert false, "createFFIContext failed: " & $error
+      return
+    defer:
+      discard pool.destroyFFIContext(ctx)
+
+    let oversized =
+      sendRequestToFFIThread(ctx, echoReq(repeat('x', MaxRequestPayloadBytes + 1)))
+    check oversized.isErr() and
+      "exceeds the " & $MaxRequestPayloadBytes & " byte cap" in oversized.error
+
+    check sendRequestToFFIThread(ctx, echoReq("small")).isOk()

--- a/tests/unit/test_ffi_ingress_limits.nim.cfg
+++ b/tests/unit/test_ffi_ingress_limits.nim.cfg
@@ -1,0 +1,3 @@
+# Small caps keep the queue-full and oversize cases cheap.
+-d:ffiRequestQueueDepth=4
+-d:ffiMaxRequestPayloadBytes=1024


### PR DESCRIPTION
## Summary

Follow-up work on the findings of #145. Request ingress had no limit of any kind: neither on how many requests one producer could leave queued, nor on how large a single payload could be.

- **The ingress queue took every request offered.** A producer faster than the FFI thread — or any producer at all once that thread is wedged — grew memory without bound, while the event queue next to it has been bounded at 1024 all along. Each queue now holds at most `RequestQueueDepth` requests, counted under the lock it already takes, and `pushRequest` answers `QueueFull` instead of appending. Ingress is sharded over 16 queues, so a context holds at most 16384 requests.
- **No request carried a maximum size.** `sendRequestToFFIThread` now rejects a payload over `MaxRequestPayloadBytes` before it reaches the queue or the decoder.

Both limits are compile-time defines: `-d:ffiRequestQueueDepth` (1024) and `-d:ffiMaxRequestPayloadBytes` (8 MiB).

## Impact on Library Users

A submit can now fail for two new reasons. Both come back as the error the submit already returns, which the generated entry points report as `RET_ERR` through the callback, so a host that stays under the limits sees no change and the C ABI is untouched.

The payload cap measures the buffer the request owns. On the `abi = c` path that buffer is the packed wire struct, so the memory its fields point at stays uncounted — that path trusts its caller, as it already does for every length it is handed.

`pushRequest` returns `PushOutcome` rather than a `bool`, and `RequestQueueDepth` is re-exported from `ffi_context`. Both are internal to the runtime; no generated binding changes.

## Tests

New `tests/unit/test_ffi_ingress_limits.nim`, with a sibling `.cfg` cutting the caps to 4 requests and 1024 bytes so the cases cost nothing. A handler blocks the FFI thread outright, so the queue fills deterministically: `RequestQueueDepth` submits succeed, the next one errors, and once the handler is released and the queue drains a submit is accepted again — that last check is what catches a depth counter that never resets. A payload one byte over the cap errors while a small one still passes.

Both cases were run with the two new guards stubbed out and both fail there. The suite passes under `--mm:orc` and `--mm:refc`.
