### PR TITLE
fix(ffi): quarantine a context whose {.ffiDtor.} did not finish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,72 @@ jobs:
       nim-versions:   ${{ needs.versions.outputs.nim-versions }}
       nimble-version: ${{ needs.versions.outputs.nimble }}
 
+  # The recycle/teardown family below all turn on thread reuse, thread exit and
+  # chronos dispatcher behaviour, which differ per OS. The Linux sanitizer jobs
+  # run every unit test, but they cannot speak for macOS or Windows.
+  dtor-orphan-reuse:
+    name: Dtor Orphan Reuse
+    needs: versions
+    uses: ./.github/workflows/test.yml
+    with:
+      test: test_ffi_dtor_orphan_reuse
+      nim-versions:   ${{ needs.versions.outputs.nim-versions }}
+      nimble-version: ${{ needs.versions.outputs.nimble }}
+
+  ffi-teardown:
+    name: Async Teardown
+    needs: versions
+    uses: ./.github/workflows/test.yml
+    with:
+      test: test_ffi_teardown
+      nim-versions:   ${{ needs.versions.outputs.nim-versions }}
+      nimble-version: ${{ needs.versions.outputs.nimble }}
+
+  recycle-reset:
+    name: Recycle Reset
+    needs: versions
+    uses: ./.github/workflows/test.yml
+    with:
+      test: test_ffi_recycle_reset
+      nim-versions:   ${{ needs.versions.outputs.nim-versions }}
+      nimble-version: ${{ needs.versions.outputs.nimble }}
+
+  claim-generation:
+    name: Claim Generation
+    needs: versions
+    uses: ./.github/workflows/test.yml
+    with:
+      test: test_ffi_claim_generation
+      nim-versions:   ${{ needs.versions.outputs.nim-versions }}
+      nimble-version: ${{ needs.versions.outputs.nimble }}
+
+  ingress-limits:
+    name: Ingress Limits
+    needs: versions
+    uses: ./.github/workflows/test.yml
+    with:
+      test: test_ffi_ingress_limits
+      nim-versions:   ${{ needs.versions.outputs.nim-versions }}
+      nimble-version: ${{ needs.versions.outputs.nimble }}
+
+  ctx-after-failed-ctor:
+    name: Ctx After Failed Ctor
+    needs: versions
+    uses: ./.github/workflows/test.yml
+    with:
+      test: test_ctx_after_failed_ctor
+      nim-versions:   ${{ needs.versions.outputs.nim-versions }}
+      nimble-version: ${{ needs.versions.outputs.nimble }}
+
+  event-thread:
+    name: Event Thread
+    needs: versions
+    uses: ./.github/workflows/test.yml
+    with:
+      test: test_event_thread
+      nim-versions:   ${{ needs.versions.outputs.nim-versions }}
+      nimble-version: ${{ needs.versions.outputs.nimble }}
+
   cpp-e2e:
     # Codegen output doesn't vary with mm, so we matrix over OS and Nim only.
     # Windows runs MSVC by default and may surface codegen tweaks needed in
@@ -204,6 +270,19 @@ jobs:
     uses: ./.github/workflows/nimble-job.yml
     with:
       run: nimble check_bindings -y
+      nim-versions:   ${{ needs.versions.outputs.nim-versions }}
+      nimble-version: ${{ needs.versions.outputs.nimble }}
+
+  unit-tests-all:
+    # Catch-all so a new tests/unit file cannot go unrun: `nimble test` discovers
+    # every test_*.nim and runs it under both orc and refc. Linux only, because
+    # the compile of ~40 files twice is the cost here and the jobs above already
+    # carry the OS-sensitive ones across the matrix.
+    name: All unit tests (orc + refc)
+    needs: versions
+    uses: ./.github/workflows/nimble-job.yml
+    with:
+      run: nimble test -y
       nim-versions:   ${{ needs.versions.outputs.nim-versions }}
       nimble-version: ${{ needs.versions.outputs.nimble }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,31 @@ All notable changes to this project are documented in this file.
   define if your host needs more.
 
 ### Fixed
+- **A context whose teardown did not finish is quarantined, not recycled.**
+  `recycleContext` gated the slot release on the request drain alone, and
+  `runTeardown` returned nothing: a `{.ffiDtor.}` cut short by
+  `TeardownTimeout`, or one that raised, still had its library freed and its slot
+  handed to the next owner, while `requestRecycle` reported success. Whatever
+  async work the abandoned teardown never cancelled keeps running on that
+  thread's chronos dispatcher — and chronos exposes no way to enumerate, let
+  alone cancel, the futures of a thread outside a debug build, so the runtime
+  cannot clean up after a teardown that gave up. Reuse is only safe when the
+  previous owner is provably gone from the thread, and the only proof is its
+  teardown having run to the end. A recycle now releases the slot only when the
+  drain succeeded **and** the teardown either completed or had nothing to do.
+  Otherwise the slot stays claimed for the life of the process, the library is
+  kept alive (the orphans still hold pointers into it), the terminal
+  `RecycleFailed` records a `RecycleFailure` reason, and `requestRecycle`
+  returns that reason as an error. A recycle that finishes after the caller's own
+  `RecycleWaitTimeout` expired is quarantined too: that caller was already told
+  it failed. `FFIContextPool.quarantinedSlots()` reports how many slots this has
+  cost, and the pool-exhausted error names the count.
+- **A recycled slot no longer carries the previous owner's stuck-queue flag.**
+  `eventQueueStuck` is set on event-queue overflow and cleared only in
+  `initContextResources`, which a reused slot skips, so one overflow left the
+  slot rejecting every request of every later owner — including the constructor,
+  which made `createFFIContext` hand out the same poisoned slot again and again.
+  The recycle reset clears it.
 - **A claim and the generation it opens are one atomic operation.** `tryClaim`
   set `inUse` and bumped `generation` in two steps, and between them a token of
   the previous owner passed both checks in `resolveCtx`: `inUse` was already

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The generated C export names are the snake_case form of the proc names, e.g.
 | `{.ffi.}` on a `proc` | proc | Exposes a method. First param is the library value, then typed params; returns `Future[Result[T, string]]`. |
 | `{.ffiStatic.}` | proc | Exposes a context-independent proc: no library param, and its wrapper takes no ctx — see below. |
 | `{.ffiCtor.}` | proc | The constructor. Returns `Future[Result[LibType, string]]`; creates the FFI context. |
-| `{.ffiDtor.}` | proc | The destructor. Exactly one param `(x: LibType)`; tears the context down. |
+| `{.ffiDtor.}` | proc | The destructor. Exactly one param `(x: LibType)`; tears the context down. Must cancel and await everything it spawned — see [the teardown contract](#the-teardown-contract). |
 | `{.ffiEvent[: "wire_name"].}` | proc (empty body) | A library-initiated callback. Call the proc from any `{.ffi.}` handler to fire it. The wire name is optional — see below. |
 | `{.ffiHandle.}` | `ref object` | Marks a type as an opaque handle: it stays server-side and crosses the wire as a `uint64` id. |
 | `{.ffiConst.}` | `const` | Re-emits the value as a native constant in every generated binding — see below. |
@@ -213,6 +213,32 @@ in the context that created it, which a static proc cannot reach. Under
 `abi = c` a static replies with a `string` or an `{.ffi.}` object type — a scalar
 return is wired only for an all-scalar `{.ffi.}` method, which rides the
 [CBOR-free fast path](#abi-format) through the ctx a static doesn't have.
+
+### The teardown contract
+
+A `{.ffiDtor.}` must cancel **and await** everything it spawned. The pool recycles
+a context by handing its slot — including the live FFI and event thread pair and
+their chronos dispatcher — to the next owner, and the only proof that the previous
+owner is gone from that thread is its teardown having run to the end. The runtime
+cannot make up for a teardown that gave up: chronos exposes no way to enumerate,
+let alone cancel, the futures of a thread outside a debug build, and a cancel is
+cooperative in any case.
+
+A teardown that overruns `-d:ffiTeardownTimeoutMs` (10 s) is cancelled at the
+timeout; one that raises stops there. Either way the runtime treats the context as
+unsafe to reuse and **quarantines** it:
+
+| | Teardown completed | Teardown cut short or raised |
+| --- | --- | --- |
+| `<lib>_ctx_destroy` | `RET_OK` | `RET_ERR` |
+| The library object | freed | kept alive — orphaned work may still hold pointers into it |
+| The pool slot | back in the pool | claimed for the life of the process |
+| In-flight callbacks | done before the destroy returned | can still fire, so keep their `userData` alive |
+
+Quarantine costs one of the 32 slots permanently, so a library that habitually
+overruns its teardown will exhaust the pool. `FFIContextPool.quarantinedSlots()`
+reports the count from Nim, every quarantine is logged at `error`, and so is the
+pool-exhausted error once any slot has been quarantined.
 
 ### The result callback contract
 

--- a/ffi/ffi_context.nim
+++ b/ffi/ffi_context.nim
@@ -24,11 +24,35 @@ proc isNil*(token: FFICtxToken): bool {.borrow.}
 proc `==`*(a, b: FFICtxToken): bool {.borrow.}
 
 type CtxLifecycle* {.pure.} = enum
-  ## Active -> RecyclePending (ffiDtor asks) -> Recycling (FFI loop drains) -> Active (slot reused) or RecycleFailed (drain timed out).
+  ## Active -> RecyclePending (ffiDtor asks) -> Recycling (FFI loop drains) -> Active (slot reused) or RecycleFailed (teardown did not complete).
   Active
   RecyclePending
   Recycling
   RecycleFailed # terminal: only the recycle handler writes it, nothing clears it
+
+type RecycleFailure* {.pure.} = enum
+  ## Why a slot was quarantined. An enum and not a message: a `string` field on a
+  ## pooled context would be written by the FFI thread and read by the host one,
+  ## which under refc crosses thread-local heaps.
+  None
+  DrainTimeout ## in-flight handlers outlasted both drain rounds
+  TeardownTimeout ## the `{.ffiDtor.}` body was cut short by TeardownTimeout
+  TeardownRaised ## the `{.ffiDtor.}` body raised
+  CallerAbandoned ## the caller's own wait expired before the recycle finished
+
+func reason*(failure: RecycleFailure): string =
+  ## The `requestRecycle` error text for a quarantine.
+  case failure
+  of RecycleFailure.None:
+    "recycle failed"
+  of RecycleFailure.DrainTimeout:
+    "in-flight handlers did not drain"
+  of RecycleFailure.TeardownTimeout:
+    "the {.ffiDtor.} teardown was cut short by its timeout"
+  of RecycleFailure.TeardownRaised:
+    "the {.ffiDtor.} teardown raised"
+  of RecycleFailure.CallerAbandoned:
+    "the teardown outlasted the caller's wait"
 
 type FFIContext*[T] = object
   myLib*: ptr T # main library object (Waku, LibP2P, SDS, …)
@@ -44,6 +68,11 @@ type FFIContext*[T] = object
     # The opaque handle the host holds for the current claim. Written by
     # createFFIContext under the claim; read only by the owner.
   lifecycle*: Atomic[CtxLifecycle]
+  recycleFailure*: Atomic[RecycleFailure]
+    # Why the slot was quarantined; written beside the terminal `RecycleFailed`.
+  recycleAbandoned*: Atomic[bool]
+    # Set by `requestRecycle` when its own wait expires. A recycle that finishes
+    # after that must quarantine: the caller was already told it failed.
   recycleDoneSignal: ThreadSignalPtr
     # fired by the recycle handler once the lib is freed, just before it releases the slot; the synchronous recycleFFIContext caller waits on it.
   libReady*: Atomic[bool]
@@ -149,6 +178,8 @@ proc initContextResources*[T](ctx: ptr FFIContext[T]): Result[void, string] =
   ctx.myLibOwned = false
   ctx.myLibRefd = false
   ctx.lifecycle.store(CtxLifecycle.Active)
+  ctx.recycleFailure.store(RecycleFailure.None)
+  ctx.recycleAbandoned.store(false)
   initRequestQueue(ctx[].reqQueueBank)
   initEventRegistry(ctx[].eventRegistry)
   initHandleRegistry(ctx[].handles)
@@ -255,11 +286,16 @@ proc requestRecycle*[T](ctx: ptr FFIContext[T]): Result[void, string] =
   ## Ask the FFI thread to drain, free the lib and release the slot, WITHOUT
   ## stopping its worker/event threads, so the next createFFIContext reuses them.
   ## Synchronous: waits on recycleDoneSignal. No fd churn -> no select() limit.
-  ## An err means the caller must keep the callback userData of every in-flight
-  ## request alive: teardown did not complete. A request the host races against its own recycle is rejected or silently dropped, never answered.
+  ## An err means the slot is quarantined: it never serves another owner, and the
+  ## caller must keep the callback userData of every in-flight request alive,
+  ## because teardown did not complete and those callbacks can still fire. A
+  ## request the host races against its own recycle is rejected or silently
+  ## dropped, never answered.
   var expected = CtxLifecycle.Active
   if not ctx.lifecycle.compareExchange(expected, CtxLifecycle.RecyclePending):
     return err("requestRecycle: context is not Active (already recycling)")
+
+  ctx.recycleAbandoned.store(false)
 
   # A recycle that timed out can fire late. The CAS makes this the only recycle
   # in flight, so drop that stale fire before the wait below can answer to it.
@@ -273,11 +309,16 @@ proc requestRecycle*[T](ctx: ptr FFIContext[T]): Result[void, string] =
   let done = ctx.recycleDoneSignal.waitSync(RecycleWaitTimeout).valueOr:
     return err("requestRecycle: failed waiting for recycle: " & $error)
   if not done:
+    # The recycle is still running. Tell it to quarantine the slot instead of
+    # releasing it: this caller already learned that the teardown failed.
+    ctx.recycleAbandoned.store(true)
+    error "recycle did not complete in time; the pool slot is quarantined",
+      timeoutMs = RecycleWaitTimeout.milliseconds
     return err("requestRecycle: recycle did not complete in time")
   if ctx.lifecycle.load() == CtxLifecycle.RecycleFailed:
     return err(
-      "requestRecycle: in-flight handlers did not drain; the library and the pool " &
-        "slot are leaked, and their callbacks can still fire"
+      "requestRecycle: " & ctx.recycleFailure.load().reason() &
+        "; the library and the pool slot are leaked, and their callbacks can still fire"
     )
   ok()
 

--- a/ffi/ffi_context_pool.nim
+++ b/ffi/ffi_context_pool.nim
@@ -88,8 +88,8 @@ proc createFFIContext*[T](
       "does not finish costs a slot for the life of the process",
       quarantined = quarantined, max = MaxFFIContexts
   err(
-    "FFI context pool exhausted (max " & $MaxFFIContexts & " contexts, " &
-      $quarantined & " quarantined by a failed teardown)"
+    "FFI context pool exhausted (max " & $MaxFFIContexts & " contexts, " & $quarantined &
+      " quarantined by a failed teardown)"
   )
 
 proc isStaticCtx[T](pool: var FFIContextPool[T], ctx: ptr FFIContext[T]): bool =

--- a/ffi/ffi_context_pool.nim
+++ b/ffi/ffi_context_pool.nim
@@ -1,5 +1,5 @@
 import std/[atomics, sysatomics]
-import results
+import chronicles, results
 import ./ffi_context
 
 const MaxFFIContexts* = 32
@@ -45,7 +45,21 @@ proc releaseSlot[T](pool: var FFIContextPool[T], ctx: ptr FFIContext[T]) =
     if pool.contexts[i].addr == ctx:
       pool.initialized[i].store(false)
       break
+  # Joining the threads is the one way out of a quarantine: whatever a cut-short
+  # teardown left behind died with the thread, and the next claim rebuilds the
+  # pair. `initContextResources` would store this anyway; doing it here keeps
+  # `quarantinedSlots` from counting a slot that is no longer out of service.
+  ctx.lifecycle.store(CtxLifecycle.Active)
+  ctx.recycleFailure.store(RecycleFailure.None)
   ctx.releaseClaim()
+
+proc quarantinedSlots*[T](pool: var FFIContextPool[T]): int =
+  ## Slots taken out of service by a recycle that could not prove the previous
+  ## owner was done with the thread. Only the recycle handler writes
+  ## `RecycleFailed`, and only a full destroy clears it, so counting it is exact.
+  for i in 0 ..< MaxFFIContexts:
+    if pool.contexts[i].lifecycle.load() == CtxLifecycle.RecycleFailed:
+      inc result
 
 proc createFFIContext*[T](
     pool: var FFIContextPool[T]
@@ -66,7 +80,17 @@ proc createFFIContext*[T](
       return err("createFFIContext: initContextResources failed: " & $error)
     pool.initialized[i].store(true)
     return ok(ctx)
-  err("FFI context pool exhausted (max " & $MaxFFIContexts & " contexts)")
+  let quarantined = pool.quarantinedSlots()
+  if quarantined > 0:
+    # Capacity a failed teardown took away permanently: worth naming, because it
+    # looks like a plain leak from the outside.
+    error "FFI context pool exhausted with quarantined slots; a {.ffiDtor.} that " &
+      "does not finish costs a slot for the life of the process",
+      quarantined = quarantined, max = MaxFFIContexts
+  err(
+    "FFI context pool exhausted (max " & $MaxFFIContexts & " contexts, " &
+      $quarantined & " quarantined by a failed teardown)"
+  )
 
 proc isStaticCtx[T](pool: var FFIContextPool[T], ctx: ptr FFIContext[T]): bool =
   ## True while `ctx` is the pool's static context, including mid-teardown.
@@ -101,6 +125,8 @@ proc destroyFFIContext*[T](
   if pool.isStaticCtx(ctx):
     return err("destroyFFIContext(pool): the {.ffiStatic.} context outlives every ctx")
   ctx.stopAndJoinThreads().isOkOr:
+    error "context threads did not exit; the pool slot and its resources are " &
+      "leaked rather than freed under live threads", reason = error
     return err("destroyFFIContext(pool): " & $error)
   let deinitRes = ctx.deinitContextResources()
   pool.releaseSlot(ctx)
@@ -145,6 +171,8 @@ proc destroyStaticFFIContext*[T](pool: var FFIContextPool[T]): Result[void, stri
   ctx.stopAndJoinThreads().isOkOr:
     # Threads are still live: leak the slot rather than free resources under them.
     pool.staticState.store(StaticCtxReady)
+    error "the {.ffiStatic.} context's threads did not exit; its slot and " &
+      "resources are leaked", reason = error
     return err("destroyStaticFFIContext: " & $error)
   let deinitRes = ctx.deinitContextResources()
   pool.releaseSlot(ctx)

--- a/ffi/ffi_thread.nim
+++ b/ffi/ffi_thread.nim
@@ -166,19 +166,32 @@ proc rejectQueuedRequests[T](ctx: ptr FFIContext[T]) =
       error "rejecting a queued request raised", error = e.msg
     request = nextRequest
 
-proc runTeardown[T](ctx: ptr FFIContext[T]) {.async.} =
+type TeardownOutcome = enum
+  ## Skipped is clean: there was nothing to tear down.
+  Skipped
+  Completed
+  TimedOut
+  Raised
+
+proc runTeardown[T](ctx: ptr FFIContext[T]): Future[TeardownOutcome] {.async.} =
   ## Awaits the library's `{.ffiDtor.}` body. `libReady` gates it: without a ctor
   ## `myLib` is the zero-valued fallback, nil for a `ref` type.
   let teardown = ffiTeardownHook[T]()
   if teardown.isNil() or ctx.myLib.isNil() or not ctx.libReady.load():
-    return
+    debug "no library teardown to run for this context"
+    return TeardownOutcome.Skipped
   try:
+    # `withTimeout` cancels the body and completes once it has unwound, so no
+    # teardown code runs past this await.
     let done = await teardown(ctx.myLib).withTimeout(TeardownTimeout)
-    if not done:
-      error "library teardown cancelled at the timeout; releasing the library",
-        timeoutMs = TeardownTimeoutMs
+    if done:
+      return TeardownOutcome.Completed
+    error "library teardown cut short at the timeout; whatever it had not " &
+      "cancelled still runs on this thread", timeoutMs = TeardownTimeoutMs
+    return TeardownOutcome.TimedOut
   except CatchableError as e:
     error "library teardown raised", error = e.msg
+    return TeardownOutcome.Raised
 
 proc drainOngoing(ongoing: ptr seq[Future[void]]): Future[bool] {.async.} =
   ## Waits out the in-flight dispatchers, then cancels them and waits again.
@@ -198,34 +211,64 @@ proc resetForNextOwner[T](ctx: ptr FFIContext[T], ongoing: ptr seq[Future[void]]
   # A reused slot skips initContextResources, so the handle ids of the old owner
   # would otherwise resolve for the next one.
   ctx[].handles.releaseAll()
+  # Same reason: the sticky overflow flag would reject every request of the next
+  # owner, including the ctor, for a queue that is no longer backed up.
+  ctx.eventQueueStuck.store(false)
   rejectQueuedRequests(ctx)
   ongoing[].setLen(0)
 
 proc recycleContext[T](
     ctx: ptr FFIContext[T], ongoing: ptr seq[Future[void]]
 ) {.async.} =
-  ## Drain in-flight handlers, run the library teardown, reset the slot, then fire recycleDoneSignal and release the slot, all WITHOUT stopping the worker/event threads, so the next createFFIContext reuses them (no fd churn). A drain that times out aborts the recycle: the slot stays claimed, the library stays alive, and the terminal `RecycleFailed` tells the host so.
-  var drained = false
+  ## Drain in-flight handlers, run the library teardown, reset the slot, then fire
+  ## recycleDoneSignal and release the slot, all WITHOUT stopping the
+  ## worker/event threads, so the next createFFIContext reuses them (no fd churn).
+  ## Anything short of a completed teardown quarantines the slot instead: it stays
+  ## claimed for the life of the process, the library is kept, and the terminal
+  ## `RecycleFailed` plus `recycleFailure` tell the host why. Reuse is only safe
+  ## when the previous owner is gone from this thread, and the only proof of that
+  ## is its `{.ffiDtor.}` having run to the end — chronos cannot enumerate, let
+  ## alone cancel, what a cut-short teardown left on the dispatcher.
+  var failure = RecycleFailure.None
   # Deferred: a raise out of the teardown must not strand the slot. Fire before the release, or a thread claiming the slot would take this as its own answer.
   defer:
-    if not drained:
+    # A caller whose own wait expired was already told this failed, so its slot
+    # must not come back. Racing that flag is benign: losing it can only release
+    # a slot whose teardown did complete.
+    if failure == RecycleFailure.None and ctx.recycleAbandoned.load():
+      failure = RecycleFailure.CallerAbandoned
+    if failure != RecycleFailure.None:
+      ctx.recycleFailure.store(failure)
       ctx.lifecycle.store(CtxLifecycle.RecycleFailed)
+      error "context quarantined; the pool slot and its threads are leaked, the " &
+        "library is kept alive and its callbacks can still fire",
+        reason = failure.reason(), cause = $failure
     let fireRes = ctx.recycleDoneSignal.fireSync()
     if fireRes.isErr():
       error "failed to fire recycleDoneSignal", err = fireRes.error
-    if drained:
+    if failure == RecycleFailure.None:
       ctx.releaseClaim()
 
-  drained = await drainOngoing(ongoing)
-  if not drained:
+  if not await drainOngoing(ongoing):
     # A handler that still runs answers a callback carrying userData the host
     # frees as soon as teardown reports success.
-    error "recycle drain timed out; leaking the pool slot and keeping the library",
+    error "recycle drain timed out; the teardown never ran",
       inFlight = ongoing[].len, timeoutMs = RecycleTimeoutMs
+    failure = RecycleFailure.DrainTimeout
     return
 
   # Before the reset: the teardown hook still needs `myLib` and its listeners.
-  await runTeardown(ctx)
+  case await runTeardown(ctx)
+  of TeardownOutcome.Skipped, TeardownOutcome.Completed:
+    discard
+  of TeardownOutcome.TimedOut:
+    failure = RecycleFailure.TeardownTimeout
+    return
+  of TeardownOutcome.Raised:
+    failure = RecycleFailure.TeardownRaised
+    return
+
+  # Only now: the previous owner is provably done with this thread.
   resetForNextOwner(ctx, ongoing)
 
 var ffiEventQueueSignalPtr {.threadvar.}: ThreadSignalPtr
@@ -332,6 +375,8 @@ proc ffiThreadBody[T](ctx: ptr FFIContext[T]) {.thread.} =
       except CatchableError as e:
         error "draining pending FFI requests on shutdown raised", error = e.msg
 
-    await runTeardown(ctx)
+    # Full teardown: the thread stops either way, so the outcome only shapes the
+    # log `runTeardown` already emitted.
+    discard await runTeardown(ctx)
 
   waitFor ffiRun(ctx)

--- a/tests/unit/test_ffi_dtor_orphan_reuse.nim
+++ b/tests/unit/test_ffi_dtor_orphan_reuse.nim
@@ -1,0 +1,364 @@
+## A `{.ffiDtor.}` cut short by `TeardownTimeout` abandons whatever async work it
+## never cancelled. Those orphans keep running on the FFI thread's dispatcher —
+## chronos offers no way to cancel every future of a thread — so the slot must be
+## quarantined instead of handed to the next owner.
+##
+## The orphan here ticks, fires an event and writes a sentinel through the `ptr`
+## it kept to its library, which is what a reused slot turns into: cross-owner
+## events and a write into the next owner's library object.
+##
+## Under `NIM_FFI_SAN=asan` the "the abandoned library is not freed" case is also
+## the use-after-free case: a slot that goes back into service frees the library
+## under the live orphan, and the orphan's next sentinel write lands in the freed
+## block. Nothing is freed once the slot is quarantined, so the run stays clean.
+##
+## test_ffi_dtor_orphan_reuse.nim.cfg cuts both timeouts for every suite here.
+
+import std/[atomics, os]
+import unittest2
+import results
+import ffi
+
+type OrphanLib = object
+  canary: int64
+
+# Stub the importc NimMain declareLibrary emits (plain-exe link).
+{.emit: "void liborphanlibNimMain(void) {}".}
+
+declareLibrary("orphanlib", OrphanLib)
+
+const
+  CtorCanary = 0x1111_1111'i64
+  OrphanSentinel = 0x0DEA_D0DE'i64
+  OrphanEvent = "orphan_evt"
+  MaxIncarnations = 8
+
+type OrphanConfig {.ffi.} = object
+  dummy: int
+
+var
+  # Per incarnation, so an orphan leaked by an earlier test cannot move the
+  # counters a later one asserts on.
+  gTicks: array[MaxIncarnations, Atomic[int]]
+  gStop: array[MaxIncarnations, Atomic[bool]]
+  gRunning: array[MaxIncarnations, Atomic[bool]]
+  gIncarnation: Atomic[int]
+  gLoopThreadId: Atomic[int]
+  gHandlerThreadId: Atomic[int]
+  gArmSentinel: Atomic[bool]
+  gLibPtr: Atomic[pointer]
+  gTeardownHangs: Atomic[bool]
+  gTeardownIgnoresCancel: Atomic[bool]
+  gTeardownHold: Atomic[bool]
+  gTeardownRan: Atomic[bool]
+  gInjected: Atomic[int]
+  gReplied: Atomic[bool]
+
+proc watchdogBody(timeoutMs: int) {.thread.} =
+  ## A wedged recycle would hang the file rather than fail a check.
+  os.sleep(timeoutMs)
+  echo "watchdog: a recycle or a drain never returned"
+  quit(1)
+
+var watchdog: Thread[int]
+createThread(watchdog, watchdogBody, 120_000)
+
+proc orphanTick(id: int) {.async.} =
+  ## The offspring a real library leaves behind when its teardown is cut short:
+  ## spawned on the FFI thread's dispatcher, stopped by nothing but the dtor.
+  gLoopThreadId.store(getThreadId())
+  gRunning[id].store(true)
+  while not gStop[id].load():
+    await sleepAsync(10.milliseconds)
+    gTicks[id].atomicInc()
+    try:
+      dispatchFFIEventCbor(OrphanEvent, id)
+    except CatchableError:
+      discard
+    if gArmSentinel.load():
+      let lib = cast[ptr OrphanLib](gLibPtr.load())
+      if not lib.isNil():
+        lib[].canary = OrphanSentinel
+  gRunning[id].store(false)
+
+proc orphanlib_create*(
+    config: OrphanConfig
+): Future[Result[OrphanLib, string]] {.ffiCtor.} =
+  return ok(OrphanLib(canary: CtorCanary))
+
+proc orphanlib_spawn*(lib: OrphanLib): Future[Result[int, string]] {.ffi.} =
+  ## Spawns the loop the way a library would: on the FFI thread, unawaited.
+  asyncSpawn orphanTick(gIncarnation.load())
+  return ok(1)
+
+proc orphanlib_ping*(lib: OrphanLib): Future[Result[int, string]] {.ffi.} =
+  ## Records the thread that served the call, so a reused thread pair is visible.
+  gHandlerThreadId.store(getThreadId())
+  return ok(1)
+
+proc waitHold() {.async.} =
+  while gTeardownHold.load():
+    await sleepAsync(10.milliseconds)
+
+proc orphanlib_destroy*(lib: OrphanLib): Future[void] {.ffiDtor.} =
+  ## Three shapes: `gTeardownHangs` sleeps past every timeout and is cut short by
+  ## `TeardownTimeout`; `gTeardownIgnoresCancel` cannot be cut short at all, so
+  ## the caller's own wait expires first; the default stops its offspring and
+  ## awaits it, which is the contract a dtor must meet.
+  if gTeardownIgnoresCancel.load():
+    await noCancel(waitHold())
+  elif gTeardownHangs.load():
+    await sleepAsync(TeardownTimeout + 60.seconds)
+  else:
+    let id = gIncarnation.load()
+    gStop[id].store(true)
+    while gRunning[id].load():
+      await sleepAsync(5.milliseconds)
+  gTeardownRan.store(true)
+
+proc noopCallback(
+    retCode: cint, msg: ptr cchar, len: csize_t, userData: pointer
+) {.cdecl, gcsafe, raises: [].} =
+  discard
+
+proc replyCallback(
+    retCode: cint, msg: ptr cchar, len: csize_t, userData: pointer
+) {.cdecl, gcsafe, raises: [].} =
+  gReplied.store(true)
+
+proc injectCallback(
+    retCode: cint, msg: ptr cchar, len: csize_t, userData: pointer
+) {.cdecl, gcsafe, raises: [].} =
+  ## Registered by the next owner: a delivery here is an event of a past one.
+  gInjected.atomicInc()
+
+proc encodedPtr(bytes: var seq[byte]): ptr byte =
+  if bytes.len == 0:
+    nil
+  else:
+    cast[ptr byte](addr bytes[0])
+
+proc waitFlag(flag: var Atomic[bool], timeoutMs = 5000): bool =
+  let deadline = Moment.now() + timeoutMs.milliseconds
+  while not flag.load():
+    if Moment.now() >= deadline:
+      return false
+    os.sleep(5)
+  true
+
+proc waitTicks(id: int, want: int, timeoutMs = 5000): bool =
+  let deadline = Moment.now() + timeoutMs.milliseconds
+  while gTicks[id].load() < want:
+    if Moment.now() >= deadline:
+      return false
+    os.sleep(5)
+  true
+
+proc createCtxWithLib(): ptr FFIContext[OrphanLib] =
+  ## Spins up a context and waits on `libReady`, the flag the teardown gates on.
+  var cfg = cborEncode(OrphanlibCreateCtorReq(config: OrphanConfig(dummy: 0)))
+  let token = orphanlib_create(encodedPtr(cfg), cfg.len.csize_t, noopCallback, nil)
+  if token.isNil():
+    return nil
+  let ctx = OrphanLibFFIPool.resolveCtx(token)
+  var tries = 0
+  while not ctx[].libReady.load() and tries < 500:
+    os.sleep(5)
+    inc tries
+  ctx
+
+proc callSpawn(ctx: ptr FFIContext[OrphanLib]): bool =
+  gReplied.store(false)
+  var rb = cborEncode(OrphanlibSpawnReq())
+  if orphanlib_spawn(ctx.ffiToken(), replyCallback, nil, encodedPtr(rb), rb.len.csize_t) !=
+      RET_OK:
+    return false
+  waitFlag(gReplied)
+
+proc callPing(ctx: ptr FFIContext[OrphanLib]): bool =
+  gReplied.store(false)
+  var rb = cborEncode(OrphanlibPingReq())
+  if orphanlib_ping(ctx.ffiToken(), replyCallback, nil, encodedPtr(rb), rb.len.csize_t) !=
+      RET_OK:
+    return false
+  waitFlag(gReplied)
+
+# The quarantined slot outlives the test that made it: the next suite compares
+# against it, and its orphan never stops.
+var gQuarantined: ptr FFIContext[OrphanLib]
+
+suite "a {.ffiDtor.} that stops its offspring":
+  # Runs first: no orphan is alive yet, so a clean recycle is observable.
+  test "the slot is reused and the loop is gone":
+    gTeardownHangs.store(false)
+    gTeardownRan.store(false)
+    gIncarnation.store(0)
+
+    let ctx = createCtxWithLib()
+    check not ctx.isNil()
+    check callSpawn(ctx)
+    check waitTicks(0, 1)
+
+    check OrphanLibFFIPool.recycleFFIContext(ctx).isOk()
+    check gTeardownRan.load()
+    check not gRunning[0].load()
+
+    let settled = gTicks[0].load()
+    os.sleep(60)
+    check gTicks[0].load() == settled
+
+    # Lowest free slot wins, so a fresh slot here would prove nothing.
+    gTeardownRan.store(false)
+    let next = createCtxWithLib()
+    check next == ctx
+    check not next[].myLib.isNil()
+    if not next[].myLib.isNil():
+      check next[].myLib.canary == CtorCanary
+    check OrphanLibFFIPool.recycleFFIContext(next).isOk()
+    check gTeardownRan.load()
+
+suite "a {.ffiDtor.} cut short by TeardownTimeout":
+  test "the recycle fails and the abandoned library is kept":
+    gTeardownHangs.store(true)
+    gTeardownRan.store(false)
+    gIncarnation.store(1)
+
+    let ctx = createCtxWithLib()
+    check not ctx.isNil()
+    # The stale `ptr T` a library would hold on to; the orphan writes through it.
+    gLibPtr.store(cast[pointer](ctx[].myLib))
+    check callSpawn(ctx)
+    check waitTicks(1, 1)
+
+    let t0 = Moment.now()
+    let res = OrphanLibFFIPool.recycleFFIContext(ctx)
+    let elapsed = Moment.now() - t0
+    gTeardownHangs.store(false)
+
+    # The timeout ended the teardown, not an early bail or the body finishing.
+    check elapsed >= TeardownTimeout
+    check elapsed < RecycleWaitTimeout
+    check not gTeardownRan.load()
+    # An incomplete teardown is a failed recycle, not a silent success.
+    check res.isErr()
+
+    # The orphan outlived the dtor: that is why the slot cannot go back.
+    check gRunning[1].load()
+    let before = gTicks[1].load()
+    check waitTicks(1, before + 3)
+
+    # Quarantine keeps the library alive, so the orphan's `ptr` stays valid.
+    # Guarded: a runtime that frees it leaves `myLib` nil, and the file has more
+    # to report than one segfault.
+    check not ctx[].myLib.isNil()
+    if not ctx[].myLib.isNil():
+      check ctx[].myLib.canary == CtorCanary
+
+    # Terminal: every later caller gets the same answer.
+    check OrphanLibFFIPool.recycleFFIContext(ctx).isErr()
+    check OrphanLibFFIPool.quarantinedSlots() == 1
+    gQuarantined = ctx
+
+  test "the next owner gets another slot and never sees the orphan":
+    check not gQuarantined.isNil()
+    gTeardownHangs.store(false)
+    gTeardownRan.store(false)
+    gIncarnation.store(2)
+    gInjected.store(0)
+
+    let next = createCtxWithLib()
+    check not next.isNil()
+    check next != gQuarantined
+
+    # Same event name as the orphan fires, on the new owner's registry.
+    check addEventListener(next[].eventRegistry, OrphanEvent, injectCallback, nil) > 0
+    check callPing(next)
+    # A reused slot would have served this call on the orphan's own thread.
+    check gHandlerThreadId.load() != gLoopThreadId.load()
+
+    # Let the orphan fire several times against the live listener.
+    let before = gTicks[1].load()
+    check waitTicks(1, before + 3)
+    check gInjected.load() == 0
+
+    # The orphan's sentinel write must not reach the next owner's library. On a
+    # reused slot `freeLib` freed that object and the next ctor is handed the same
+    # block back, so the write lands in the library serving this context.
+    gArmSentinel.store(true)
+    let armed = gTicks[1].load()
+    check waitTicks(1, armed + 3)
+    gArmSentinel.store(false)
+    check not next[].myLib.isNil()
+    if not next[].myLib.isNil():
+      check next[].myLib.canary == CtorCanary
+
+    check OrphanLibFFIPool.recycleFFIContext(next).isOk()
+    check gTeardownRan.load()
+
+  test "the abandoned library is not freed under the orphan":
+    # Armed before the recycle, with nothing allocating a context afterwards, so
+    # on a runtime that frees the library the orphan's next write lands in the
+    # freed block: this is the case the `NIM_FFI_SAN=asan` job reports as a
+    # heap-use-after-free. (Arming *after* the next owner exists instead hits the
+    # reallocated block, which the test above covers.)
+    gTeardownHangs.store(true)
+    gTeardownRan.store(false)
+    gIncarnation.store(4)
+
+    let ctx = createCtxWithLib()
+    check not ctx.isNil()
+    gLibPtr.store(cast[pointer](ctx[].myLib))
+    check callSpawn(ctx)
+    check waitTicks(4, 1)
+
+    gArmSentinel.store(true)
+    let res = OrphanLibFFIPool.recycleFFIContext(ctx)
+    gTeardownHangs.store(false)
+    check res.isErr()
+
+    let armed = gTicks[4].load()
+    check waitTicks(4, armed + 3)
+    gArmSentinel.store(false)
+
+    # The orphan wrote into its own library, which quarantine keeps alive.
+    check not ctx[].myLib.isNil()
+    if not ctx[].myLib.isNil():
+      check ctx[].myLib.canary == OrphanSentinel
+
+suite "quarantine after the caller stopped waiting":
+  test "a teardown that finishes past RecycleWaitTimeout does not release the slot":
+    # An uncancellable teardown outlasts the caller's wait, so the recycle it
+    # reported as failed must not hand the slot back when the body finally ends.
+    gTeardownIgnoresCancel.store(true)
+    gTeardownHold.store(true)
+    gTeardownRan.store(false)
+    gIncarnation.store(3)
+
+    let ctx = createCtxWithLib()
+    check not ctx.isNil()
+    check callSpawn(ctx)
+    check waitTicks(3, 1)
+
+    let quarantinedBefore = OrphanLibFFIPool.quarantinedSlots()
+    let t0 = Moment.now()
+    let res = OrphanLibFFIPool.recycleFFIContext(ctx)
+    let elapsed = Moment.now() - t0
+    check res.isErr()
+    check elapsed >= RecycleWaitTimeout
+
+    # Release the body: it completes, but long after the caller gave up.
+    gTeardownHold.store(false)
+    check waitFlag(gTeardownRan)
+    gTeardownIgnoresCancel.store(false)
+    os.sleep(100)
+    check OrphanLibFFIPool.quarantinedSlots() == quarantinedBefore + 1
+
+    # Nothing can bring a quarantined slot back, so the pool never offers it.
+    for _ in 0 .. 2:
+      let other = createCtxWithLib()
+      check not other.isNil()
+      check other != ctx
+      check other != gQuarantined
+      gTeardownRan.store(false)
+      check OrphanLibFFIPool.recycleFFIContext(other).isOk()
+      check gTeardownRan.load()

--- a/tests/unit/test_ffi_dtor_orphan_reuse.nim.cfg
+++ b/tests/unit/test_ffi_dtor_orphan_reuse.nim.cfg
@@ -1,0 +1,4 @@
+# File-wide: at the defaults the hanging teardown costs 10s and each drain round
+# 1.5s on every matrix job.
+-d:ffiTeardownTimeoutMs=300
+-d:ffiRecycleTimeoutMs=200

--- a/tests/unit/test_ffi_teardown.nim
+++ b/tests/unit/test_ffi_teardown.nim
@@ -122,14 +122,15 @@ suite "{.ffiDtor.} teardown on the recycle path":
     check TeardownlibFFIPool.recycleFFIContext(second).isOk()
     check gTeardownRan.load()
 
-  test "a teardown past TeardownTimeout still releases the slot":
+  test "a teardown past TeardownTimeout quarantines the slot":
+    # Runs last in this file: the slot never comes back.
     let ctx = createCtxWithLib()
     check not ctx.isNil()
 
     gTeardownRan.store(false)
     gTeardownHangs.store(true)
     let t0 = Moment.now()
-    check TeardownlibFFIPool.recycleFFIContext(ctx).isOk()
+    let res = TeardownlibFFIPool.recycleFFIContext(ctx)
     let elapsed = Moment.now() - t0
     gTeardownHangs.store(false)
 
@@ -137,10 +138,15 @@ suite "{.ffiDtor.} teardown on the recycle path":
     check elapsed >= TeardownTimeout
     check elapsed < RecycleWaitTimeout
     check not gTeardownRan.load()
+    # A body that never finished cannot promise the thread is free of it, so the
+    # recycle fails and the library is kept. See test_ffi_dtor_orphan_reuse.
+    check res.isErr()
+    check not ctx[].myLib.isNil()
+    check TeardownlibFFIPool.quarantinedSlots() == 1
 
     let next = createCtxWithLib()
     check not next.isNil()
-    check next == ctx
+    check next != ctx
     check not next[].myLib.isNil()
     check TeardownlibFFIPool.recycleFFIContext(next).isOk()
     check gTeardownRan.load()


### PR DESCRIPTION
## Summary

A pooled context is recycled by handing its slot — **including the live FFI and event thread pair and their chronos dispatcher** — to the next owner. `recycleContext` decided that was safe by looking at the request drain alone: `runTeardown` returned `void` and swallowed both its `withTimeout` expiry and any raise. So a `{.ffiDtor.}` cut short by `TeardownTimeout` (10 s), or one that raised, still had its library freed and its slot released, and `requestRecycle` reported **success**.

The gap that leaves: whatever async work the abandoned teardown never cancelled keeps running on that thread. It is not a theoretical window — the new test reproduces the whole chain on `master`.

### The failure chain, measured

A library spawns a loop (`asyncSpawn`), its dtor overruns the timeout and never cancels it. On the unpatched runtime:

| What the host sees | Reality |
| --- | --- |
| `<lib>_ctx_destroy` → `RET_OK` | the dtor body was cancelled mid-way; only a log line says so |
| the context is gone | `ctx[].myLib` is **nil** — the library was freed *under* the still-running loop. Reading it segfaults |
| a fresh context | the **same slot**, served by the **same thread id** as the orphan (`41284909` in the run) |
| its own event stream | its listener received **3 events belonging to the previous owner** |
| its own library | `myLib.canary` came back as **`233492702` = `0x0DEAD0DE`** — the orphan's sentinel, written through its stale `ptr T`, inside the *next owner's* library object |
| — | under `asan+ubsan` the same write hits the allocator's free list and **aborts the process**: `member access within misaligned address 0x00000dead0de for type 'FreeCell'` |

The last line is worse than a use-after-free: Nim's shared allocator hands out sub-blocks of large `malloc` chunks, so ASan cannot see the per-object free — the corruption surfaces when the allocator follows the sentinel as a free-list pointer.

### Why the runtime cannot clean up after a cut-short teardown

There is no "cancel everything on this thread" to reach for:

| Fact | Where |
| --- | --- |
| the pending-future list is per-thread, so the scope would be right | `chronos/futures.nim:118` — `var futureList* {.threadvar.}` |
| enumeration exists (`pendingFutures`, `pendingFuturesCount`)… | `chronos/internal/asyncengine.nim:1261` |
| …but only under `-d:chronosFutureTracking` (default off) | `chronos/config.nim:47` |
| `cancelSoon(FutureBase)` is public, so cancelling an enumerated future would work | `chronos/internal/asyncfutures.nim:1000` |
| the list carries **no ownership tag** — the FFI loop's own futures are in it | cancelling untargeted would kill the runtime |
| a cancel is cooperative regardless | a future that swallows `CancelledError` never dies |

Reuse is only safe when the previous owner is provably gone from the thread, and the only proof available is its teardown having run to the end.

## What changed

A recycle releases the slot **only** when the drain succeeded *and* the teardown either completed or had nothing to do (`Skipped`: no hook, or no library because the ctor never landed). Anything else **quarantines**:

- the slot stays claimed for the life of the process, so `createFFIContext` never offers it again;
- the library is **kept alive** — the orphans still hold pointers into it, and freeing it is what turned a leak into corruption;
- the terminal `RecycleFailed` carries a `RecycleFailure` reason (`DrainTimeout`, `TeardownTimeout`, `TeardownRaised`, `CallerAbandoned`), which `requestRecycle` returns as its error. An enum and not a message: a `string` field on a pooled context is written by the FFI thread and read by the host thread, which crosses thread-local heaps under refc.

Also:

- **The late-completion hole is closed.** A teardown that ignores cancellation outlasts the caller's own `RecycleWaitTimeout`; that caller was already told the recycle failed, so `requestRecycle` marks the context abandoned and the recycle quarantines instead of silently handing the slot back later.
- **Joining the threads is the one way out.** `destroyFFIContext` still stops and joins the pair — the orphans die with the dispatcher — and `releaseSlot` now clears the quarantine so the slot rebuilds cleanly.
- **`eventQueueStuck` is cleared on the recycle reset.** It is set on event-queue overflow and cleared only in `initContextResources`, which a reused slot skips, so one overflow left the slot rejecting every request of every later owner — the constructor included, which made `createFFIContext` hand out the same poisoned slot again and again, bricking context creation for the process.
- **Every path that stops serving without a completed teardown logs at `error`**: drain timeout, teardown timeout, teardown raised, caller's wait expired, thread-exit timeout in `destroyFFIContext` and in `destroyStaticFFIContext`, and pool exhaustion once any slot has been quarantined. A teardown skipped because there was nothing to tear down logs at `debug` — that is not a failure.
- `FFIContextPool.quarantinedSlots()` reports the lost capacity, and the pool-exhausted error names the count.

## Impact on Library Users

**Behavioural break.** `<lib>_ctx_destroy` now returns `RET_ERR` where it returned `RET_OK`: when the `{.ffiDtor.}` overran its timeout or raised. On that error the context and its library are leaked deliberately and their callbacks can still fire, so the host must keep the `userData` of in-flight requests alive. The C ABI itself is unchanged and no generated binding changes (`nimble check_bindings` clean).

**The dtor contract, now written down** (README → *The teardown contract*): a `{.ffiDtor.}` must cancel **and await** everything it spawned. A quarantine costs one of the 32 slots for the life of the process, so a library that habitually overruns its teardown will exhaust the pool — loudly, with the count named, rather than by silently corrupting the next owner.

**Nim API:** `RecycleFailure` + `reason()`, `FFIContextPool.quarantinedSlots()`, and `FFIContext` gains `recycleFailure` / `recycleAbandoned`.

## Risk Assessment

The change only ever *withholds* a slot, so the failure direction is capacity, not safety. The hard stop is a clean, attributable `pool exhausted (max 32 contexts, N quarantined by a failed teardown)` instead of a diffuse corruption far from the cause.

Note that both the old and the new behaviour leak the orphan **threads** — quarantine does not make them stop. What it prevents is a *second* owner sharing them.

The `recycleAbandoned` flag races the recycle's own completion by design; losing that race can only release a slot whose teardown did complete, so the unsafe direction is unreachable.

One pre-existing edge this makes more visible: `destroyFFIContext` on a quarantined context re-enters the `{.ffiDtor.}`, because the shutdown path ends in `runTeardown` and `libReady`/`myLib` are still set (the reset is skipped on quarantine). Worth a follow-up guard; it is not introduced here.

## Tests

New `tests/unit/test_ffi_dtor_orphan_reuse.nim`, with a sibling `.cfg` cutting `TeardownTimeout` to 300 ms and the drain rounds to 200 ms. An `asyncSpawn`ed loop that the dtor never cancels ticks, fires an event and writes a sentinel through its stale `ptr T`; per-incarnation counters keep an orphan leaked by one case from moving the numbers another case asserts on. Five cases:

1. a dtor that stops and awaits its offspring recycles cleanly and the slot **is** reused (the control — it runs first, while no orphan is alive);
2. a dtor cut short by the timeout fails the recycle, and the library is kept while the orphan keeps ticking;
3. the next owner gets **another** slot, on another thread, never sees the orphan's events, and its library keeps its own canary;
4. the abandoned library is not freed under the orphan — armed before the recycle with nothing allocating afterwards, this is the case the ASan/UBSan job reports as allocator corruption on `master`;
5. a teardown that finishes *past* `RecycleWaitTimeout` still does not release the slot, and three later creates never land on it.

All five fail on the unpatched recycle path (case 1 passes, as it must); with the fix they pass under `--mm:orc`, `--mm:refc`, `NIM_FFI_SAN=asan-ubsan` and `NIM_FFI_SAN=tsan`. Full suite: `nimble test` green under both memory models.

`test_ffi_teardown`'s *"a teardown past TeardownTimeout still releases the slot"* asserted the old behaviour and is rewritten as *"…quarantines the slot"*.

## CI

Two gaps, both fixed here.

**The new file would have run almost nowhere.** `ci.yml` names one job per test file for the cross-OS matrix (3 OS × Nim versions × orc/refc), and that list covered 9 of the 43 unit test files. Everything else ran only inside the two Linux sanitizer jobs, which call `nimble test_sanitized` over every discovered file — so a new file gets no macOS, no Windows and no unsanitized run. The recycle/teardown family all turn on thread reuse, thread exit and dispatcher behaviour, which differ per OS, so each now has its own matrix job: the new orphan-reuse file plus `test_ffi_teardown`, `test_ffi_recycle_reset`, `test_ffi_claim_generation`, `test_ffi_ingress_limits`, `test_ctx_after_failed_ctor` and `test_event_thread`. Per-file matrix coverage goes 9 → 16.

**A new file could go unrun again.** `unit-tests-all` runs `nimble test` — all 43 files, orc and refc — as a catch-all.

Consequences, deliberately chosen:

- `unit-tests-all` is **Linux only**. The cost here is compiling ~40 files twice (measured 4:25 wall locally; expect 10–18 min on a runner), and the jobs above already carry the OS-sensitive files across the matrix.
- It is an **addition, not a replacement**. One aggregate job on the full matrix would serialise inside each cell and cost *more* wall clock than the current one-job-per-file design, which runs them in parallel.
- Nothing needed in `ffi.nimble`: `test.yml` compiles `tests/unit/<test>.nim` directly, and `nimble-job.yml` already runs an arbitrary nimble command on one OS. No changes to either reusable workflow.
- Every referenced file was verified to exist, and each new block is a clone of the existing `listener-reentrancy` / `check-bindings` shape.

## References

Issue #145 (SEC-01 was the drain half of this; this PR is the teardown half). Follows #147, which put the teardown on the recycle path, and #148, which reset the slot and made the host's context handle opaque.
